### PR TITLE
feat: the source and sink APIs of Flink-lance have been refactored(FLIP-143/FLIP-27)

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,0 +1,41 @@
+
+[tool.bumpversion]
+current_version = "0.1.0"
+parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)(-(?P<pre_label>alpha|beta|rc)\\.(?P<pre_n>\\d+))?"
+serialize = [
+    "{major}.{minor}.{patch}-{pre_label}.{pre_n}",
+    "{major}.{minor}.{patch}"
+]
+search = "{current_version}"
+replace = "{new_version}"
+regex = false
+ignore_missing_files = false
+ignore_missing_version = false
+tag = false
+sign_tags = false
+tag_name = "v{new_version}"
+tag_message = "Release version {new_version}"
+allow_dirty = false
+commit = false
+message = "chore: bump version {current_version} → {new_version}"
+
+[tool.bumpversion.parts.pre_label]
+optional_value = "stable"
+first_value = "stable"
+values = ["stable", "alpha", "beta", "rc"]
+
+[tool.bumpversion.parts.pre_n]
+optional_value = "0"
+first_value = "0"
+
+# Root pom.xml - project version
+[[tool.bumpversion.files]]
+filename = "pom.xml"
+search = "<version>{current_version}</version>"
+replace = "<version>{new_version}</version>"
+
+# Root pom.xml - lance-flink.version property
+[[tool.bumpversion.files]]
+filename = "pom.xml"
+search = "<lance-flink.version>{current_version}</lance-flink.version>"
+replace = "<lance-flink.version>{new_version}</lance-flink.version>"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,37 @@
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 1
+appendOnly: true
+# Labels are applied based on conventional commits standard
+# https://www.conventionalcommits.org/en/v1.0.0/
+# These labels are later used in release notes. See .github/release.yml
+labels:
+# If the PR title has an ! before the : it will be considered a breaking change
+# For example, `feat!: add new feature` will be considered a breaking change
+- label: breaking-change
+  title: "^[^:]+!:.*"
+- label: breaking-change
+  body: "BREAKING CHANGE"
+- label: enhancement
+  title: "^feat(\\(.+\\))?!?:.*"
+- label: bug
+  title: "^fix(\\(.+\\))?!?:.*"
+- label: documentation
+  title: "^docs(\\(.+\\))?!?:.*"
+- label: performance
+  title: "^perf(\\(.+\\))?!?:.*"
+- label: ci
+  title: "^ci(\\(.+\\))?!?:.*"
+- label: chore
+  title: "^(chore|test|build|style)(\\(.+\\))?!?:.*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,37 @@
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+changelog:
+  exclude:
+    labels:
+      - ci
+      - chore
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - enhancement
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+    - title: Documentation 📚
+      labels:
+        - documentation
+    - title: Performance Improvements 🚀
+      labels:
+        - performance
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/auto-bump.yml
+++ b/.github/workflows/auto-bump.yml
@@ -1,0 +1,191 @@
+
+name: Auto Bump Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump_type:
+        description: 'Type of version bump'
+        required: false
+        default: 'auto'
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+
+jobs:
+  check-for-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      should_bump: ${{ steps.check.outputs.should_bump }}
+      bump_type: ${{ steps.check.outputs.bump_type }}
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Check for unreleased changes
+      id: check
+      run: |
+        # Get the last tag
+        LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+        
+        if [ -z "$LAST_TAG" ]; then
+          echo "No tags found, should create initial release"
+          echo "should_bump=true" >> $GITHUB_OUTPUT
+          echo "bump_type=patch" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+        
+        # Check for commits since last tag
+        COMMITS_SINCE_TAG=$(git rev-list --count ${LAST_TAG}..HEAD)
+        
+        if [ "$COMMITS_SINCE_TAG" -gt 0 ]; then
+          echo "Found $COMMITS_SINCE_TAG commits since last tag $LAST_TAG"
+          
+          if [ "${{ inputs.bump_type }}" != "auto" ] && [ -n "${{ inputs.bump_type }}" ]; then
+            BUMP_TYPE="${{ inputs.bump_type }}"
+          else
+            BUMP_TYPE="patch"
+            
+            if git log ${LAST_TAG}..HEAD --grep="BREAKING CHANGE" --grep="!:" | grep -q .; then
+              BUMP_TYPE="major"
+            elif git log ${LAST_TAG}..HEAD --grep="^feat" --grep="^feature" | grep -q .; then
+              BUMP_TYPE="minor"
+            fi
+          fi
+          
+          echo "should_bump=true" >> $GITHUB_OUTPUT
+          echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
+        else
+          echo "No commits since last tag $LAST_TAG"
+          echo "should_bump=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Summary
+      run: |
+        echo "## Auto Bump Check" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        if [ "${{ steps.check.outputs.should_bump }}" == "true" ]; then
+          echo "✅ Version bump needed" >> $GITHUB_STEP_SUMMARY
+          echo "- **Bump Type:** ${{ steps.check.outputs.bump_type }}" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "⏭️ No version bump needed" >> $GITHUB_STEP_SUMMARY
+        fi
+
+  create-bump-pr:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.should_bump == 'true'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        fetch-depth: 0
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        pip install packaging lxml
+
+    - name: Get current version
+      id: current_version
+      run: |
+        CURRENT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+        echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+        echo "Current version: $CURRENT_VERSION"
+
+    - name: Calculate new version
+      id: new_version
+      run: |
+        python ci/calculate_version.py \
+          --current "${{ steps.current_version.outputs.version }}" \
+          --type "${{ needs.check-for-changes.outputs.bump_type }}" \
+          --channel "stable"
+
+    - name: Create feature branch
+      run: |
+        BRANCH_NAME="auto-bump-${{ steps.new_version.outputs.version }}"
+        git checkout -b $BRANCH_NAME
+        echo "branch=$BRANCH_NAME" >> $GITHUB_ENV
+
+    - name: Bump version
+      run: |
+        python ci/bump_version.py --version "${{ steps.new_version.outputs.version }}"
+
+    - name: Configure git
+      run: |
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+    - name: Commit changes
+      run: |
+        git add -A
+        git commit -m "chore: bump version to ${{ steps.new_version.outputs.version }}
+        
+        Automated version bump from ${{ steps.current_version.outputs.version }} to ${{ steps.new_version.outputs.version }}.
+        Bump type: ${{ needs.check-for-changes.outputs.bump_type }}"
+
+    - name: Push changes
+      run: |
+        git push origin ${{ env.branch }}
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch: ${{ env.branch }}
+        base: main
+        title: "chore: bump version to ${{ steps.new_version.outputs.version }}"
+        body: |
+          ## Automated Version Bump
+          
+          This PR automatically bumps the version from `${{ steps.current_version.outputs.version }}` to `${{ steps.new_version.outputs.version }}`.
+          
+          ### Details
+          - **Bump Type:** ${{ needs.check-for-changes.outputs.bump_type }}
+          - **Triggered By:** Manual trigger
+          
+          ### Checklist
+          - [ ] Review version bump changes
+          - [ ] Verify pom.xml is updated
+          - [ ] Confirm CI checks pass
+          
+          ### Next Steps
+          After merging this PR, you can create a release by:
+          1. Going to Actions → Create Release workflow
+          2. Selecting the release channel (stable/preview)
+          3. Running the workflow
+          
+          ---
+          *This PR was automatically generated by the auto-bump workflow.*
+        labels: |
+          version-bump
+          automated
+        assignees: ${{ github.actor }}
+
+    - name: Summary
+      run: |
+        echo "## Version Bump PR Created" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "- **Current Version:** ${{ steps.current_version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **New Version:** ${{ steps.new_version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Bump Type:** ${{ needs.check-for-changes.outputs.bump_type }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Branch:** ${{ env.branch }}" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "✅ Pull request created successfully!" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/flink.yml
+++ b/.github/workflows/flink.yml
@@ -1,0 +1,82 @@
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Flink
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+      - reopened
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: "maven"
+      - name: Check code style
+        run: make lint
+
+  build:
+    name: Build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: "maven"
+      - name: Build
+        run: make install
+
+  test:
+    name: Test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: "maven"
+      - name: Run tests
+        run: make test

--- a/.github/workflows/lance-release-timer.yml
+++ b/.github/workflows/lance-release-timer.yml
@@ -1,0 +1,95 @@
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Lance Release Timer
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: lance-release-timer
+  cancel-in-progress: false
+
+jobs:
+  trigger-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: |
+          pip install lxml
+
+      - name: Check for new Lance tag
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+        run: |
+          python3 ci/check_lance_release.py --github-output "$GITHUB_OUTPUT"
+
+      - name: Look for existing PR
+        if: steps.check.outputs.needs_update == 'true'
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          TITLE="chore: update lance dependency to v${{ steps.check.outputs.latest_version }}"
+          COUNT=$(gh pr list --search "\"$TITLE\" in:title" --state open --limit 1 --json number --jq 'length')
+          if [ "$COUNT" -gt 0 ]; then
+            echo "Open PR already exists for $TITLE"
+            echo "pr_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No existing PR for $TITLE"
+            echo "pr_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create update PR
+        if: steps.check.outputs.needs_update == 'true' && steps.pr.outputs.pr_exists != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          LATEST_VERSION="${{ steps.check.outputs.latest_version }}"
+          CURRENT_VERSION="${{ steps.check.outputs.current_version }}"
+          BRANCH_NAME="auto/update-lance-${LATEST_VERSION//[^a-zA-Z0-9]/-}"
+
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+          git checkout -b "$BRANCH_NAME"
+
+          # Update lance.version in pom.xml
+          sed -i "s|<lance.version>${CURRENT_VERSION}</lance.version>|<lance.version>${LATEST_VERSION}</lance.version>|" pom.xml
+
+          git add pom.xml
+          git commit -m "chore: update lance dependency to v${LATEST_VERSION}"
+          git push origin "$BRANCH_NAME"
+
+          gh pr create \
+            --title "chore: update lance dependency to v${LATEST_VERSION}" \
+            --body "Automated update of lance-core dependency from v${CURRENT_VERSION} to v${LATEST_VERSION}." \
+            --base main \
+            --head "$BRANCH_NAME"

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,95 @@
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: PR Title Checks
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  labeler:
+    permissions:
+      pull-requests: write
+    name: Label PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: srvaroa/labeler@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          fail_on_error: true
+  commitlint:
+    permissions:
+      pull-requests: write
+    name: Verify PR title / description conforms to semantic-release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm install @commitlint/config-conventional
+      - run: >
+          echo 'module.exports = {
+            "rules": {
+              "body-max-line-length": [0, "always", Infinity],
+              "footer-max-line-length": [0, "always", Infinity],
+              "body-leading-blank": [0, "always"]
+            }
+          }' > .commitlintrc.js
+      - run: npx commitlint --extends @commitlint/config-conventional --verbose <<< $COMMIT_MSG
+        env:
+          COMMIT_MSG: >
+            ${{ github.event.pull_request.title }}
+
+            ${{ github.event.pull_request.body }}
+      - if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const message = `**ACTION NEEDED**
+              Lance follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) for release automation.
+
+              The PR title and description are used as the merge commit message.\
+              Please update your PR title and description to match the specification.
+
+              For details on the error please inspect the "PR Title Check" action.
+              `
+            // Get list of current comments
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+            // Check if this job already commented
+            for (const comment of comments) {
+              if (comment.body === message) {
+                return // Already commented
+              }
+            }
+            // Post the comment about Conventional Commits
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: message
+            })
+            core.setFailed(message)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,133 @@
+
+name: Publish Flink packages
+on:
+  release:
+    types: [published]
+  pull_request:
+    paths:
+      - .github/workflows/publish.yml
+    types:
+      - opened
+      - synchronize
+      - ready_for_review
+      - reopened
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Release mode'
+        required: true
+        type: choice
+        default: dry_run
+        options:
+          - dry_run
+          - release
+      ref:
+        description: 'The branch, tag or SHA to checkout'
+        required: false
+        type: string
+
+jobs:
+  release:
+    name: Release Flink
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.ref }}
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: corretto
+          java-version: 17
+          cache: "maven"
+          server-id: ossrh
+          server-username: SONATYPE_USER
+          server-password: SONATYPE_TOKEN
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Set github
+        run: |
+          git config --global user.email "Lance Github Runner"
+          git config --global user.name "dev+gha@lancedb.com"
+      - name: Dry run
+        if: |
+          github.event_name == 'pull_request' ||
+          inputs.mode == 'dry_run'
+        run: |
+          ./mvnw --batch-mode -DskipTests package
+      - name: Publish to Maven Central
+        if: |
+          github.event_name == 'release' ||
+          inputs.mode == 'release'
+        run: |
+          echo "use-agent" >> ~/.gnupg/gpg.conf
+          echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+          export GPG_TTY=$(tty)
+          ./mvnw --batch-mode -DskipTests -DpushChanges=false -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} deploy -P deploy-to-ossrh
+        env:
+          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+          SONATYPE_TOKEN: ${{ secrets.SONATYPE_TOKEN }}
+
+      - name: Get published version
+        if: |
+          github.event_name == 'release' ||
+          inputs.mode == 'release'
+        id: get_version
+        run: |
+          VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Published version: $VERSION"
+
+      - name: Wait for Maven Central availability
+        if: |
+          github.event_name == 'release' ||
+          inputs.mode == 'release'
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          GROUP_ID="org.lance"
+          ARTIFACT_ID="lance-flink"
+
+          echo "Waiting for version $VERSION to be available in Maven Central..."
+          echo "This typically takes 10-30 minutes after publishing to OSSRH."
+
+          # Maximum wait time: 60 minutes
+          MAX_WAIT=3600
+          INTERVAL=60
+          ELAPSED=0
+
+          while [ $ELAPSED -lt $MAX_WAIT ]; do
+            URL="https://repo1.maven.org/maven2/org/lance/${ARTIFACT_ID}/${VERSION}/${ARTIFACT_ID}-${VERSION}.pom"
+
+            if curl --head --silent --fail "$URL" > /dev/null 2>&1; then
+              echo ""
+              echo "🎉 Artifact is now available in Maven Central!"
+              echo ""
+              echo "Users can now add the following dependency:"
+              echo ""
+              echo "Maven:"
+              echo "<dependency>"
+              echo "  <groupId>org.lance</groupId>"
+              echo "  <artifactId>lance-flink</artifactId>"
+              echo "  <version>${VERSION}</version>"
+              echo "</dependency>"
+              echo ""
+              echo "Gradle:"
+              echo "implementation 'org.lance:lance-flink:${VERSION}'"
+              exit 0
+            fi
+
+            ELAPSED=$((ELAPSED + INTERVAL))
+
+            if [ $ELAPSED -lt $MAX_WAIT ]; then
+              echo "Artifact not yet available. Waiting ${INTERVAL} seconds... (${ELAPSED}s elapsed)"
+              sleep $INTERVAL
+            fi
+          done
+
+          echo ""
+          echo "⚠️ WARNING: Artifact not yet available in Maven Central after ${MAX_WAIT} seconds."
+          echo "This is normal - Maven Central sync can take up to 2 hours."
+          echo "Check status at: https://central.sonatype.com/artifact/org.lance/lance-flink/${VERSION}"
+          exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,178 @@
+
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Version bump type (patch/minor/major bumps version, current keeps it unchanged)'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - current
+      release_channel:
+        description: 'Release channel (preview creates beta tag, stable creates release tag)'
+        required: true
+        default: 'preview'
+        type: choice
+        options:
+          - preview
+          - stable
+      dry_run:
+        description: 'Dry run (simulate the release without pushing)'
+        required: true
+        default: true
+        type: boolean
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Output Inputs
+      run: echo "${{ toJSON(github.event.inputs) }}"
+
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        ref: main
+        token: ${{ secrets.LANCE_RELEASE_TOKEN }}
+        fetch-depth: 0
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v4
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        pip install packaging lxml bump-my-version
+
+    - name: Get current version
+      id: current_version
+      run: |
+        CURRENT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+        echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+        echo "Current version: $CURRENT_VERSION"
+
+    - name: Calculate base version
+      id: base_version
+      run: |
+        python ci/calculate_version.py \
+          --current "${{ steps.current_version.outputs.version }}" \
+          --type "${{ inputs.release_type }}" \
+          --channel "${{ inputs.release_channel }}"
+
+    - name: Determine tag and pom version
+      id: versions
+      run: |
+        BASE_VERSION="${{ steps.base_version.outputs.version }}"
+        CURRENT_VERSION="${{ steps.current_version.outputs.version }}"
+        if [ "${{ inputs.release_channel }}" == "stable" ]; then
+          TAG="v${BASE_VERSION}"
+          POM_VERSION="${BASE_VERSION}"
+        else
+          # For preview releases, find the next beta number for this base version
+          BETA_TAGS=$(git tag -l "v${BASE_VERSION}-beta.*" | sort -V)
+          if [ -z "$BETA_TAGS" ]; then
+            BETA_NUM=1
+          else
+            LAST_BETA=$(echo "$BETA_TAGS" | tail -n 1)
+            LAST_NUM=$(echo "$LAST_BETA" | sed "s/v${BASE_VERSION}-beta.//")
+            BETA_NUM=$((LAST_NUM + 1))
+          fi
+          TAG="v${BASE_VERSION}-beta.${BETA_NUM}"
+          POM_VERSION="${BASE_VERSION}-beta.${BETA_NUM}"
+        fi
+
+        # Check if version actually changes
+        if [ "$CURRENT_VERSION" != "$POM_VERSION" ]; then
+          VERSION_CHANGED="true"
+        else
+          VERSION_CHANGED="false"
+        fi
+
+        echo "tag=$TAG" >> $GITHUB_OUTPUT
+        echo "pom_version=$POM_VERSION" >> $GITHUB_OUTPUT
+        echo "version_changed=$VERSION_CHANGED" >> $GITHUB_OUTPUT
+        echo "Tag will be: $TAG"
+        echo "POM version will be: $POM_VERSION"
+        echo "Version changed: $VERSION_CHANGED"
+
+    - name: Update version (when version changes)
+      if: steps.versions.outputs.version_changed == 'true'
+      run: |
+        python ci/bump_version.py --version "${{ steps.versions.outputs.pom_version }}"
+
+    - name: Configure git identity
+      run: |
+        git config user.name 'github-actions[bot]'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+    - name: Create release commit (when version changes)
+      if: steps.versions.outputs.version_changed == 'true'
+      run: |
+        git add -A
+        git commit -m "chore: bump version to ${{ steps.versions.outputs.pom_version }}" || echo "No changes to commit"
+
+    - name: Create tag
+      run: |
+        git tag -a "${{ steps.versions.outputs.tag }}" -m "Release ${{ steps.versions.outputs.tag }}"
+
+    - name: Push changes (if not dry run)
+      if: ${{ !inputs.dry_run }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.LANCE_RELEASE_TOKEN }}
+      run: |
+        git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+
+        if [ "${{ steps.versions.outputs.version_changed }}" == "true" ]; then
+          git push origin main
+        fi
+        git push origin "${{ steps.versions.outputs.tag }}"
+
+    - name: Create GitHub Release Draft (if not dry run)
+      if: ${{ !inputs.dry_run }}
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ steps.versions.outputs.tag }}
+        name: ${{ steps.versions.outputs.tag }}
+        generate_release_notes: true
+        draft: true
+        prerelease: ${{ inputs.release_channel == 'preview' }}
+        token: ${{ secrets.LANCE_RELEASE_TOKEN }}
+
+    - name: Summary
+      run: |
+        echo "## Release Summary" >> $GITHUB_STEP_SUMMARY
+        echo "" >> $GITHUB_STEP_SUMMARY
+        echo "- **Release Type:** ${{ inputs.release_type }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Release Channel:** ${{ inputs.release_channel }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Current Version:** ${{ steps.current_version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+        if [ "${{ steps.versions.outputs.version_changed }}" == "true" ]; then
+          echo "- **New Version:** ${{ steps.versions.outputs.pom_version }}" >> $GITHUB_STEP_SUMMARY
+        fi
+        echo "- **Tag:** ${{ steps.versions.outputs.tag }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Dry Run:** ${{ inputs.dry_run }}" >> $GITHUB_STEP_SUMMARY
+        
+        if [ "${{ inputs.dry_run }}" == "true" ]; then
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "⚠️ This was a dry run. No changes were pushed." >> $GITHUB_STEP_SUMMARY
+        else
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "📝 Draft release created successfully!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Next Steps:" >> $GITHUB_STEP_SUMMARY
+          echo "1. Review the draft release on the [releases page](https://github.com/${{ github.repository }}/releases)" >> $GITHUB_STEP_SUMMARY
+          echo "2. Edit the release notes if needed" >> $GITHUB_STEP_SUMMARY
+          echo "3. Publish the release to trigger automatic publishing to Maven Central" >> $GITHUB_STEP_SUMMARY
+        fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,36 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### Maven ###
 target/
-!.mvn/wrapper/maven-wrapper.jar
-!**/src/main/**/target/
-!**/src/test/**/target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
 
 ### IntelliJ IDEA ###
-.idea/modules.xml
-.idea/jarRepositories.xml
-.idea/compiler.xml
-.idea/libraries/
+.idea
 *.iws
 *.iml
 *.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
 
 ### Eclipse ###
 .apt_generated
@@ -20,6 +40,9 @@ target/
 .settings
 .springBeans
 .sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
 
 ### NetBeans ###
 /nbproject/private/
@@ -27,15 +50,25 @@ target/
 /dist/
 /nbdist/
 /.nb-gradle/
-build/
-!**/src/main/**/build/
-!**/src/test/**/build/
 
 ### VS Code ###
 .vscode/
+.metals/
 
 ### Mac OS ###
 .DS_Store
 
 ### CodeBuddy ###
 .codebuddy/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Test data
+test-data/

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,72 @@
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# =============================================================================
+# Build commands
+# =============================================================================
+
+.PHONY: install
+install:
+	./mvnw install -DskipTests
+
+.PHONY: test
+test:
+	./mvnw test
+
+.PHONY: build
+build: lint install
+
+.PHONY: package
+package:
+	./mvnw package -DskipTests
+
+# =============================================================================
+# Code style
+# =============================================================================
+
+.PHONY: lint
+lint:
+	./mvnw checkstyle:check spotless:check
+
+.PHONY: format
+format:
+	./mvnw spotless:apply
+
+# =============================================================================
+# Clean
+# =============================================================================
+
+.PHONY: clean
+clean:
+	./mvnw clean
+
+# =============================================================================
+# Help
+# =============================================================================
+
+.PHONY: help
+help:
+	@echo "Lance Flink Makefile"
+	@echo ""
+	@echo "Build commands:"
+	@echo "  install    - Install without tests"
+	@echo "  test       - Run tests"
+	@echo "  build      - Lint and install"
+	@echo "  package    - Package without tests"
+	@echo ""
+	@echo "Code style:"
+	@echo "  lint       - Check code style (checkstyle + spotless)"
+	@echo "  format     - Apply spotless formatting"
+	@echo ""
+	@echo "Clean:"
+	@echo "  clean      - Clean build artifacts"

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -39,7 +39,7 @@
     </module>
 
     <module name="LineLength">
-        <property name="max" value="100"/>
+        <property name="max" value="120"/>
         <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
     </module>
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,181 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name = "Checker">
+    <property name="charset" value="UTF-8"/>
+
+    <property name="severity" value="error"/>
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+
+    <!-- Checks for whitespace                               -->
+    <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
+
+    <module name="RegexpSingleline">
+        <!-- \s matches whitespace character, $ matches end of line. -->
+        <property name="format" value="\s+$"/>
+        <property name="message" value="No trailing whitespace allowed."/>
+    </module>
+
+    <module name="LineLength">
+        <property name="max" value="100"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+    </module>
+
+    <module name="TreeWalker">
+        <!--
+        If you wish to turn off checking for a section of code, you can put a comment in the source
+        before and after the section, with the following syntax:
+
+          // checkstyle.off: XXX (such as checkstyle.off: NoFinalizer)
+          ...  // stuff that breaks the styles
+          // checkstyle.on: XXX (such as checkstyle.on: NoFinalizer)
+        -->
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="checkstyle\.off\: ([\w\|]+)"/>
+            <property name="onCommentFormat" value="checkstyle\.on\: ([\w\|]+)"/>
+            <property name="checkFormat" value="$1"/>
+        </module>
+        <module name="OuterTypeFilename"/>
+        <module name="IllegalTokenText">
+            <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
+            <property name="format" value="\\u00(08|09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message" value="Avoid using corresponding octal or Unicode escape."/>
+        </module>
+        <module name="AvoidEscapedUnicodeCharacters">
+            <property name="allowEscapesForControlCharacters" value="true"/>
+            <property name="allowByTailComment" value="true"/>
+            <property name="allowNonPrintableEscapes" value="true"/>
+        </module>
+        <module name="NoLineWrap"/>
+        <module name="EmptyBlock">
+            <property name="option" value="TEXT"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+        </module>
+        <module name="NeedBraces">
+            <property name="allowSingleLineStatement" value="true"/>
+        </module>
+        <module name="OneStatementPerLine"/>
+        <module name="ArrayTypeStyle"/>
+        <module name="FallThrough"/>
+        <module name="UpperEll"/>
+        <module name="ModifierOrder"/>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="DOT"/>
+            <property name="option" value="nl"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="tokens" value="COMMA"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="PackageName">
+            <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
+            <message key="name.invalidPattern"
+                     value="Package name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="ClassTypeParameterName">
+            <property name="format" value="([A-Z][a-zA-Z0-9]*$)"/>
+            <message key="name.invalidPattern"
+                     value="Class type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="([A-Z][a-zA-Z0-9]*)"/>
+            <message key="name.invalidPattern"
+                     value="Method type name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="GenericWhitespace">
+            <message key="ws.followed"
+                     value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+            <message key="ws.preceded"
+                     value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+            <message key="ws.illegalFollow"
+                     value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+            <message key="ws.notPreceded"
+                     value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+        </module>
+        <module name="MethodParamPad"/>
+        <module name="AnnotationLocation">
+            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+        </module>
+        <module name="AnnotationLocation">
+            <property name="tokens" value="VARIABLE_DEF"/>
+            <property name="allowSamelineMultipleAnnotations" value="true"/>
+        </module>
+        <module name="MethodName">
+            <property name="format" value="^[a-z][a-z0-9][a-zA-Z0-9_]*$"/>
+            <message key="name.invalidPattern"
+                     value="Method name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="EmptyCatchBlock">
+            <property name="exceptionVariableName" value="expected"/>
+        </module>
+        <module name="CommentsIndentation"/>
+        <module name="UnusedImports"/>
+        <module name="RedundantImport"/>
+        <module name="RedundantModifier"/>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="throw new \w+Error\("/>
+            <property name="message" value="Avoid throwing error in application code."/>
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="Objects\.toStringHelper"/>
+            <property name="message" value="Avoid using Object.toStringHelper. Use ToStringBuilder instead." />
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="new (java\.lang\.)?(Byte|Integer|Long|Short)\("/>
+            <property name="message" value="Use static factory 'valueOf' or 'parseXXX' instead of the deprecated constructors." />
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="Files\.createTempDir\("/>
+            <property name="message"
+                      value="Avoid using com.google.common.io.Files.createTempDir() due to CVE-2020-8908.
+                Use org.apache.spark.network.util.JavaUtils.createTempDir() instead." />
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="FileBackedOutputStream"/>
+            <property name="message" value="Avoid using FileBackedOutputStream due to CVE-2023-2976." />
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="AtomicDoubleArray"/>
+            <property name="message" value="Avoid using AtomicDoubleArray due to CVE-2018-10237." />
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="CompoundOrdering"/>
+            <property name="message" value="Avoid using CompoundOrdering due to CVE-2018-10237." />
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="@Test\(expected"/>
+            <property name="message" value="Please use the `assertThrows` method to test for exceptions." />
+        </module>
+        <module name="IllegalImport">
+            <property name="illegalPkgs" value="org.apache.log4j" />
+            <property name="illegalPkgs" value="org.apache.commons.lang" />
+        </module>
+        <!-- support structured logging -->
+<!--        <module name="RegexpSinglelineJava">-->
+<!--            <property name="format" value="org\.slf4j\.(Logger|LoggerFactory)" />-->
+<!--            <property name="message" value="Please use org.apache.spark.internal.(SparkLogger|SparkLoggerFactory) instead." />-->
+<!--        </module>-->
+    </module>
+</module>

--- a/ci/bump_version.py
+++ b/ci/bump_version.py
@@ -1,0 +1,138 @@
+
+#!/usr/bin/env python3
+"""
+Version management script for Lance Flink project.
+Uses bump-my-version to handle version bumping across all project components.
+
+Versioning scheme:
+  - Stable releases: X.Y.Z (e.g., 0.1.0, 1.0.0)
+  - Pre-releases: X.Y.Z-<label>.<n> (e.g., 0.1.0-beta.1, 0.2.0-rc.2)
+  - Labels: alpha, beta, rc
+
+Examples:
+  # Bump to a specific version
+  python ci/bump_version.py --version 0.2.0
+  python ci/bump_version.py --version 0.2.0-beta.1
+
+  # Bump a specific part
+  python ci/bump_version.py --bump patch       # 0.1.0 -> 0.1.1
+  python ci/bump_version.py --bump minor       # 0.1.0 -> 0.2.0
+  python ci/bump_version.py --bump major       # 0.1.0 -> 1.0.0
+  python ci/bump_version.py --bump pre_n       # 0.1.0-beta.1 -> 0.1.0-beta.2
+  python ci/bump_version.py --bump pre_label   # 0.1.0-beta.1 -> 0.1.0-rc.1
+
+  # Dry run to see changes without applying them
+  python ci/bump_version.py --version 0.2.0 --dry-run
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_command(cmd: list[str], capture_output: bool = True) -> subprocess.CompletedProcess:
+    """Run a command and return the result."""
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, capture_output=capture_output, text=True)
+    if result.returncode != 0:
+        print(f"Error running command: {' '.join(cmd)}")
+        if capture_output:
+            print(f"stderr: {result.stderr}")
+        sys.exit(result.returncode)
+    return result
+
+
+def get_current_version() -> str:
+    """Get the current version from .bumpversion.toml."""
+    config_path = Path(".bumpversion.toml")
+    if not config_path.exists():
+        raise FileNotFoundError(".bumpversion.toml not found in current directory")
+
+    with open(config_path, "r") as f:
+        for line in f:
+            if line.strip().startswith('current_version = "'):
+                return line.split('"')[1]
+    raise ValueError("Could not find current_version in .bumpversion.toml")
+
+
+def parse_version(version: str) -> dict:
+    """Parse version string into components."""
+    pattern = r"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<pre_label>alpha|beta|rc)\.(?P<pre_n>\d+))?"
+    match = re.match(pattern, version)
+    if not match:
+        raise ValueError(f"Invalid version format: {version}")
+    return match.groupdict()
+
+
+def is_prerelease(version: str) -> bool:
+    """Check if version is a pre-release version."""
+    parts = parse_version(version)
+    return parts.get("pre_label") is not None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Bump version in Maven project using bump-my-version',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('--version', help='New version to set (e.g., 0.2.0 or 0.2.0-beta.1)')
+    group.add_argument('--bump', choices=['major', 'minor', 'patch', 'pre_label', 'pre_n'],
+                       help='Bump a specific version part')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Show what would be changed without making changes')
+
+    args = parser.parse_args()
+
+    # Get current version
+    current_version = get_current_version()
+    print(f"Current version: {current_version}")
+
+    # Build base command
+    base_cmd = ["bump-my-version", "bump"]
+
+    if args.dry_run:
+        print("\nDry run mode - no changes will be made")
+        base_cmd.extend(["--dry-run", "--verbose"])
+    else:
+        base_cmd.extend(["--no-commit", "--no-tag"])
+
+    base_cmd.append("--allow-dirty")
+
+    if args.version:
+        # Explicit version specified
+        new_version = args.version
+        print(f"Target version: {new_version}")
+
+        # Validate version format
+        try:
+            parse_version(new_version)
+        except ValueError as e:
+            print(f"Error: {e}")
+            sys.exit(1)
+
+        cmd = base_cmd + ["--current-version", current_version, "--new-version", new_version]
+    else:
+        # Bump a specific part
+        bump_part = args.bump
+
+        # Validate that pre_n and pre_label bumps are valid for current version
+        if bump_part in ["pre_n", "pre_label"] and not is_prerelease(current_version):
+            print(f"Error: Cannot bump '{bump_part}' on a stable version ({current_version}).")
+            print("Use --version to set a specific pre-release version first.")
+            sys.exit(1)
+
+        cmd = base_cmd + [bump_part]
+
+    run_command(cmd, capture_output=False)
+
+    if not args.dry_run:
+        new_version = get_current_version()
+        print(f"\nSuccessfully updated version from {current_version} to {new_version}")
+
+
+if __name__ == '__main__':
+    main()

--- a/ci/calculate_version.py
+++ b/ci/calculate_version.py
@@ -1,0 +1,79 @@
+
+#!/usr/bin/env python3
+"""
+Script to calculate the next version based on release type.
+"""
+
+import argparse
+import os
+import sys
+from packaging import version
+
+
+def calculate_next_version(current_version, release_type, channel):
+    """Calculate the next version based on release type and channel."""
+
+    # Parse current version
+    v = version.parse(current_version)
+
+    # Extract major, minor, patch
+    if hasattr(v, 'release'):
+        major, minor, patch = v.release[:3] if len(v.release) >= 3 else (*v.release, 0, 0)[:3]
+    else:
+        # Fallback for simple versions
+        parts = current_version.split('.')
+        major = int(parts[0]) if len(parts) > 0 else 0
+        minor = int(parts[1]) if len(parts) > 1 else 0
+        patch = int(parts[2]) if len(parts) > 2 else 0
+
+    # Calculate new version based on release type
+    # Note: 'current' keeps the same version (used to finalize previews to stable)
+    if release_type == 'major':
+        new_version = f"{major + 1}.0.0"
+    elif release_type == 'minor':
+        new_version = f"{major}.{minor + 1}.0"
+    elif release_type == 'patch':
+        new_version = f"{major}.{minor}.{patch + 1}"
+    elif release_type == 'current':
+        # Keep current base version - used for:
+        # - Subsequent preview releases (v0.0.16-beta.2, beta.3, etc.)
+        # - Finalizing preview to stable (v0.0.16-beta.X -> v0.0.16)
+        # Strip any pre-release suffix to get base version
+        new_version = f"{major}.{minor}.{patch}"
+    else:
+        raise ValueError(f"Unknown release type: {release_type}")
+
+    return new_version
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Calculate next version')
+    parser.add_argument('--current', required=True, help='Current version')
+    parser.add_argument('--type', required=True,
+                        choices=['major', 'minor', 'patch', 'current'],
+                        help='Release type')
+    parser.add_argument('--channel', required=True,
+                        choices=['stable', 'preview'],
+                        help='Release channel')
+
+    args = parser.parse_args()
+
+    try:
+        new_version = calculate_next_version(args.current, args.type, args.channel)
+
+        # Output for GitHub Actions
+        print(f"version={new_version}")
+
+        # Also write to GITHUB_OUTPUT if available
+        github_output = os.environ.get('GITHUB_OUTPUT')
+        if github_output:
+            with open(github_output, 'a') as f:
+                f.write(f"version={new_version}\n")
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/ci/check_lance_release.py
+++ b/ci/check_lance_release.py
@@ -1,0 +1,222 @@
+
+#!/usr/bin/env python3
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Determine whether a newer Lance tag exists and expose results for CI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from lxml import etree
+except ImportError:
+    import xml.etree.ElementTree as etree
+
+LANCE_REPO = "lance-format/lance"
+
+SEMVER_RE = re.compile(
+    r"^\s*(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)"
+    r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?"
+    r"(?:\+[0-9A-Za-z.-]+)?\s*$"
+)
+
+
+@dataclass(frozen=True)
+class SemVer:
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[int | str, ...]
+
+    def __lt__(self, other: SemVer) -> bool:
+        if (self.major, self.minor, self.patch) != (
+            other.major,
+            other.minor,
+            other.patch,
+        ):
+            return (self.major, self.minor, self.patch) < (
+                other.major,
+                other.minor,
+                other.patch,
+            )
+        if self.prerelease == other.prerelease:
+            return False
+        if not self.prerelease:
+            return False  # release > anything else
+        if not other.prerelease:
+            return True
+        for left, right in zip(self.prerelease, other.prerelease, strict=False):
+            if left == right:
+                continue
+            if isinstance(left, int) and isinstance(right, int):
+                return left < right
+            if isinstance(left, int):
+                return True
+            if isinstance(right, int):
+                return False
+            return str(left) < str(right)
+        return len(self.prerelease) < len(other.prerelease)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SemVer):
+            return NotImplemented
+        return (
+            self.major == other.major
+            and self.minor == other.minor
+            and self.patch == other.patch
+            and self.prerelease == other.prerelease
+        )
+
+
+def parse_semver(raw: str) -> SemVer:
+    match = SEMVER_RE.match(raw)
+    if not match:
+        raise ValueError(f"Unsupported version format: {raw}")
+    prerelease = match.group("prerelease")
+    parts: tuple[int | str, ...] = ()
+    if prerelease:
+        parsed: list[int | str] = []
+        for piece in prerelease.split("."):
+            if piece.isdigit():
+                parsed.append(int(piece))
+            else:
+                parsed.append(piece)
+        parts = tuple(parsed)
+    return SemVer(
+        major=int(match.group("major")),
+        minor=int(match.group("minor")),
+        patch=int(match.group("patch")),
+        prerelease=parts,
+    )
+
+
+@dataclass
+class TagInfo:
+    tag: str  # e.g. v1.0.0-beta.2
+    version: str  # e.g. 1.0.0-beta.2
+    semver: SemVer
+
+
+def run_command(cmd: Sequence[str]) -> str:
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Command {' '.join(cmd)} failed with {result.returncode}: {result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def fetch_remote_tags() -> list[TagInfo]:
+    output = run_command(
+        [
+            "gh",
+            "api",
+            "-X",
+            "GET",
+            f"repos/{LANCE_REPO}/git/refs/tags",
+            "--paginate",
+            "--jq",
+            ".[].ref",
+        ]
+    )
+    tags: list[TagInfo] = []
+    for line in output.splitlines():
+        ref = line.strip()
+        if not ref.startswith("refs/tags/v"):
+            continue
+        tag = ref.split("refs/tags/")[-1]
+        version = tag.lstrip("v")
+        try:
+            tags.append(TagInfo(tag=tag, version=version, semver=parse_semver(version)))
+        except ValueError:
+            continue
+    if not tags:
+        raise RuntimeError("No Lance tags could be parsed from GitHub API output")
+    return tags
+
+
+def read_current_version(repo_root: Path) -> str:
+    """Read lance.version from pom.xml."""
+    pom_path = repo_root / "pom.xml"
+    tree = etree.parse(str(pom_path))
+    root = tree.getroot()
+
+    ns = {"m": "http://maven.apache.org/POM/4.0.0"}
+    lance_version_elem = root.find(".//m:properties/m:lance.version", ns)
+
+    if lance_version_elem is None or lance_version_elem.text is None:
+        raise RuntimeError("Failed to locate lance.version property in pom.xml")
+
+    return lance_version_elem.text.strip()
+
+
+def determine_latest_tag(tags: Iterable[TagInfo]) -> TagInfo:
+    return max(tags, key=lambda tag: tag.semver)
+
+
+def write_outputs(args: argparse.Namespace, payload: dict) -> None:
+    target = getattr(args, "github_output", None)
+    if not target:
+        return
+    with open(target, "a", encoding="utf-8") as handle:
+        for key, value in payload.items():
+            handle.write(f"{key}={value}\n")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        default=Path(__file__).resolve().parents[1],
+        type=Path,
+        help="Path to the lance-flink repository root",
+    )
+    parser.add_argument(
+        "--github-output",
+        default=os.environ.get("GITHUB_OUTPUT"),
+        help="Optional file path for writing GitHub Action outputs",
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root)
+    current_version = read_current_version(repo_root)
+    current_semver = parse_semver(current_version)
+
+    tags = fetch_remote_tags()
+    latest = determine_latest_tag(tags)
+    needs_update = latest.semver > current_semver
+
+    payload = {
+        "current_version": current_version,
+        "current_tag": f"v{current_version}",
+        "latest_version": latest.version,
+        "latest_tag": latest.tag,
+        "needs_update": "true" if needs_update else "false",
+    }
+
+    print(json.dumps(payload))
+    write_outputs(args, payload)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mvnw
+++ b/mvnw
@@ -1,0 +1,295 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.4
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+scriptDir="$(dirname "$0")"
+scriptName="$(basename "$0")"
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"$scriptDir/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${scriptName#mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c - >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+actualDistributionDir=""
+
+# First try the expected directory name (for regular distributions)
+if [ -d "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" ]; then
+  if [ -f "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/bin/$MVN_CMD" ]; then
+    actualDistributionDir="$distributionUrlNameMain"
+  fi
+fi
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if [ -z "$actualDistributionDir" ]; then
+  # enable globbing to iterate over items
+  set +f
+  for dir in "$TMP_DOWNLOAD_DIR"/*; do
+    if [ -d "$dir" ]; then
+      if [ -f "$dir/bin/$MVN_CMD" ]; then
+        actualDistributionDir="$(basename "$dir")"
+        break
+      fi
+    fi
+  done
+  set -f
+fi
+
+if [ -z "$actualDistributionDir" ]; then
+  verbose "Contents of $TMP_DOWNLOAD_DIR:"
+  verbose "$(ls -la "$TMP_DOWNLOAD_DIR")"
+  die "Could not find Maven distribution directory in extracted archive"
+fi
+
+verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$actualDistributionDir/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$actualDistributionDir" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -1,0 +1,189 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" ("%__MVNW_CMD__%" %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND -eq $False) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace "^.*$MVNW_REPO_PATTERN",'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+
+$MAVEN_M2_PATH = "$HOME/.m2"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_M2_PATH = "$env:MAVEN_USER_HOME"
+}
+
+if (-not (Test-Path -Path $MAVEN_M2_PATH)) {
+    New-Item -Path $MAVEN_M2_PATH -ItemType Directory | Out-Null
+}
+
+$MAVEN_WRAPPER_DISTS = $null
+if ((Get-Item $MAVEN_M2_PATH).Target[0] -eq $null) {
+  $MAVEN_WRAPPER_DISTS = "$MAVEN_M2_PATH/wrapper/dists"
+} else {
+  $MAVEN_WRAPPER_DISTS = (Get-Item $MAVEN_M2_PATH).Target[0] + "/wrapper/dists"
+}
+
+$MAVEN_HOME_PARENT = "$MAVEN_WRAPPER_DISTS/$distributionUrlNameMain"
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.SHA256]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+
+# Find the actual extracted directory name (handles snapshots where filename != directory name)
+$actualDistributionDir = ""
+
+# First try the expected directory name (for regular distributions)
+$expectedPath = Join-Path "$TMP_DOWNLOAD_DIR" "$distributionUrlNameMain"
+$expectedMvnPath = Join-Path "$expectedPath" "bin/$MVN_CMD"
+if ((Test-Path -Path $expectedPath -PathType Container) -and (Test-Path -Path $expectedMvnPath -PathType Leaf)) {
+  $actualDistributionDir = $distributionUrlNameMain
+}
+
+# If not found, search for any directory with the Maven executable (for snapshots)
+if (!$actualDistributionDir) {
+  Get-ChildItem -Path "$TMP_DOWNLOAD_DIR" -Directory | ForEach-Object {
+    $testPath = Join-Path $_.FullName "bin/$MVN_CMD"
+    if (Test-Path -Path $testPath -PathType Leaf) {
+      $actualDistributionDir = $_.Name
+    }
+  }
+}
+
+if (!$actualDistributionDir) {
+  Write-Error "Could not find Maven distribution directory in extracted archive"
+}
+
+Write-Verbose "Found extracted Maven distribution directory: $actualDistributionDir"
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$actualDistributionDir" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/pom.xml
+++ b/pom.xml
@@ -3,22 +3,61 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.apache.flink</groupId>
-    <artifactId>flink-connector-lance</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <groupId>org.lance</groupId>
+    <artifactId>lance-flink</artifactId>
+    <version>0.1.0</version>
     <packaging>jar</packaging>
 
-    <name>Flink Connector Lance</name>
-    <description>Apache Flink Connector for Lance vector data format</description>
-    <url>https://github.com/apache/flink-connector-lance</url>
+    <name>${project.artifactId}</name>
+    <description>Lance Flink Connector - Apache Flink connector for Lance columnar data format</description>
+    <url>https://lance.org/integrations/flink</url>
+
+    <developers>
+        <developer>
+            <name>Lance DB Dev Group</name>
+            <email>dev@lancedb.com</email>
+        </developer>
+    </developers>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git@github.com:lance-format/lance-flink.git</connection>
+        <developerConnection>scm:git:git@github.com:lance-format/lance-flink.git</developerConnection>
+        <url>git@github.com:lance-format/lance-flink.git</url>
+        <tag>HEAD</tag>
+    </scm>
+
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/lance-format/lance-flink/issues</url>
+    </issueManagement>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        
-        <!-- 版本管理 -->
+
+        <!-- Lance Flink version (kept in sync with project version via bump-my-version) -->
+        <lance-flink.version>0.1.0</lance-flink.version>
+
+        <!-- Dependency versions -->
         <flink.version>1.16.1</flink.version>
         <lance.version>0.23.3</lance.version>
         <arrow.version>14.0.0</arrow.version>
@@ -27,6 +66,42 @@
         <log4j.version>2.20.0</log4j.version>
         <mockito.version>5.3.1</mockito.version>
         <assertj.version>3.24.2</assertj.version>
+
+        <!-- Code style -->
+        <spotless.skip>false</spotless.skip>
+        <spotless.version>2.43.0</spotless.version>
+        <spotless.java.googlejavaformat.version>1.19.2</spotless.java.googlejavaformat.version>
+        <spotless.delimiter>package</spotless.delimiter>
+        <spotless.license.header>
+            /*
+            * Licensed under the Apache License, Version 2.0 (the "License");
+            * you may not use this file except in compliance with the License.
+            * You may obtain a copy of the License at
+            *
+            *     http://www.apache.org/licenses/LICENSE-2.0
+            *
+            * Unless required by applicable law or agreed to in writing, software
+            * distributed under the License is distributed on an "AS IS" BASIS,
+            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            * See the License for the specific language governing permissions and
+            * limitations under the License.
+            */
+        </spotless.license.header>
+
+        <!-- Plugin versions -->
+        <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
+        <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
+        <maven-shade-plugin.version>3.5.0</maven-shade-plugin.version>
+        <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
+        <maven-source-plugin.version>3.3.0</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
+        <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
+        <maven-release-plugin.version>3.1.0</maven-release-plugin.version>
+        <jacoco-plugin.version>0.8.10</jacoco-plugin.version>
+
+        <!-- Java version -->
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <dependencies>
@@ -215,11 +290,11 @@
 
     <build>
         <plugins>
-            <!-- Maven 编译插件 -->
+            <!-- Maven Compiler Plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -229,20 +304,41 @@
                 </configuration>
             </plugin>
 
-            <!-- Maven Surefire 测试插件 -->
+            <!-- Maven Surefire Plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>${maven-surefire-plugin.version}</version>
                 <configuration>
+                    <argLine>
+                        -XX:+IgnoreUnrecognizedVMOptions
+                        --add-opens=java.base/java.lang=ALL-UNNAMED
+                        --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+                        --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+                        --add-opens=java.base/java.io=ALL-UNNAMED
+                        --add-opens=java.base/java.net=ALL-UNNAMED
+                        --add-opens=java.base/java.nio=ALL-UNNAMED
+                        --add-opens=java.base/java.util=ALL-UNNAMED
+                        --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+                        --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
+                        --add-opens=java.base/jdk.internal.ref=ALL-UNNAMED
+                        --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+                        --add-opens=java.base/sun.nio.cs=ALL-UNNAMED
+                        --add-opens=java.base/sun.security.action=ALL-UNNAMED
+                        --add-opens=java.base/sun.util.calendar=ALL-UNNAMED
+                        -Djdk.reflect.useDirectMethodHandle=false
+                        -Dio.netty.tryReflectionSetAccessible=true
+                    </argLine>
+                    <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
+                    <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>
 
-            <!-- Maven Shade 插件 (打包 Fat JAR) -->
+            <!-- Maven Shade Plugin (Fat JAR) -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>${maven-shade-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -285,11 +381,11 @@
                 </executions>
             </plugin>
 
-            <!-- Maven JAR 插件 -->
+            <!-- Maven JAR Plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>${maven-jar-plugin.version}</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -300,11 +396,11 @@
                 </configuration>
             </plugin>
 
-            <!-- Maven Source 插件 -->
+            <!-- Maven Source Plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -315,21 +411,85 @@
                 </executions>
             </plugin>
 
-            <!-- Maven Javadoc 插件 -->
+            <!-- Maven Javadoc Plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>${maven-javadoc-plugin.version}</version>
                 <configuration>
                     <doclint>none</doclint>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
-            <!-- JaCoCo 代码覆盖率插件 -->
+            <!-- Checkstyle Plugin (run via: mvn checkstyle:check or make lint) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>${maven-checkstyle-plugin.version}</version>
+                <configuration>
+                    <configLocation>checkstyle.xml</configLocation>
+                    <consoleOutput>true</consoleOutput>
+                    <failsOnError>true</failsOnError>
+                    <violationSeverity>warning</violationSeverity>
+                    <linkXRef>false</linkXRef>
+                </configuration>
+            </plugin>
+
+            <!-- Spotless Plugin -->
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>${spotless.version}</version>
+                <configuration>
+                    <skip>${spotless.skip}</skip>
+                    <upToDateChecking>
+                        <enabled>true</enabled>
+                    </upToDateChecking>
+                    <java>
+                        <includes>
+                            <include>src/main/java/**/*.java</include>
+                            <include>src/test/java/**/*.java</include>
+                        </includes>
+                        <googleJavaFormat>
+                            <version>${spotless.java.googlejavaformat.version}</version>
+                            <style>GOOGLE</style>
+                        </googleJavaFormat>
+                        <importOrder>
+                            <order>org.lance,,javax,java,\#</order>
+                        </importOrder>
+                        <removeUnusedImports/>
+                    </java>
+                    <licenseHeader>
+                        <content>${spotless.license.header}</content>
+                        <delimiter>${spotless.delimiter}</delimiter>
+                    </licenseHeader>
+                </configuration>
+                <!-- Run via: mvn spotless:check / spotless:apply or make lint / make format -->
+            </plugin>
+
+            <!-- Maven Release Plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${maven-release-plugin.version}</version>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                </configuration>
+            </plugin>
+
+            <!-- JaCoCo Code Coverage Plugin -->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.10</version>
+                <version>${jacoco-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -348,13 +508,60 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!-- Deploy to Maven Central (OSSRH) -->
+        <profile>
+            <id>deploy-to-ossrh</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>ossrh</publishingServerId>
+                            <tokenAuth>true</tokenAuth>
+                            <autoPublish>true</autoPublish>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.13</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.5</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <repositories>
-        <!-- Maven 中央仓库 -->
+        <!-- Maven Central -->
         <repository>
             <id>central</id>
             <url>https://repo.maven.apache.org/maven2</url>
         </repository>
-        <!-- Apache 快照仓库 -->
+        <!-- Apache Snapshots -->
         <repository>
             <id>apache-snapshots</id>
             <url>https://repository.apache.org/content/repositories/snapshots/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -439,6 +439,7 @@
                     <consoleOutput>true</consoleOutput>
                     <failsOnError>true</failsOnError>
                     <violationSeverity>warning</violationSeverity>
+                    <includeTestSourceDirectory>false</includeTestSourceDirectory>
                     <linkXRef>false</linkXRef>
                 </configuration>
             </plugin>

--- a/src/main/java/org/apache/flink/connector/lance/LanceAggregateSource.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceAggregateSource.java
@@ -41,14 +41,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
 /**
  * Lance data source with aggregate push-down support.
  *
- * <p>Executes aggregate computation at the data source, supporting COUNT, SUM, AVG, MIN, MAX and other aggregate functions.
+ * <p>Executes aggregate computation at the data source,
+ * supporting COUNT, SUM, AVG, MIN, MAX and other aggregate functions.
  *
  * <p>Usage example:
  * <pre>{@code

--- a/src/main/java/org/apache/flink/connector/lance/LanceAggregateSource.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceAggregateSource.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,18 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance;
-
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.connector.lance.aggregate.AggregateExecutor;
-import org.apache.flink.connector.lance.aggregate.AggregateInfo;
-import org.apache.flink.connector.lance.config.LanceOptions;
-import org.apache.flink.connector.lance.converter.LanceTypeConverter;
-import org.apache.flink.connector.lance.converter.RowDataConverter;
-import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.logical.RowType;
 
 import com.lancedb.lance.Dataset;
 import com.lancedb.lance.Fragment;
@@ -37,6 +22,15 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.lance.aggregate.AggregateExecutor;
+import org.apache.flink.connector.lance.aggregate.AggregateInfo;
+import org.apache.flink.connector.lance.config.LanceOptions;
+import org.apache.flink.connector.lance.converter.LanceTypeConverter;
+import org.apache.flink.connector.lance.converter.RowDataConverter;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,10 +41,11 @@ import java.util.List;
 /**
  * Lance data source with aggregate push-down support.
  *
- * <p>Executes aggregate computation at the data source,
- * supporting COUNT, SUM, AVG, MIN, MAX and other aggregate functions.
+ * <p>Executes aggregate computation at the data source, supporting COUNT, SUM, AVG, MIN, MAX and
+ * other aggregate functions.
  *
  * <p>Usage example:
+ *
  * <pre>{@code
  * AggregateInfo aggInfo = AggregateInfo.builder()
  *     .addCountStar("cnt")
@@ -63,263 +58,249 @@ import java.util.List;
  */
 public class LanceAggregateSource extends RichParallelSourceFunction<RowData> {
 
-    private static final long serialVersionUID = 1L;
-    private static final Logger LOG = LoggerFactory.getLogger(LanceAggregateSource.class);
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(LanceAggregateSource.class);
 
-    private final LanceOptions options;
-    private final RowType sourceRowType;
-    private final AggregateInfo aggregateInfo;
-    private final String[] selectedColumns;
+  private final LanceOptions options;
+  private final RowType sourceRowType;
+  private final AggregateInfo aggregateInfo;
+  private final String[] selectedColumns;
 
-    private transient volatile boolean running;
-    private transient BufferAllocator allocator;
-    private transient Dataset dataset;
-    private transient RowDataConverter converter;
-    private transient AggregateExecutor aggregateExecutor;
+  private transient volatile boolean running;
+  private transient BufferAllocator allocator;
+  private transient Dataset dataset;
+  private transient RowDataConverter converter;
+  private transient AggregateExecutor aggregateExecutor;
 
-    /**
-     * Create LanceAggregateSource
-     *
-     * @param options Lance configuration options
-     * @param sourceRowType RowType of source table
-     * @param aggregateInfo Aggregate information
-     */
-    public LanceAggregateSource(LanceOptions options, RowType sourceRowType, AggregateInfo aggregateInfo) {
-        this.options = options;
-        this.sourceRowType = sourceRowType;
-        this.aggregateInfo = aggregateInfo;
+  /**
+   * Create LanceAggregateSource
+   *
+   * @param options Lance configuration options
+   * @param sourceRowType RowType of source table
+   * @param aggregateInfo Aggregate information
+   */
+  public LanceAggregateSource(
+      LanceOptions options, RowType sourceRowType, AggregateInfo aggregateInfo) {
+    this.options = options;
+    this.sourceRowType = sourceRowType;
+    this.aggregateInfo = aggregateInfo;
 
-        // Calculate columns to read
-        List<String> requiredColumns = aggregateInfo.getRequiredColumns();
-        this.selectedColumns = requiredColumns.isEmpty() ? null : requiredColumns.toArray(new String[0]);
+    // Calculate columns to read
+    List<String> requiredColumns = aggregateInfo.getRequiredColumns();
+    this.selectedColumns =
+        requiredColumns.isEmpty() ? null : requiredColumns.toArray(new String[0]);
+  }
+
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    super.open(parameters);
+
+    LOG.info("Opening Lance aggregate data source: {}", options.getPath());
+    LOG.info("Aggregate info: {}", aggregateInfo);
+
+    this.running = true;
+    this.allocator = new RootAllocator(Long.MAX_VALUE);
+
+    // Open Lance dataset
+    String datasetPath = options.getPath();
+    if (datasetPath == null || datasetPath.isEmpty()) {
+      throw new IllegalArgumentException("Lance dataset path cannot be empty");
     }
 
-    @Override
-    public void open(Configuration parameters) throws Exception {
-        super.open(parameters);
-
-        LOG.info("Opening Lance aggregate data source: {}", options.getPath());
-        LOG.info("Aggregate info: {}", aggregateInfo);
-
-        this.running = true;
-        this.allocator = new RootAllocator(Long.MAX_VALUE);
-
-        // Open Lance dataset
-        String datasetPath = options.getPath();
-        if (datasetPath == null || datasetPath.isEmpty()) {
-            throw new IllegalArgumentException("Lance dataset path cannot be empty");
-        }
-
-        try {
-            this.dataset = Dataset.open(datasetPath, allocator);
-        } catch (Exception e) {
-            throw new IOException("Failed to open Lance dataset: " + datasetPath, e);
-        }
-
-        // Initialize RowDataConverter (using source table Schema)
-        RowType actualRowType = this.sourceRowType;
-        if (actualRowType == null) {
-            Schema arrowSchema = dataset.getSchema();
-            actualRowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
-        }
-        this.converter = new RowDataConverter(actualRowType);
-
-        // Initialize aggregate executor
-        this.aggregateExecutor = new AggregateExecutor(aggregateInfo, actualRowType);
-        this.aggregateExecutor.init();
-
-        LOG.info("Lance aggregate data source opened");
+    try {
+      this.dataset = Dataset.open(datasetPath, allocator);
+    } catch (Exception e) {
+      throw new IOException("Failed to open Lance dataset: " + datasetPath, e);
     }
 
-    @Override
-    public void run(SourceContext<RowData> ctx) throws Exception {
-        LOG.info("Starting aggregate read from Lance dataset: {}", options.getPath());
+    // Initialize RowDataConverter (using source table Schema)
+    RowType actualRowType = this.sourceRowType;
+    if (actualRowType == null) {
+      Schema arrowSchema = dataset.getSchema();
+      actualRowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
+    }
+    this.converter = new RowDataConverter(actualRowType);
 
-        int subtaskIndex = getRuntimeContext().getIndexOfThisSubtask();
-        int numSubtasks = getRuntimeContext().getNumberOfParallelSubtasks();
+    // Initialize aggregate executor
+    this.aggregateExecutor = new AggregateExecutor(aggregateInfo, actualRowType);
+    this.aggregateExecutor.init();
 
-        // Aggregate operation only executes on subtask 0 to avoid duplicate aggregation
-        if (subtaskIndex != 0) {
-            LOG.info("Subtask {} skipped (only subtask 0 executes in aggregate mode)", subtaskIndex);
-            return;
-        }
+    LOG.info("Lance aggregate data source opened");
+  }
 
-        String filter = options.getReadFilter();
+  @Override
+  public void run(SourceContext<RowData> ctx) throws Exception {
+    LOG.info("Starting aggregate read from Lance dataset: {}", options.getPath());
 
-        // Read all data and perform aggregation
-        if (filter != null && !filter.isEmpty()) {
-            readAndAggregateWithFilter(ctx);
-        } else {
-            readAndAggregateAll(ctx);
-        }
+    int subtaskIndex = getRuntimeContext().getIndexOfThisSubtask();
+    int numSubtasks = getRuntimeContext().getNumberOfParallelSubtasks();
 
-        LOG.info("Lance aggregate data source read completed");
+    // Aggregate operation only executes on subtask 0 to avoid duplicate aggregation
+    if (subtaskIndex != 0) {
+      LOG.info("Subtask {} skipped (only subtask 0 executes in aggregate mode)", subtaskIndex);
+      return;
     }
 
-    /**
-     * Aggregate read with filter condition
-     */
-    private void readAndAggregateWithFilter(SourceContext<RowData> ctx) throws Exception {
-        ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder();
-        scanOptionsBuilder.batchSize(options.getReadBatchSize());
+    String filter = options.getReadFilter();
 
-        if (selectedColumns != null && selectedColumns.length > 0) {
-            scanOptionsBuilder.columns(Arrays.asList(selectedColumns));
-        }
-
-        String filter = options.getReadFilter();
-        if (filter != null && !filter.isEmpty()) {
-            LOG.info("Applying filter condition: {}", filter);
-            scanOptionsBuilder.filter(filter);
-        }
-
-        ScanOptions scanOptions = scanOptionsBuilder.build();
-
-        // Phase 1: Read data and accumulate aggregation
-        try (LanceScanner scanner = dataset.newScan(scanOptions)) {
-            try (ArrowReader reader = scanner.scanBatches()) {
-                while (reader.loadNextBatch() && running) {
-                    VectorSchemaRoot root = reader.getVectorSchemaRoot();
-                    List<RowData> rows = converter.toRowDataList(root);
-
-                    for (RowData row : rows) {
-                        aggregateExecutor.accumulate(row);
-                    }
-                }
-            }
-        }
-
-        // Phase 2: Output aggregate results
-        outputAggregateResults(ctx);
+    // Read all data and perform aggregation
+    if (filter != null && !filter.isEmpty()) {
+      readAndAggregateWithFilter(ctx);
+    } else {
+      readAndAggregateAll(ctx);
     }
 
-    /**
-     * Read all data and aggregate (without filter condition)
-     */
-    private void readAndAggregateAll(SourceContext<RowData> ctx) throws Exception {
-        List<Fragment> fragments = dataset.getFragments();
-        LOG.info("Dataset has {} Fragments", fragments.size());
+    LOG.info("Lance aggregate data source read completed");
+  }
 
-        // Phase 1: Read all Fragments and accumulate aggregation
-        for (Fragment fragment : fragments) {
-            if (!running) {
-                break;
-            }
-            readAndAggregateFragment(fragment);
+  /** Aggregate read with filter condition */
+  private void readAndAggregateWithFilter(SourceContext<RowData> ctx) throws Exception {
+    ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder();
+    scanOptionsBuilder.batchSize(options.getReadBatchSize());
+
+    if (selectedColumns != null && selectedColumns.length > 0) {
+      scanOptionsBuilder.columns(Arrays.asList(selectedColumns));
+    }
+
+    String filter = options.getReadFilter();
+    if (filter != null && !filter.isEmpty()) {
+      LOG.info("Applying filter condition: {}", filter);
+      scanOptionsBuilder.filter(filter);
+    }
+
+    ScanOptions scanOptions = scanOptionsBuilder.build();
+
+    // Phase 1: Read data and accumulate aggregation
+    try (LanceScanner scanner = dataset.newScan(scanOptions)) {
+      try (ArrowReader reader = scanner.scanBatches()) {
+        while (reader.loadNextBatch() && running) {
+          VectorSchemaRoot root = reader.getVectorSchemaRoot();
+          List<RowData> rows = converter.toRowDataList(root);
+
+          for (RowData row : rows) {
+            aggregateExecutor.accumulate(row);
+          }
         }
-
-        // Phase 2: Output aggregate results
-        outputAggregateResults(ctx);
+      }
     }
 
-    /**
-     * Read single Fragment and accumulate aggregation
-     */
-    private void readAndAggregateFragment(Fragment fragment) throws Exception {
-        LOG.debug("Reading Fragment: {}", fragment.getId());
+    // Phase 2: Output aggregate results
+    outputAggregateResults(ctx);
+  }
 
-        ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder();
-        scanOptionsBuilder.batchSize(options.getReadBatchSize());
+  /** Read all data and aggregate (without filter condition) */
+  private void readAndAggregateAll(SourceContext<RowData> ctx) throws Exception {
+    List<Fragment> fragments = dataset.getFragments();
+    LOG.info("Dataset has {} Fragments", fragments.size());
 
-        if (selectedColumns != null && selectedColumns.length > 0) {
-            scanOptionsBuilder.columns(Arrays.asList(selectedColumns));
+    // Phase 1: Read all Fragments and accumulate aggregation
+    for (Fragment fragment : fragments) {
+      if (!running) {
+        break;
+      }
+      readAndAggregateFragment(fragment);
+    }
+
+    // Phase 2: Output aggregate results
+    outputAggregateResults(ctx);
+  }
+
+  /** Read single Fragment and accumulate aggregation */
+  private void readAndAggregateFragment(Fragment fragment) throws Exception {
+    LOG.debug("Reading Fragment: {}", fragment.getId());
+
+    ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder();
+    scanOptionsBuilder.batchSize(options.getReadBatchSize());
+
+    if (selectedColumns != null && selectedColumns.length > 0) {
+      scanOptionsBuilder.columns(Arrays.asList(selectedColumns));
+    }
+
+    ScanOptions scanOptions = scanOptionsBuilder.build();
+
+    try (LanceScanner scanner = fragment.newScan(scanOptions)) {
+      try (ArrowReader reader = scanner.scanBatches()) {
+        while (reader.loadNextBatch() && running) {
+          VectorSchemaRoot root = reader.getVectorSchemaRoot();
+          List<RowData> rows = converter.toRowDataList(root);
+
+          for (RowData row : rows) {
+            aggregateExecutor.accumulate(row);
+          }
         }
+      }
+    }
+  }
 
-        ScanOptions scanOptions = scanOptionsBuilder.build();
+  /** Output aggregate results */
+  private void outputAggregateResults(SourceContext<RowData> ctx) {
+    List<RowData> results = aggregateExecutor.getResults();
+    LOG.info("Aggregation completed, {} result rows", results.size());
 
-        try (LanceScanner scanner = fragment.newScan(scanOptions)) {
-            try (ArrowReader reader = scanner.scanBatches()) {
-                while (reader.loadNextBatch() && running) {
-                    VectorSchemaRoot root = reader.getVectorSchemaRoot();
-                    List<RowData> rows = converter.toRowDataList(root);
+    synchronized (ctx.getCheckpointLock()) {
+      for (RowData result : results) {
+        ctx.collect(result);
+      }
+    }
+  }
 
-                    for (RowData row : rows) {
-                        aggregateExecutor.accumulate(row);
-                    }
-                }
-            }
-        }
+  @Override
+  public void cancel() {
+    LOG.info("Cancelling Lance aggregate data source");
+    this.running = false;
+  }
+
+  @Override
+  public void close() throws Exception {
+    LOG.info("Closing Lance aggregate data source");
+
+    this.running = false;
+
+    if (aggregateExecutor != null) {
+      aggregateExecutor.reset();
     }
 
-    /**
-     * Output aggregate results
-     */
-    private void outputAggregateResults(SourceContext<RowData> ctx) {
-        List<RowData> results = aggregateExecutor.getResults();
-        LOG.info("Aggregation completed, {} result rows", results.size());
-
-        synchronized (ctx.getCheckpointLock()) {
-            for (RowData result : results) {
-                ctx.collect(result);
-            }
-        }
+    if (dataset != null) {
+      try {
+        dataset.close();
+      } catch (Exception e) {
+        LOG.warn("Error closing Lance dataset", e);
+      }
+      dataset = null;
     }
 
-    @Override
-    public void cancel() {
-        LOG.info("Cancelling Lance aggregate data source");
-        this.running = false;
+    if (allocator != null) {
+      try {
+        allocator.close();
+      } catch (Exception e) {
+        LOG.warn("Error closing memory allocator", e);
+      }
+      allocator = null;
     }
 
-    @Override
-    public void close() throws Exception {
-        LOG.info("Closing Lance aggregate data source");
+    super.close();
+  }
 
-        this.running = false;
+  /** Get aggregate information */
+  public AggregateInfo getAggregateInfo() {
+    return aggregateInfo;
+  }
 
-        if (aggregateExecutor != null) {
-            aggregateExecutor.reset();
-        }
+  /** Get configuration options */
+  public LanceOptions getOptions() {
+    return options;
+  }
 
-        if (dataset != null) {
-            try {
-                dataset.close();
-            } catch (Exception e) {
-                LOG.warn("Error closing Lance dataset", e);
-            }
-            dataset = null;
-        }
+  /** Get source table RowType */
+  public RowType getSourceRowType() {
+    return sourceRowType;
+  }
 
-        if (allocator != null) {
-            try {
-                allocator.close();
-            } catch (Exception e) {
-                LOG.warn("Error closing memory allocator", e);
-            }
-            allocator = null;
-        }
-
-        super.close();
+  /** Get aggregate result RowType */
+  public RowType getResultRowType() {
+    if (aggregateExecutor != null) {
+      return aggregateExecutor.buildResultRowType();
     }
-
-    /**
-     * Get aggregate information
-     */
-    public AggregateInfo getAggregateInfo() {
-        return aggregateInfo;
-    }
-
-    /**
-     * Get configuration options
-     */
-    public LanceOptions getOptions() {
-        return options;
-    }
-
-    /**
-     * Get source table RowType
-     */
-    public RowType getSourceRowType() {
-        return sourceRowType;
-    }
-
-    /**
-     * Get aggregate result RowType
-     */
-    public RowType getResultRowType() {
-        if (aggregateExecutor != null) {
-            return aggregateExecutor.buildResultRowType();
-        }
-        return null;
-    }
+    return null;
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/LanceAggregateSource.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceAggregateSource.java
@@ -25,6 +25,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.lance.aggregate.AggregateExecutor;
 import org.apache.flink.connector.lance.aggregate.AggregateInfo;
+import org.apache.flink.connector.lance.config.LanceDatasetFactory;
 import org.apache.flink.connector.lance.config.LanceOptions;
 import org.apache.flink.connector.lance.converter.LanceTypeConverter;
 import org.apache.flink.connector.lance.converter.RowDataConverter;
@@ -34,7 +35,6 @@ import org.apache.flink.table.types.logical.RowType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -102,16 +102,7 @@ public class LanceAggregateSource extends RichParallelSourceFunction<RowData> {
     this.allocator = new RootAllocator(Long.MAX_VALUE);
 
     // Open Lance dataset
-    String datasetPath = options.getPath();
-    if (datasetPath == null || datasetPath.isEmpty()) {
-      throw new IllegalArgumentException("Lance dataset path cannot be empty");
-    }
-
-    try {
-      this.dataset = Dataset.open(datasetPath, allocator);
-    } catch (Exception e) {
-      throw new IOException("Failed to open Lance dataset: " + datasetPath, e);
-    }
+    this.dataset = LanceDatasetFactory.open(options.getPath(), allocator);
 
     // Initialize RowDataConverter (using source table Schema)
     RowType actualRowType = this.sourceRowType;

--- a/src/main/java/org/apache/flink/connector/lance/LanceIndexBuilder.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceIndexBuilder.java
@@ -22,7 +22,7 @@ import com.lancedb.lance.index.vector.IvfBuildParams;
 import com.lancedb.lance.index.vector.PQBuildParams;
 import com.lancedb.lance.index.vector.VectorIndexParams;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
+import org.apache.flink.connector.lance.config.LanceDatasetFactory;
 import org.apache.flink.connector.lance.config.LanceOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,8 +102,8 @@ public class LanceIndexBuilder implements Closeable, Serializable {
 
     try {
       // Initialize resources
-      this.allocator = new RootAllocator(Long.MAX_VALUE);
-      this.dataset = Dataset.open(datasetPath, allocator);
+      this.allocator = LanceDatasetFactory.createAllocator();
+      this.dataset = LanceDatasetFactory.open(datasetPath, allocator);
 
       // Validate column exists
       validateColumn();

--- a/src/main/java/org/apache/flink/connector/lance/LanceIndexBuilder.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceIndexBuilder.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,10 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance;
-
-import org.apache.flink.connector.lance.config.LanceOptions;
 
 import com.lancedb.lance.Dataset;
 import com.lancedb.lance.index.DistanceType;
@@ -30,6 +23,7 @@ import com.lancedb.lance.index.vector.PQBuildParams;
 import com.lancedb.lance.index.vector.VectorIndexParams;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.flink.connector.lance.config.LanceOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +39,7 @@ import java.util.Optional;
  * <p>Supports building IVF_PQ, IVF_HNSW_PQ, and IVF_FLAT vector indices.
  *
  * <p>Usage example:
+ *
  * <pre>{@code
  * LanceIndexBuilder builder = LanceIndexBuilder.builder()
  *     .datasetPath("/path/to/dataset")
@@ -59,378 +54,381 @@ import java.util.Optional;
  */
 public class LanceIndexBuilder implements Closeable, Serializable {
 
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(LanceIndexBuilder.class);
+
+  private final String datasetPath;
+  private final String columnName;
+  private final LanceOptions.IndexType indexType;
+  private final LanceOptions.MetricType metricType;
+  private final int numPartitions;
+  private final Integer numSubVectors;
+  private final int numBits;
+  private final int maxLevel;
+  private final int m;
+  private final int efConstruction;
+  private final boolean replace;
+
+  private transient BufferAllocator allocator;
+  private transient Dataset dataset;
+
+  private LanceIndexBuilder(Builder builder) {
+    this.datasetPath = builder.datasetPath;
+    this.columnName = builder.columnName;
+    this.indexType = builder.indexType;
+    this.metricType = builder.metricType;
+    this.numPartitions = builder.numPartitions;
+    this.numSubVectors = builder.numSubVectors;
+    this.numBits = builder.numBits;
+    this.maxLevel = builder.maxLevel;
+    this.m = builder.m;
+    this.efConstruction = builder.efConstruction;
+    this.replace = builder.replace;
+  }
+
+  /**
+   * Build vector index
+   *
+   * @return Index build result
+   */
+  public IndexBuildResult buildIndex() throws IOException {
+    LOG.info(
+        "Starting to build vector index, type: {}, column: {}, dataset: {}",
+        indexType,
+        columnName,
+        datasetPath);
+
+    long startTime = System.currentTimeMillis();
+
+    try {
+      // Initialize resources
+      this.allocator = new RootAllocator(Long.MAX_VALUE);
+      this.dataset = Dataset.open(datasetPath, allocator);
+
+      // Validate column exists
+      validateColumn();
+
+      // Get distance metric type
+      DistanceType distanceType = toDistanceType(metricType);
+
+      // Build IVF parameters
+      IvfBuildParams ivfParams =
+          new IvfBuildParams.Builder().setNumPartitions(numPartitions).build();
+
+      // Build index based on index type
+      IndexType lanceIndexType;
+      IndexParams indexParams;
+
+      switch (indexType) {
+        case IVF_PQ:
+          lanceIndexType = IndexType.IVF_PQ;
+          PQBuildParams pqParams =
+              new PQBuildParams.Builder()
+                  .setNumSubVectors(numSubVectors != null ? numSubVectors : 16)
+                  .setNumBits(numBits)
+                  .build();
+          VectorIndexParams ivfPqParams =
+              VectorIndexParams.withIvfPqParams(distanceType, ivfParams, pqParams);
+          indexParams =
+              new IndexParams.Builder()
+                  .setDistanceType(distanceType)
+                  .setVectorIndexParams(ivfPqParams)
+                  .build();
+          break;
+
+        case IVF_HNSW:
+          lanceIndexType = IndexType.IVF_HNSW_PQ;
+          HnswBuildParams hnswParams =
+              new HnswBuildParams.Builder()
+                  .setMaxLevel((short) maxLevel)
+                  .setM(m)
+                  .setEfConstruction(efConstruction)
+                  .build();
+          PQBuildParams hnswPqParams =
+              new PQBuildParams.Builder()
+                  .setNumSubVectors(numSubVectors != null ? numSubVectors : 16)
+                  .setNumBits(numBits)
+                  .build();
+          VectorIndexParams ivfHnswParams =
+              VectorIndexParams.withIvfHnswPqParams(
+                  distanceType, ivfParams, hnswParams, hnswPqParams);
+          indexParams =
+              new IndexParams.Builder()
+                  .setDistanceType(distanceType)
+                  .setVectorIndexParams(ivfHnswParams)
+                  .build();
+          break;
+
+        case IVF_FLAT:
+          lanceIndexType = IndexType.IVF_FLAT;
+          VectorIndexParams ivfFlatParams = VectorIndexParams.ivfFlat(numPartitions, distanceType);
+          indexParams =
+              new IndexParams.Builder()
+                  .setDistanceType(distanceType)
+                  .setVectorIndexParams(ivfFlatParams)
+                  .build();
+          break;
+
+        default:
+          throw new IllegalArgumentException("Unsupported index type: " + indexType);
+      }
+
+      // Create index
+      dataset.createIndex(
+          Collections.singletonList(columnName),
+          lanceIndexType,
+          Optional.empty(), // Index name, use default
+          indexParams,
+          replace);
+
+      long endTime = System.currentTimeMillis();
+      long duration = endTime - startTime;
+
+      LOG.info("Vector index build completed, duration: {} ms", duration);
+
+      return new IndexBuildResult(true, indexType, columnName, datasetPath, duration, null);
+    } catch (Exception e) {
+      LOG.error("Failed to build vector index", e);
+      return new IndexBuildResult(
+          false,
+          indexType,
+          columnName,
+          datasetPath,
+          System.currentTimeMillis() - startTime,
+          e.getMessage());
+    }
+  }
+
+  /** Validate vector column exists */
+  private void validateColumn() throws IOException {
+    // Check if column exists in Schema
+    boolean columnExists =
+        dataset.getSchema().getFields().stream()
+            .anyMatch(field -> field.getName().equals(columnName));
+
+    if (!columnExists) {
+      throw new IOException("Vector column does not exist: " + columnName);
+    }
+  }
+
+  /** Convert distance metric type */
+  private DistanceType toDistanceType(LanceOptions.MetricType metricType) {
+    switch (metricType) {
+      case L2:
+        return DistanceType.L2;
+      case COSINE:
+        return DistanceType.Cosine;
+      case DOT:
+        return DistanceType.Dot;
+      default:
+        return DistanceType.L2;
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (dataset != null) {
+      try {
+        dataset.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close dataset", e);
+      }
+      dataset = null;
+    }
+
+    if (allocator != null) {
+      try {
+        allocator.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close allocator", e);
+      }
+      allocator = null;
+    }
+  }
+
+  /** Create builder */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Create index builder from LanceOptions */
+  public static LanceIndexBuilder fromOptions(LanceOptions options) {
+    return builder()
+        .datasetPath(options.getPath())
+        .columnName(options.getIndexColumn())
+        .indexType(options.getIndexType())
+        .metricType(options.getVectorMetric())
+        .numPartitions(options.getIndexNumPartitions())
+        .numSubVectors(options.getIndexNumSubVectors())
+        .numBits(options.getIndexNumBits())
+        .maxLevel(options.getIndexMaxLevel())
+        .maxEdges(options.getIndexM())
+        .efConstruction(options.getIndexEfConstruction())
+        .build();
+  }
+
+  /** Builder */
+  public static class Builder {
+    private String datasetPath;
+    private String columnName;
+    private LanceOptions.IndexType indexType = LanceOptions.IndexType.IVF_PQ;
+    private LanceOptions.MetricType metricType = LanceOptions.MetricType.L2;
+    private int numPartitions = 256;
+    private Integer numSubVectors;
+    private int numBits = 8;
+    private int maxLevel = 7;
+    private int m = 16;
+    private int efConstruction = 100;
+    private boolean replace = false;
+
+    public Builder datasetPath(String datasetPath) {
+      this.datasetPath = datasetPath;
+      return this;
+    }
+
+    public Builder columnName(String columnName) {
+      this.columnName = columnName;
+      return this;
+    }
+
+    public Builder indexType(LanceOptions.IndexType indexType) {
+      this.indexType = indexType;
+      return this;
+    }
+
+    public Builder metricType(LanceOptions.MetricType metricType) {
+      this.metricType = metricType;
+      return this;
+    }
+
+    public Builder numPartitions(int numPartitions) {
+      this.numPartitions = numPartitions;
+      return this;
+    }
+
+    public Builder numSubVectors(Integer numSubVectors) {
+      this.numSubVectors = numSubVectors;
+      return this;
+    }
+
+    public Builder numBits(int numBits) {
+      this.numBits = numBits;
+      return this;
+    }
+
+    public Builder maxLevel(int maxLevel) {
+      this.maxLevel = maxLevel;
+      return this;
+    }
+
+    public Builder maxEdges(int m) {
+      this.m = m;
+      return this;
+    }
+
+    public Builder efConstruction(int efConstruction) {
+      this.efConstruction = efConstruction;
+      return this;
+    }
+
+    public Builder replace(boolean replace) {
+      this.replace = replace;
+      return this;
+    }
+
+    public LanceIndexBuilder build() {
+      validate();
+      return new LanceIndexBuilder(this);
+    }
+
+    private void validate() {
+      if (datasetPath == null || datasetPath.isEmpty()) {
+        throw new IllegalArgumentException("Dataset path cannot be empty");
+      }
+      if (columnName == null || columnName.isEmpty()) {
+        throw new IllegalArgumentException("Column name cannot be empty");
+      }
+      if (numPartitions <= 0) {
+        throw new IllegalArgumentException("Number of partitions must be greater than 0");
+      }
+      if (numSubVectors != null && numSubVectors <= 0) {
+        throw new IllegalArgumentException("Number of sub-vectors must be greater than 0");
+      }
+      if (numBits <= 0 || numBits > 16) {
+        throw new IllegalArgumentException("Quantization bits must be between 1 and 16");
+      }
+    }
+  }
+
+  /** Index build result */
+  public static class IndexBuildResult implements Serializable {
     private static final long serialVersionUID = 1L;
-    private static final Logger LOG = LoggerFactory.getLogger(LanceIndexBuilder.class);
 
-    private final String datasetPath;
-    private final String columnName;
+    private final boolean success;
     private final LanceOptions.IndexType indexType;
-    private final LanceOptions.MetricType metricType;
-    private final int numPartitions;
-    private final Integer numSubVectors;
-    private final int numBits;
-    private final int maxLevel;
-    private final int m;
-    private final int efConstruction;
-    private final boolean replace;
+    private final String columnName;
+    private final String datasetPath;
+    private final long durationMillis;
+    private final String errorMessage;
 
-    private transient BufferAllocator allocator;
-    private transient Dataset dataset;
-
-    private LanceIndexBuilder(Builder builder) {
-        this.datasetPath = builder.datasetPath;
-        this.columnName = builder.columnName;
-        this.indexType = builder.indexType;
-        this.metricType = builder.metricType;
-        this.numPartitions = builder.numPartitions;
-        this.numSubVectors = builder.numSubVectors;
-        this.numBits = builder.numBits;
-        this.maxLevel = builder.maxLevel;
-        this.m = builder.m;
-        this.efConstruction = builder.efConstruction;
-        this.replace = builder.replace;
+    public IndexBuildResult(
+        boolean success,
+        LanceOptions.IndexType indexType,
+        String columnName,
+        String datasetPath,
+        long durationMillis,
+        String errorMessage) {
+      this.success = success;
+      this.indexType = indexType;
+      this.columnName = columnName;
+      this.datasetPath = datasetPath;
+      this.durationMillis = durationMillis;
+      this.errorMessage = errorMessage;
     }
 
-    /**
-     * Build vector index
-     *
-     * @return Index build result
-     */
-    public IndexBuildResult buildIndex() throws IOException {
-        LOG.info("Starting to build vector index, type: {}, column: {}, dataset: {}",
-                indexType, columnName, datasetPath);
-
-        long startTime = System.currentTimeMillis();
-
-        try {
-            // Initialize resources
-            this.allocator = new RootAllocator(Long.MAX_VALUE);
-            this.dataset = Dataset.open(datasetPath, allocator);
-
-            // Validate column exists
-            validateColumn();
-
-            // Get distance metric type
-            DistanceType distanceType = toDistanceType(metricType);
-
-            // Build IVF parameters
-            IvfBuildParams ivfParams = new IvfBuildParams.Builder()
-                    .setNumPartitions(numPartitions)
-                    .build();
-
-            // Build index based on index type
-            IndexType lanceIndexType;
-            IndexParams indexParams;
-
-            switch (indexType) {
-                case IVF_PQ:
-                    lanceIndexType = IndexType.IVF_PQ;
-                    PQBuildParams pqParams = new PQBuildParams.Builder()
-                            .setNumSubVectors(numSubVectors != null ? numSubVectors : 16)
-                            .setNumBits(numBits)
-                            .build();
-                    VectorIndexParams ivfPqParams = VectorIndexParams.withIvfPqParams(
-                            distanceType, ivfParams, pqParams);
-                    indexParams = new IndexParams.Builder()
-                            .setDistanceType(distanceType)
-                            .setVectorIndexParams(ivfPqParams)
-                            .build();
-                    break;
-
-                case IVF_HNSW:
-                    lanceIndexType = IndexType.IVF_HNSW_PQ;
-                    HnswBuildParams hnswParams = new HnswBuildParams.Builder()
-                            .setMaxLevel((short) maxLevel)
-                            .setM(m)
-                            .setEfConstruction(efConstruction)
-                            .build();
-                    PQBuildParams hnswPqParams = new PQBuildParams.Builder()
-                            .setNumSubVectors(numSubVectors != null ? numSubVectors : 16)
-                            .setNumBits(numBits)
-                            .build();
-                    VectorIndexParams ivfHnswParams = VectorIndexParams.withIvfHnswPqParams(
-                            distanceType, ivfParams, hnswParams, hnswPqParams);
-                    indexParams = new IndexParams.Builder()
-                            .setDistanceType(distanceType)
-                            .setVectorIndexParams(ivfHnswParams)
-                            .build();
-                    break;
-
-                case IVF_FLAT:
-                    lanceIndexType = IndexType.IVF_FLAT;
-                    VectorIndexParams ivfFlatParams = VectorIndexParams.ivfFlat(numPartitions, distanceType);
-                    indexParams = new IndexParams.Builder()
-                            .setDistanceType(distanceType)
-                            .setVectorIndexParams(ivfFlatParams)
-                            .build();
-                    break;
-
-                default:
-                    throw new IllegalArgumentException("Unsupported index type: " + indexType);
-            }
-
-            // Create index
-            dataset.createIndex(
-                    Collections.singletonList(columnName),
-                    lanceIndexType,
-                    Optional.empty(),  // Index name, use default
-                    indexParams,
-                    replace
-            );
-
-            long endTime = System.currentTimeMillis();
-            long duration = endTime - startTime;
-
-            LOG.info("Vector index build completed, duration: {} ms", duration);
-
-            return new IndexBuildResult(
-                    true,
-                    indexType,
-                    columnName,
-                    datasetPath,
-                    duration,
-                    null
-            );
-        } catch (Exception e) {
-            LOG.error("Failed to build vector index", e);
-            return new IndexBuildResult(
-                    false,
-                    indexType,
-                    columnName,
-                    datasetPath,
-                    System.currentTimeMillis() - startTime,
-                    e.getMessage()
-            );
-        }
+    public boolean isSuccess() {
+      return success;
     }
 
-    /**
-     * Validate vector column exists
-     */
-    private void validateColumn() throws IOException {
-        // Check if column exists in Schema
-        boolean columnExists = dataset.getSchema().getFields().stream()
-                .anyMatch(field -> field.getName().equals(columnName));
-
-        if (!columnExists) {
-            throw new IOException("Vector column does not exist: " + columnName);
-        }
+    public LanceOptions.IndexType getIndexType() {
+      return indexType;
     }
 
-    /**
-     * Convert distance metric type
-     */
-    private DistanceType toDistanceType(LanceOptions.MetricType metricType) {
-        switch (metricType) {
-            case L2:
-                return DistanceType.L2;
-            case COSINE:
-                return DistanceType.Cosine;
-            case DOT:
-                return DistanceType.Dot;
-            default:
-                return DistanceType.L2;
-        }
+    public String getColumnName() {
+      return columnName;
+    }
+
+    public String getDatasetPath() {
+      return datasetPath;
+    }
+
+    public long getDurationMillis() {
+      return durationMillis;
+    }
+
+    public String getErrorMessage() {
+      return errorMessage;
     }
 
     @Override
-    public void close() throws IOException {
-        if (dataset != null) {
-            try {
-                dataset.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close dataset", e);
-            }
-            dataset = null;
-        }
-
-        if (allocator != null) {
-            try {
-                allocator.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close allocator", e);
-            }
-            allocator = null;
-        }
+    public String toString() {
+      return "IndexBuildResult{"
+          + "success="
+          + success
+          + ", indexType="
+          + indexType
+          + ", columnName='"
+          + columnName
+          + '\''
+          + ", datasetPath='"
+          + datasetPath
+          + '\''
+          + ", durationMillis="
+          + durationMillis
+          + ", errorMessage='"
+          + errorMessage
+          + '\''
+          + '}';
     }
-
-    /**
-     * Create builder
-     */
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    /**
-     * Create index builder from LanceOptions
-     */
-    public static LanceIndexBuilder fromOptions(LanceOptions options) {
-        return builder()
-                .datasetPath(options.getPath())
-                .columnName(options.getIndexColumn())
-                .indexType(options.getIndexType())
-                .metricType(options.getVectorMetric())
-                .numPartitions(options.getIndexNumPartitions())
-                .numSubVectors(options.getIndexNumSubVectors())
-                .numBits(options.getIndexNumBits())
-                .maxLevel(options.getIndexMaxLevel())
-                .maxEdges(options.getIndexM())
-                .efConstruction(options.getIndexEfConstruction())
-                .build();
-    }
-
-    /**
-     * Builder
-     */
-    public static class Builder {
-        private String datasetPath;
-        private String columnName;
-        private LanceOptions.IndexType indexType = LanceOptions.IndexType.IVF_PQ;
-        private LanceOptions.MetricType metricType = LanceOptions.MetricType.L2;
-        private int numPartitions = 256;
-        private Integer numSubVectors;
-        private int numBits = 8;
-        private int maxLevel = 7;
-        private int m = 16;
-        private int efConstruction = 100;
-        private boolean replace = false;
-
-        public Builder datasetPath(String datasetPath) {
-            this.datasetPath = datasetPath;
-            return this;
-        }
-
-        public Builder columnName(String columnName) {
-            this.columnName = columnName;
-            return this;
-        }
-
-        public Builder indexType(LanceOptions.IndexType indexType) {
-            this.indexType = indexType;
-            return this;
-        }
-
-        public Builder metricType(LanceOptions.MetricType metricType) {
-            this.metricType = metricType;
-            return this;
-        }
-
-        public Builder numPartitions(int numPartitions) {
-            this.numPartitions = numPartitions;
-            return this;
-        }
-
-        public Builder numSubVectors(Integer numSubVectors) {
-            this.numSubVectors = numSubVectors;
-            return this;
-        }
-
-        public Builder numBits(int numBits) {
-            this.numBits = numBits;
-            return this;
-        }
-
-        public Builder maxLevel(int maxLevel) {
-            this.maxLevel = maxLevel;
-            return this;
-        }
-
-        public Builder maxEdges(int m) {
-            this.m = m;
-            return this;
-        }
-
-        public Builder efConstruction(int efConstruction) {
-            this.efConstruction = efConstruction;
-            return this;
-        }
-
-        public Builder replace(boolean replace) {
-            this.replace = replace;
-            return this;
-        }
-
-        public LanceIndexBuilder build() {
-            validate();
-            return new LanceIndexBuilder(this);
-        }
-
-        private void validate() {
-            if (datasetPath == null || datasetPath.isEmpty()) {
-                throw new IllegalArgumentException("Dataset path cannot be empty");
-            }
-            if (columnName == null || columnName.isEmpty()) {
-                throw new IllegalArgumentException("Column name cannot be empty");
-            }
-            if (numPartitions <= 0) {
-                throw new IllegalArgumentException("Number of partitions must be greater than 0");
-            }
-            if (numSubVectors != null && numSubVectors <= 0) {
-                throw new IllegalArgumentException("Number of sub-vectors must be greater than 0");
-            }
-            if (numBits <= 0 || numBits > 16) {
-                throw new IllegalArgumentException("Quantization bits must be between 1 and 16");
-            }
-        }
-    }
-
-    /**
-     * Index build result
-     */
-    public static class IndexBuildResult implements Serializable {
-        private static final long serialVersionUID = 1L;
-
-        private final boolean success;
-        private final LanceOptions.IndexType indexType;
-        private final String columnName;
-        private final String datasetPath;
-        private final long durationMillis;
-        private final String errorMessage;
-
-        public IndexBuildResult(boolean success, LanceOptions.IndexType indexType, String columnName,
-                                String datasetPath, long durationMillis, String errorMessage) {
-            this.success = success;
-            this.indexType = indexType;
-            this.columnName = columnName;
-            this.datasetPath = datasetPath;
-            this.durationMillis = durationMillis;
-            this.errorMessage = errorMessage;
-        }
-
-        public boolean isSuccess() {
-            return success;
-        }
-
-        public LanceOptions.IndexType getIndexType() {
-            return indexType;
-        }
-
-        public String getColumnName() {
-            return columnName;
-        }
-
-        public String getDatasetPath() {
-            return datasetPath;
-        }
-
-        public long getDurationMillis() {
-            return durationMillis;
-        }
-
-        public String getErrorMessage() {
-            return errorMessage;
-        }
-
-        @Override
-        public String toString() {
-            return "IndexBuildResult{" +
-                    "success=" + success +
-                    ", indexType=" + indexType +
-                    ", columnName='" + columnName + '\'' +
-                    ", datasetPath='" + datasetPath + '\'' +
-                    ", durationMillis=" + durationMillis +
-                    ", errorMessage='" + errorMessage + '\'' +
-                    '}';
-        }
-    }
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/LanceIndexBuilder.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceIndexBuilder.java
@@ -41,9 +41,9 @@ import java.util.Optional;
 
 /**
  * Lance vector index builder.
- * 
+ *
  * <p>Supports building IVF_PQ, IVF_HNSW_PQ, and IVF_FLAT vector indices.
- * 
+ *
  * <p>Usage example:
  * <pre>{@code
  * LanceIndexBuilder builder = LanceIndexBuilder.builder()
@@ -53,7 +53,7 @@ import java.util.Optional;
  *     .numPartitions(256)
  *     .numSubVectors(16)
  *     .build();
- * 
+ *
  * IndexBuildResult result = builder.buildIndex();
  * }</pre>
  */
@@ -97,31 +97,31 @@ public class LanceIndexBuilder implements Closeable, Serializable {
      * @return Index build result
      */
     public IndexBuildResult buildIndex() throws IOException {
-        LOG.info("Starting to build vector index, type: {}, column: {}, dataset: {}", 
+        LOG.info("Starting to build vector index, type: {}, column: {}, dataset: {}",
                 indexType, columnName, datasetPath);
-        
+
         long startTime = System.currentTimeMillis();
-        
+
         try {
             // Initialize resources
             this.allocator = new RootAllocator(Long.MAX_VALUE);
             this.dataset = Dataset.open(datasetPath, allocator);
-            
+
             // Validate column exists
             validateColumn();
-            
+
             // Get distance metric type
             DistanceType distanceType = toDistanceType(metricType);
-            
+
             // Build IVF parameters
             IvfBuildParams ivfParams = new IvfBuildParams.Builder()
                     .setNumPartitions(numPartitions)
                     .build();
-            
+
             // Build index based on index type
             IndexType lanceIndexType;
             IndexParams indexParams;
-            
+
             switch (indexType) {
                 case IVF_PQ:
                     lanceIndexType = IndexType.IVF_PQ;
@@ -136,7 +136,7 @@ public class LanceIndexBuilder implements Closeable, Serializable {
                             .setVectorIndexParams(ivfPqParams)
                             .build();
                     break;
-                    
+
                 case IVF_HNSW:
                     lanceIndexType = IndexType.IVF_HNSW_PQ;
                     HnswBuildParams hnswParams = new HnswBuildParams.Builder()
@@ -155,7 +155,7 @@ public class LanceIndexBuilder implements Closeable, Serializable {
                             .setVectorIndexParams(ivfHnswParams)
                             .build();
                     break;
-                    
+
                 case IVF_FLAT:
                     lanceIndexType = IndexType.IVF_FLAT;
                     VectorIndexParams ivfFlatParams = VectorIndexParams.ivfFlat(numPartitions, distanceType);
@@ -164,11 +164,11 @@ public class LanceIndexBuilder implements Closeable, Serializable {
                             .setVectorIndexParams(ivfFlatParams)
                             .build();
                     break;
-                    
+
                 default:
                     throw new IllegalArgumentException("Unsupported index type: " + indexType);
             }
-            
+
             // Create index
             dataset.createIndex(
                     Collections.singletonList(columnName),
@@ -177,12 +177,12 @@ public class LanceIndexBuilder implements Closeable, Serializable {
                     indexParams,
                     replace
             );
-            
+
             long endTime = System.currentTimeMillis();
             long duration = endTime - startTime;
-            
+
             LOG.info("Vector index build completed, duration: {} ms", duration);
-            
+
             return new IndexBuildResult(
                     true,
                     indexType,
@@ -211,7 +211,7 @@ public class LanceIndexBuilder implements Closeable, Serializable {
         // Check if column exists in Schema
         boolean columnExists = dataset.getSchema().getFields().stream()
                 .anyMatch(field -> field.getName().equals(columnName));
-        
+
         if (!columnExists) {
             throw new IOException("Vector column does not exist: " + columnName);
         }
@@ -243,7 +243,7 @@ public class LanceIndexBuilder implements Closeable, Serializable {
             }
             dataset = null;
         }
-        
+
         if (allocator != null) {
             try {
                 allocator.close();
@@ -274,7 +274,7 @@ public class LanceIndexBuilder implements Closeable, Serializable {
                 .numSubVectors(options.getIndexNumSubVectors())
                 .numBits(options.getIndexNumBits())
                 .maxLevel(options.getIndexMaxLevel())
-                .m(options.getIndexM())
+                .maxEdges(options.getIndexM())
                 .efConstruction(options.getIndexEfConstruction())
                 .build();
     }
@@ -335,7 +335,7 @@ public class LanceIndexBuilder implements Closeable, Serializable {
             return this;
         }
 
-        public Builder m(int m) {
+        public Builder maxEdges(int m) {
             this.m = m;
             return this;
         }

--- a/src/main/java/org/apache/flink/connector/lance/LanceInputFormat.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceInputFormat.java
@@ -41,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -49,7 +48,7 @@ import java.util.List;
 
 /**
  * Lance InputFormat implementation.
- * 
+ *
  * <p>Reads data from Lance dataset using InputFormat interface, supports parallel reading with splits.
  */
 public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
@@ -78,10 +77,10 @@ public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
     public LanceInputFormat(LanceOptions options, RowType rowType) {
         this.options = options;
         this.rowType = rowType;
-        
+
         List<String> columns = options.getReadColumns();
-        this.selectedColumns = columns != null && !columns.isEmpty() 
-                ? columns.toArray(new String[0]) 
+        this.selectedColumns = columns != null && !columns.isEmpty()
+                ? columns.toArray(new String[0])
                 : null;
     }
 
@@ -99,7 +98,7 @@ public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
     @Override
     public LanceSplit[] createInputSplits(int minNumSplits) throws IOException {
         LOG.info("Creating input splits, minimum split count: {}", minNumSplits);
-        
+
         String datasetPath = options.getPath();
         if (datasetPath == null || datasetPath.isEmpty()) {
             throw new IOException("Dataset path cannot be empty");
@@ -111,13 +110,13 @@ public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
             try {
                 List<Fragment> fragments = tempDataset.getFragments();
                 LanceSplit[] splits = new LanceSplit[fragments.size()];
-                
+
                 for (int i = 0; i < fragments.size(); i++) {
                     Fragment fragment = fragments.get(i);
                     long rowCount = fragment.countRows();
                     splits[i] = new LanceSplit(i, fragment.getId(), datasetPath, rowCount);
                 }
-                
+
                 LOG.info("Created {} input splits", splits.length);
                 return splits;
             } finally {
@@ -136,10 +135,10 @@ public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
     @Override
     public void open(LanceSplit split) throws IOException {
         LOG.info("Opening split: {}", split);
-        
+
         this.allocator = new RootAllocator(Long.MAX_VALUE);
         this.reachedEnd = false;
-        
+
         // Open dataset
         String datasetPath = split.getDatasetPath();
         try {
@@ -147,7 +146,7 @@ public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
         } catch (Exception e) {
             throw new IOException("Cannot open dataset: " + datasetPath, e);
         }
-        
+
         // Initialize converter
         RowType actualRowType = this.rowType;
         if (actualRowType == null) {
@@ -155,7 +154,7 @@ public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
             actualRowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
         }
         this.converter = new RowDataConverter(actualRowType);
-        
+
         // Get specified Fragment
         List<Fragment> fragments = dataset.getFragments();
         Fragment targetFragment = null;
@@ -165,26 +164,26 @@ public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
                 break;
             }
         }
-        
+
         if (targetFragment == null) {
             throw new IOException("Cannot find Fragment: " + split.getFragmentId());
         }
-        
+
         // Build scan options
         ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder();
         scanOptionsBuilder.batchSize(options.getReadBatchSize());
-        
+
         if (selectedColumns != null && selectedColumns.length > 0) {
             scanOptionsBuilder.columns(Arrays.asList(selectedColumns));
         }
-        
+
         String filter = options.getReadFilter();
         if (filter != null && !filter.isEmpty()) {
             scanOptionsBuilder.filter(filter);
         }
-        
+
         ScanOptions scanOptions = scanOptionsBuilder.build();
-        
+
         // Create Scanner
         try {
             this.currentScanner = targetFragment.newScan(scanOptions);
@@ -192,7 +191,7 @@ public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
         } catch (Exception e) {
             throw new IOException("Failed to create Scanner", e);
         }
-        
+
         // Load first batch of data
         loadNextBatch();
     }
@@ -225,30 +224,30 @@ public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
         if (reachedEnd) {
             return null;
         }
-        
+
         // Current batch still has data
         if (currentBatchIterator != null && currentBatchIterator.hasNext()) {
             return currentBatchIterator.next();
         }
-        
+
         // Load next batch
         loadNextBatch();
-        
+
         if (reachedEnd) {
             return null;
         }
-        
+
         if (currentBatchIterator != null && currentBatchIterator.hasNext()) {
             return currentBatchIterator.next();
         }
-        
+
         return null;
     }
 
     @Override
     public void close() throws IOException {
         LOG.info("Closing LanceInputFormat");
-        
+
         if (currentReader != null) {
             try {
                 currentReader.close();
@@ -257,7 +256,7 @@ public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
             }
             currentReader = null;
         }
-        
+
         if (currentScanner != null) {
             try {
                 currentScanner.close();
@@ -266,7 +265,7 @@ public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
             }
             currentScanner = null;
         }
-        
+
         if (dataset != null) {
             try {
                 dataset.close();
@@ -275,7 +274,7 @@ public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
             }
             dataset = null;
         }
-        
+
         if (allocator != null) {
             try {
                 allocator.close();
@@ -306,7 +305,7 @@ public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
     private static class LanceSplitAssigner implements InputSplitAssigner {
         private final List<LanceSplit> remainingSplits;
 
-        public LanceSplitAssigner(LanceSplit[] splits) {
+        LanceSplitAssigner(LanceSplit[] splits) {
             this.remainingSplits = new ArrayList<>();
             for (LanceSplit split : splits) {
                 remainingSplits.add(split);

--- a/src/main/java/org/apache/flink/connector/lance/LanceInputFormat.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceInputFormat.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,18 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance;
-
-import org.apache.flink.api.common.io.RichInputFormat;
-import org.apache.flink.api.common.io.statistics.BaseStatistics;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.connector.lance.config.LanceOptions;
-import org.apache.flink.connector.lance.converter.LanceTypeConverter;
-import org.apache.flink.connector.lance.converter.RowDataConverter;
-import org.apache.flink.core.io.InputSplitAssigner;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.logical.RowType;
 
 import com.lancedb.lance.Dataset;
 import com.lancedb.lance.Fragment;
@@ -37,6 +22,15 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.flink.api.common.io.RichInputFormat;
+import org.apache.flink.api.common.io.statistics.BaseStatistics;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.lance.config.LanceOptions;
+import org.apache.flink.connector.lance.converter.LanceTypeConverter;
+import org.apache.flink.connector.lance.converter.RowDataConverter;
+import org.apache.flink.core.io.InputSplitAssigner;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,286 +43,278 @@ import java.util.List;
 /**
  * Lance InputFormat implementation.
  *
- * <p>Reads data from Lance dataset using InputFormat interface, supports parallel reading with splits.
+ * <p>Reads data from Lance dataset using InputFormat interface, supports parallel reading with
+ * splits.
  */
 public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
 
-    private static final long serialVersionUID = 1L;
-    private static final Logger LOG = LoggerFactory.getLogger(LanceInputFormat.class);
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(LanceInputFormat.class);
 
-    private final LanceOptions options;
-    private final RowType rowType;
-    private final String[] selectedColumns;
+  private final LanceOptions options;
+  private final RowType rowType;
+  private final String[] selectedColumns;
 
-    private transient BufferAllocator allocator;
-    private transient Dataset dataset;
-    private transient RowDataConverter converter;
-    private transient LanceScanner currentScanner;
-    private transient ArrowReader currentReader;
-    private transient Iterator<RowData> currentBatchIterator;
-    private transient boolean reachedEnd;
+  private transient BufferAllocator allocator;
+  private transient Dataset dataset;
+  private transient RowDataConverter converter;
+  private transient LanceScanner currentScanner;
+  private transient ArrowReader currentReader;
+  private transient Iterator<RowData> currentBatchIterator;
+  private transient boolean reachedEnd;
 
-    /**
-     * Create LanceInputFormat
-     *
-     * @param options Lance configuration options
-     * @param rowType Flink RowType
-     */
-    public LanceInputFormat(LanceOptions options, RowType rowType) {
-        this.options = options;
-        this.rowType = rowType;
+  /**
+   * Create LanceInputFormat
+   *
+   * @param options Lance configuration options
+   * @param rowType Flink RowType
+   */
+  public LanceInputFormat(LanceOptions options, RowType rowType) {
+    this.options = options;
+    this.rowType = rowType;
 
-        List<String> columns = options.getReadColumns();
-        this.selectedColumns = columns != null && !columns.isEmpty()
-                ? columns.toArray(new String[0])
-                : null;
+    List<String> columns = options.getReadColumns();
+    this.selectedColumns =
+        columns != null && !columns.isEmpty() ? columns.toArray(new String[0]) : null;
+  }
+
+  @Override
+  public void configure(Configuration parameters) {
+    // Configuration already done in constructor
+  }
+
+  @Override
+  public BaseStatistics getStatistics(BaseStatistics cachedStatistics) throws IOException {
+    // Return basic statistics
+    return cachedStatistics;
+  }
+
+  @Override
+  public LanceSplit[] createInputSplits(int minNumSplits) throws IOException {
+    LOG.info("Creating input splits, minimum split count: {}", minNumSplits);
+
+    String datasetPath = options.getPath();
+    if (datasetPath == null || datasetPath.isEmpty()) {
+      throw new IOException("Dataset path cannot be empty");
+    }
+
+    BufferAllocator tempAllocator = new RootAllocator(Long.MAX_VALUE);
+    try {
+      Dataset tempDataset = Dataset.open(datasetPath, tempAllocator);
+      try {
+        List<Fragment> fragments = tempDataset.getFragments();
+        LanceSplit[] splits = new LanceSplit[fragments.size()];
+
+        for (int i = 0; i < fragments.size(); i++) {
+          Fragment fragment = fragments.get(i);
+          long rowCount = fragment.countRows();
+          splits[i] = new LanceSplit(i, fragment.getId(), datasetPath, rowCount);
+        }
+
+        LOG.info("Created {} input splits", splits.length);
+        return splits;
+      } finally {
+        tempDataset.close();
+      }
+    } finally {
+      tempAllocator.close();
+    }
+  }
+
+  @Override
+  public InputSplitAssigner getInputSplitAssigner(LanceSplit[] inputSplits) {
+    return new LanceSplitAssigner(inputSplits);
+  }
+
+  @Override
+  public void open(LanceSplit split) throws IOException {
+    LOG.info("Opening split: {}", split);
+
+    this.allocator = new RootAllocator(Long.MAX_VALUE);
+    this.reachedEnd = false;
+
+    // Open dataset
+    String datasetPath = split.getDatasetPath();
+    try {
+      this.dataset = Dataset.open(datasetPath, allocator);
+    } catch (Exception e) {
+      throw new IOException("Cannot open dataset: " + datasetPath, e);
+    }
+
+    // Initialize converter
+    RowType actualRowType = this.rowType;
+    if (actualRowType == null) {
+      Schema arrowSchema = dataset.getSchema();
+      actualRowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
+    }
+    this.converter = new RowDataConverter(actualRowType);
+
+    // Get specified Fragment
+    List<Fragment> fragments = dataset.getFragments();
+    Fragment targetFragment = null;
+    for (Fragment fragment : fragments) {
+      if (fragment.getId() == split.getFragmentId()) {
+        targetFragment = fragment;
+        break;
+      }
+    }
+
+    if (targetFragment == null) {
+      throw new IOException("Cannot find Fragment: " + split.getFragmentId());
+    }
+
+    // Build scan options
+    ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder();
+    scanOptionsBuilder.batchSize(options.getReadBatchSize());
+
+    if (selectedColumns != null && selectedColumns.length > 0) {
+      scanOptionsBuilder.columns(Arrays.asList(selectedColumns));
+    }
+
+    String filter = options.getReadFilter();
+    if (filter != null && !filter.isEmpty()) {
+      scanOptionsBuilder.filter(filter);
+    }
+
+    ScanOptions scanOptions = scanOptionsBuilder.build();
+
+    // Create Scanner
+    try {
+      this.currentScanner = targetFragment.newScan(scanOptions);
+      this.currentReader = currentScanner.scanBatches();
+    } catch (Exception e) {
+      throw new IOException("Failed to create Scanner", e);
+    }
+
+    // Load first batch of data
+    loadNextBatch();
+  }
+
+  /** Load next batch of data */
+  private void loadNextBatch() throws IOException {
+    try {
+      if (currentReader.loadNextBatch()) {
+        VectorSchemaRoot root = currentReader.getVectorSchemaRoot();
+        List<RowData> rows = converter.toRowDataList(root);
+        this.currentBatchIterator = rows.iterator();
+      } else {
+        this.reachedEnd = true;
+        this.currentBatchIterator = null;
+      }
+    } catch (Exception e) {
+      throw new IOException("Failed to load data batch", e);
+    }
+  }
+
+  @Override
+  public boolean reachedEnd() throws IOException {
+    return reachedEnd;
+  }
+
+  @Override
+  public RowData nextRecord(RowData reuse) throws IOException {
+    if (reachedEnd) {
+      return null;
+    }
+
+    // Current batch still has data
+    if (currentBatchIterator != null && currentBatchIterator.hasNext()) {
+      return currentBatchIterator.next();
+    }
+
+    // Load next batch
+    loadNextBatch();
+
+    if (reachedEnd) {
+      return null;
+    }
+
+    if (currentBatchIterator != null && currentBatchIterator.hasNext()) {
+      return currentBatchIterator.next();
+    }
+
+    return null;
+  }
+
+  @Override
+  public void close() throws IOException {
+    LOG.info("Closing LanceInputFormat");
+
+    if (currentReader != null) {
+      try {
+        currentReader.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close Reader", e);
+      }
+      currentReader = null;
+    }
+
+    if (currentScanner != null) {
+      try {
+        currentScanner.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close Scanner", e);
+      }
+      currentScanner = null;
+    }
+
+    if (dataset != null) {
+      try {
+        dataset.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close dataset", e);
+      }
+      dataset = null;
+    }
+
+    if (allocator != null) {
+      try {
+        allocator.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close allocator", e);
+      }
+      allocator = null;
+    }
+  }
+
+  /** Get RowType */
+  public RowType getRowType() {
+    return rowType;
+  }
+
+  /** Get configuration options */
+  public LanceOptions getOptions() {
+    return options;
+  }
+
+  /** Lance split assigner */
+  private static class LanceSplitAssigner implements InputSplitAssigner {
+    private final List<LanceSplit> remainingSplits;
+
+    LanceSplitAssigner(LanceSplit[] splits) {
+      this.remainingSplits = new ArrayList<>();
+      for (LanceSplit split : splits) {
+        remainingSplits.add(split);
+      }
     }
 
     @Override
-    public void configure(Configuration parameters) {
-        // Configuration already done in constructor
-    }
-
-    @Override
-    public BaseStatistics getStatistics(BaseStatistics cachedStatistics) throws IOException {
-        // Return basic statistics
-        return cachedStatistics;
-    }
-
-    @Override
-    public LanceSplit[] createInputSplits(int minNumSplits) throws IOException {
-        LOG.info("Creating input splits, minimum split count: {}", minNumSplits);
-
-        String datasetPath = options.getPath();
-        if (datasetPath == null || datasetPath.isEmpty()) {
-            throw new IOException("Dataset path cannot be empty");
-        }
-
-        BufferAllocator tempAllocator = new RootAllocator(Long.MAX_VALUE);
-        try {
-            Dataset tempDataset = Dataset.open(datasetPath, tempAllocator);
-            try {
-                List<Fragment> fragments = tempDataset.getFragments();
-                LanceSplit[] splits = new LanceSplit[fragments.size()];
-
-                for (int i = 0; i < fragments.size(); i++) {
-                    Fragment fragment = fragments.get(i);
-                    long rowCount = fragment.countRows();
-                    splits[i] = new LanceSplit(i, fragment.getId(), datasetPath, rowCount);
-                }
-
-                LOG.info("Created {} input splits", splits.length);
-                return splits;
-            } finally {
-                tempDataset.close();
-            }
-        } finally {
-            tempAllocator.close();
-        }
-    }
-
-    @Override
-    public InputSplitAssigner getInputSplitAssigner(LanceSplit[] inputSplits) {
-        return new LanceSplitAssigner(inputSplits);
-    }
-
-    @Override
-    public void open(LanceSplit split) throws IOException {
-        LOG.info("Opening split: {}", split);
-
-        this.allocator = new RootAllocator(Long.MAX_VALUE);
-        this.reachedEnd = false;
-
-        // Open dataset
-        String datasetPath = split.getDatasetPath();
-        try {
-            this.dataset = Dataset.open(datasetPath, allocator);
-        } catch (Exception e) {
-            throw new IOException("Cannot open dataset: " + datasetPath, e);
-        }
-
-        // Initialize converter
-        RowType actualRowType = this.rowType;
-        if (actualRowType == null) {
-            Schema arrowSchema = dataset.getSchema();
-            actualRowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
-        }
-        this.converter = new RowDataConverter(actualRowType);
-
-        // Get specified Fragment
-        List<Fragment> fragments = dataset.getFragments();
-        Fragment targetFragment = null;
-        for (Fragment fragment : fragments) {
-            if (fragment.getId() == split.getFragmentId()) {
-                targetFragment = fragment;
-                break;
-            }
-        }
-
-        if (targetFragment == null) {
-            throw new IOException("Cannot find Fragment: " + split.getFragmentId());
-        }
-
-        // Build scan options
-        ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder();
-        scanOptionsBuilder.batchSize(options.getReadBatchSize());
-
-        if (selectedColumns != null && selectedColumns.length > 0) {
-            scanOptionsBuilder.columns(Arrays.asList(selectedColumns));
-        }
-
-        String filter = options.getReadFilter();
-        if (filter != null && !filter.isEmpty()) {
-            scanOptionsBuilder.filter(filter);
-        }
-
-        ScanOptions scanOptions = scanOptionsBuilder.build();
-
-        // Create Scanner
-        try {
-            this.currentScanner = targetFragment.newScan(scanOptions);
-            this.currentReader = currentScanner.scanBatches();
-        } catch (Exception e) {
-            throw new IOException("Failed to create Scanner", e);
-        }
-
-        // Load first batch of data
-        loadNextBatch();
-    }
-
-    /**
-     * Load next batch of data
-     */
-    private void loadNextBatch() throws IOException {
-        try {
-            if (currentReader.loadNextBatch()) {
-                VectorSchemaRoot root = currentReader.getVectorSchemaRoot();
-                List<RowData> rows = converter.toRowDataList(root);
-                this.currentBatchIterator = rows.iterator();
-            } else {
-                this.reachedEnd = true;
-                this.currentBatchIterator = null;
-            }
-        } catch (Exception e) {
-            throw new IOException("Failed to load data batch", e);
-        }
-    }
-
-    @Override
-    public boolean reachedEnd() throws IOException {
-        return reachedEnd;
-    }
-
-    @Override
-    public RowData nextRecord(RowData reuse) throws IOException {
-        if (reachedEnd) {
-            return null;
-        }
-
-        // Current batch still has data
-        if (currentBatchIterator != null && currentBatchIterator.hasNext()) {
-            return currentBatchIterator.next();
-        }
-
-        // Load next batch
-        loadNextBatch();
-
-        if (reachedEnd) {
-            return null;
-        }
-
-        if (currentBatchIterator != null && currentBatchIterator.hasNext()) {
-            return currentBatchIterator.next();
-        }
-
+    public synchronized LanceSplit getNextInputSplit(String host, int taskId) {
+      if (remainingSplits.isEmpty()) {
         return null;
+      }
+      return remainingSplits.remove(remainingSplits.size() - 1);
     }
 
     @Override
-    public void close() throws IOException {
-        LOG.info("Closing LanceInputFormat");
-
-        if (currentReader != null) {
-            try {
-                currentReader.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close Reader", e);
-            }
-            currentReader = null;
+    public void returnInputSplit(List<org.apache.flink.core.io.InputSplit> splits, int taskId) {
+      for (org.apache.flink.core.io.InputSplit split : splits) {
+        if (split instanceof LanceSplit) {
+          synchronized (this) {
+            remainingSplits.add((LanceSplit) split);
+          }
         }
-
-        if (currentScanner != null) {
-            try {
-                currentScanner.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close Scanner", e);
-            }
-            currentScanner = null;
-        }
-
-        if (dataset != null) {
-            try {
-                dataset.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close dataset", e);
-            }
-            dataset = null;
-        }
-
-        if (allocator != null) {
-            try {
-                allocator.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close allocator", e);
-            }
-            allocator = null;
-        }
+      }
     }
-
-    /**
-     * Get RowType
-     */
-    public RowType getRowType() {
-        return rowType;
-    }
-
-    /**
-     * Get configuration options
-     */
-    public LanceOptions getOptions() {
-        return options;
-    }
-
-    /**
-     * Lance split assigner
-     */
-    private static class LanceSplitAssigner implements InputSplitAssigner {
-        private final List<LanceSplit> remainingSplits;
-
-        LanceSplitAssigner(LanceSplit[] splits) {
-            this.remainingSplits = new ArrayList<>();
-            for (LanceSplit split : splits) {
-                remainingSplits.add(split);
-            }
-        }
-
-        @Override
-        public synchronized LanceSplit getNextInputSplit(String host, int taskId) {
-            if (remainingSplits.isEmpty()) {
-                return null;
-            }
-            return remainingSplits.remove(remainingSplits.size() - 1);
-        }
-
-        @Override
-        public void returnInputSplit(List<org.apache.flink.core.io.InputSplit> splits, int taskId) {
-            for (org.apache.flink.core.io.InputSplit split : splits) {
-                if (split instanceof LanceSplit) {
-                    synchronized (this) {
-                        remainingSplits.add((LanceSplit) split);
-                    }
-                }
-            }
-        }
-    }
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/LanceInputFormat.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceInputFormat.java
@@ -25,6 +25,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.flink.api.common.io.RichInputFormat;
 import org.apache.flink.api.common.io.statistics.BaseStatistics;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.lance.config.LanceDatasetFactory;
 import org.apache.flink.connector.lance.config.LanceOptions;
 import org.apache.flink.connector.lance.converter.LanceTypeConverter;
 import org.apache.flink.connector.lance.converter.RowDataConverter;
@@ -98,26 +99,18 @@ public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
       throw new IOException("Dataset path cannot be empty");
     }
 
-    BufferAllocator tempAllocator = new RootAllocator(Long.MAX_VALUE);
-    try {
-      Dataset tempDataset = Dataset.open(datasetPath, tempAllocator);
-      try {
-        List<Fragment> fragments = tempDataset.getFragments();
-        LanceSplit[] splits = new LanceSplit[fragments.size()];
+    try (LanceDatasetFactory.ManagedDataset md = LanceDatasetFactory.openManaged(datasetPath)) {
+      List<Fragment> fragments = md.getDataset().getFragments();
+      LanceSplit[] splits = new LanceSplit[fragments.size()];
 
-        for (int i = 0; i < fragments.size(); i++) {
-          Fragment fragment = fragments.get(i);
-          long rowCount = fragment.countRows();
-          splits[i] = new LanceSplit(i, fragment.getId(), datasetPath, rowCount);
-        }
-
-        LOG.info("Created {} input splits", splits.length);
-        return splits;
-      } finally {
-        tempDataset.close();
+      for (int i = 0; i < fragments.size(); i++) {
+        Fragment fragment = fragments.get(i);
+        long rowCount = fragment.countRows();
+        splits[i] = new LanceSplit(i, fragment.getId(), datasetPath, rowCount);
       }
-    } finally {
-      tempAllocator.close();
+
+      LOG.info("Created {} input splits", splits.length);
+      return splits;
     }
   }
 
@@ -134,12 +127,7 @@ public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
     this.reachedEnd = false;
 
     // Open dataset
-    String datasetPath = split.getDatasetPath();
-    try {
-      this.dataset = Dataset.open(datasetPath, allocator);
-    } catch (Exception e) {
-      throw new IOException("Cannot open dataset: " + datasetPath, e);
-    }
+    this.dataset = LanceDatasetFactory.open(split.getDatasetPath(), allocator);
 
     // Initialize converter
     RowType actualRowType = this.rowType;

--- a/src/main/java/org/apache/flink/connector/lance/LanceSink.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceSink.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,19 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance;
-
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.connector.lance.config.LanceOptions;
-import org.apache.flink.connector.lance.converter.LanceTypeConverter;
-import org.apache.flink.connector.lance.converter.RowDataConverter;
-import org.apache.flink.runtime.state.FunctionInitializationContext;
-import org.apache.flink.runtime.state.FunctionSnapshotContext;
-import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
-import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.logical.RowType;
 
 import com.lancedb.lance.Dataset;
 import com.lancedb.lance.Fragment;
@@ -38,6 +22,16 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.lance.config.LanceOptions;
+import org.apache.flink.connector.lance.converter.LanceTypeConverter;
+import org.apache.flink.connector.lance.converter.RowDataConverter;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +50,7 @@ import java.util.Optional;
  * <p>Writes Flink RowData to Lance dataset, supports batch writing and Checkpoint.
  *
  * <p>Usage example:
+ *
  * <pre>{@code
  * LanceOptions options = LanceOptions.builder()
  *     .path("/path/to/lance/dataset")
@@ -69,289 +64,274 @@ import java.util.Optional;
  */
 public class LanceSink extends RichSinkFunction<RowData> implements CheckpointedFunction {
 
-    private static final long serialVersionUID = 1L;
-    private static final Logger LOG = LoggerFactory.getLogger(LanceSink.class);
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(LanceSink.class);
 
-    private final LanceOptions options;
-    private final RowType rowType;
+  private final LanceOptions options;
+  private final RowType rowType;
 
-    private transient BufferAllocator allocator;
-    private transient Dataset dataset;
-    private transient RowDataConverter converter;
-    private transient Schema arrowSchema;
-    private transient List<RowData> buffer;
-    private transient long totalWrittenRows;
-    private transient boolean datasetExists;
-    private transient boolean isFirstWrite;
+  private transient BufferAllocator allocator;
+  private transient Dataset dataset;
+  private transient RowDataConverter converter;
+  private transient Schema arrowSchema;
+  private transient List<RowData> buffer;
+  private transient long totalWrittenRows;
+  private transient boolean datasetExists;
+  private transient boolean isFirstWrite;
 
-    /**
-     * Create LanceSink
-     *
-     * @param options Lance configuration options
-     * @param rowType Flink RowType
-     */
-    public LanceSink(LanceOptions options, RowType rowType) {
-        this.options = options;
-        this.rowType = rowType;
+  /**
+   * Create LanceSink
+   *
+   * @param options Lance configuration options
+   * @param rowType Flink RowType
+   */
+  public LanceSink(LanceOptions options, RowType rowType) {
+    this.options = options;
+    this.rowType = rowType;
+  }
+
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    super.open(parameters);
+
+    LOG.info("Opening Lance Sink: {}", options.getPath());
+
+    this.allocator = new RootAllocator(Long.MAX_VALUE);
+    this.buffer = new ArrayList<>(options.getWriteBatchSize());
+    this.totalWrittenRows = 0;
+    this.isFirstWrite = true;
+
+    // Initialize converter and Schema
+    this.converter = new RowDataConverter(rowType);
+    this.arrowSchema = LanceTypeConverter.toArrowSchema(rowType);
+
+    // Check if dataset exists
+    String datasetPath = options.getPath();
+    if (datasetPath == null || datasetPath.isEmpty()) {
+      throw new IllegalArgumentException("Lance dataset path cannot be empty");
     }
 
-    @Override
-    public void open(Configuration parameters) throws Exception {
-        super.open(parameters);
+    Path path = Paths.get(datasetPath);
+    this.datasetExists = Files.exists(path);
 
-        LOG.info("Opening Lance Sink: {}", options.getPath());
+    // If overwrite mode and dataset exists, delete first
+    if (datasetExists && options.getWriteMode() == LanceOptions.WriteMode.OVERWRITE) {
+      LOG.info("Overwrite mode, deleting existing dataset: {}", datasetPath);
+      deleteDirectory(path);
+      this.datasetExists = false;
+    }
 
-        this.allocator = new RootAllocator(Long.MAX_VALUE);
-        this.buffer = new ArrayList<>(options.getWriteBatchSize());
-        this.totalWrittenRows = 0;
-        this.isFirstWrite = true;
+    LOG.info("Lance Sink opened, Schema: {}", rowType);
+  }
 
-        // Initialize converter and Schema
-        this.converter = new RowDataConverter(rowType);
-        this.arrowSchema = LanceTypeConverter.toArrowSchema(rowType);
+  @Override
+  public void invoke(RowData value, Context context) throws Exception {
+    buffer.add(value);
 
-        // Check if dataset exists
-        String datasetPath = options.getPath();
-        if (datasetPath == null || datasetPath.isEmpty()) {
-            throw new IllegalArgumentException("Lance dataset path cannot be empty");
+    // When buffer reaches batch size, execute write
+    if (buffer.size() >= options.getWriteBatchSize()) {
+      flush();
+    }
+  }
+
+  /** Flush buffer, write data to Lance dataset */
+  public void flush() throws IOException {
+    if (buffer.isEmpty()) {
+      return;
+    }
+
+    LOG.debug("Flushing buffer, row count: {}", buffer.size());
+
+    try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+      // Convert RowData to VectorSchemaRoot
+      converter.toVectorSchemaRoot(buffer, root);
+
+      String datasetPath = options.getPath();
+
+      // Build write parameters
+      WriteParams writeParams =
+          new WriteParams.Builder().withMaxRowsPerFile(options.getWriteMaxRowsPerFile()).build();
+
+      // Create Fragment
+      List<FragmentMetadata> fragments = Fragment.create(datasetPath, allocator, root, writeParams);
+
+      if (!datasetExists) {
+        // Create new dataset (using Overwrite operation)
+        FragmentOperation.Overwrite overwrite =
+            new FragmentOperation.Overwrite(fragments, arrowSchema);
+        dataset =
+            overwrite.commit(allocator, datasetPath, Optional.empty(), Collections.emptyMap());
+        datasetExists = true;
+        isFirstWrite = false;
+        LOG.info("Created new dataset: {}", datasetPath);
+      } else {
+        // Append data
+        if (isFirstWrite && options.getWriteMode() == LanceOptions.WriteMode.OVERWRITE) {
+          // First write and overwrite mode
+          FragmentOperation.Overwrite overwrite =
+              new FragmentOperation.Overwrite(fragments, arrowSchema);
+          dataset =
+              overwrite.commit(allocator, datasetPath, Optional.empty(), Collections.emptyMap());
+          isFirstWrite = false;
+        } else {
+          // Append mode: need to get current dataset version
+          Dataset existingDataset = Dataset.open(datasetPath, allocator);
+          long readVersion;
+          try {
+            readVersion = existingDataset.version();
+          } finally {
+            existingDataset.close();
+          }
+
+          FragmentOperation.Append append = new FragmentOperation.Append(fragments);
+          dataset =
+              append.commit(
+                  allocator, datasetPath, Optional.of(readVersion), Collections.emptyMap());
         }
+      }
 
-        Path path = Paths.get(datasetPath);
-        this.datasetExists = Files.exists(path);
+      totalWrittenRows += buffer.size();
+      LOG.debug("Written {} rows, total: {} rows", buffer.size(), totalWrittenRows);
 
-        // If overwrite mode and dataset exists, delete first
-        if (datasetExists && options.getWriteMode() == LanceOptions.WriteMode.OVERWRITE) {
-            LOG.info("Overwrite mode, deleting existing dataset: {}", datasetPath);
-            deleteDirectory(path);
-            this.datasetExists = false;
-        }
+      buffer.clear();
+    } catch (Exception e) {
+      throw new IOException("Failed to write Lance dataset", e);
+    }
+  }
 
-        LOG.info("Lance Sink opened, Schema: {}", rowType);
+  @Override
+  public void close() throws Exception {
+    LOG.info("Closing Lance Sink");
+    // Flush remaining data
+    try {
+      flush();
+    } catch (Exception e) {
+      LOG.warn("Failed to flush data on close", e);
+    }
+    if (dataset != null) {
+      try {
+        dataset.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close dataset", e);
+      }
+      dataset = null;
     }
 
-    @Override
-    public void invoke(RowData value, Context context) throws Exception {
-        buffer.add(value);
-
-        // When buffer reaches batch size, execute write
-        if (buffer.size() >= options.getWriteBatchSize()) {
-            flush();
-        }
+    if (allocator != null) {
+      try {
+        allocator.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close allocator", e);
+      }
+      allocator = null;
     }
 
-    /**
-     * Flush buffer, write data to Lance dataset
-     */
-    public void flush() throws IOException {
-        if (buffer.isEmpty()) {
-            return;
-        }
+    LOG.info("Lance Sink closed, total written {} rows", totalWrittenRows);
 
-        LOG.debug("Flushing buffer, row count: {}", buffer.size());
+    super.close();
+  }
 
-        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
-            // Convert RowData to VectorSchemaRoot
-            converter.toVectorSchemaRoot(buffer, root);
+  @Override
+  public void snapshotState(FunctionSnapshotContext context) throws Exception {
+    LOG.debug("Snapshot state, checkpointId: {}", context.getCheckpointId());
 
-            String datasetPath = options.getPath();
+    // Flush all buffered data at Checkpoint
+    flush();
+  }
 
-            // Build write parameters
-            WriteParams writeParams = new WriteParams.Builder()
-                    .withMaxRowsPerFile(options.getWriteMaxRowsPerFile())
-                    .build();
+  @Override
+  public void initializeState(FunctionInitializationContext context) throws Exception {
+    LOG.debug("Initialize state, isRestored: {}", context.isRestored());
+    // State initialization (if recovery needed)
+  }
 
-            // Create Fragment
-            List<FragmentMetadata> fragments = Fragment.create(
-                    datasetPath,
-                    allocator,
-                    root,
-                    writeParams
-            );
+  /** Get RowType */
+  public RowType getRowType() {
+    return rowType;
+  }
 
-            if (!datasetExists) {
-                // Create new dataset (using Overwrite operation)
-                FragmentOperation.Overwrite overwrite = new FragmentOperation.Overwrite(fragments, arrowSchema);
-                dataset = overwrite.commit(allocator, datasetPath, Optional.empty(), Collections.emptyMap());
-                datasetExists = true;
-                isFirstWrite = false;
-                LOG.info("Created new dataset: {}", datasetPath);
-                } else {
-                    // Append data
-                    if (isFirstWrite && options.getWriteMode() == LanceOptions.WriteMode.OVERWRITE) {
-                        // First write and overwrite mode
-                        FragmentOperation.Overwrite overwrite = new FragmentOperation.Overwrite(fragments, arrowSchema);
-                        dataset = overwrite.commit(allocator, datasetPath, Optional.empty(), Collections.emptyMap());
-                        isFirstWrite = false;
-                    } else {
-                        // Append mode: need to get current dataset version
-                        Dataset existingDataset = Dataset.open(datasetPath, allocator);
-                        long readVersion;
-                        try {
-                            readVersion = existingDataset.version();
-                        } finally {
-                            existingDataset.close();
-                        }
+  /** Get configuration options */
+  public LanceOptions getOptions() {
+    return options;
+  }
 
-                        FragmentOperation.Append append =
-                                new FragmentOperation.Append(fragments);
-                        dataset = append.commit(
-                                allocator, datasetPath,
-                                Optional.of(readVersion),
-                                Collections.emptyMap());
-                    }
-                }
+  /** Get total written row count */
+  public long getTotalWrittenRows() {
+    return totalWrittenRows;
+  }
 
-            totalWrittenRows += buffer.size();
-            LOG.debug("Written {} rows, total: {} rows", buffer.size(), totalWrittenRows);
-
-            buffer.clear();
-        } catch (Exception e) {
-            throw new IOException("Failed to write Lance dataset", e);
-        }
-    }
-
-    @Override
-    public void close() throws Exception {
-        LOG.info("Closing Lance Sink");
-        // Flush remaining data
-        try {
-            flush();
-        } catch (Exception e) {
-            LOG.warn("Failed to flush data on close", e);
-        }
-        if (dataset != null) {
-            try {
-                dataset.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close dataset", e);
-            }
-            dataset = null;
-        }
-
-        if (allocator != null) {
-            try {
-                allocator.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close allocator", e);
-            }
-            allocator = null;
-        }
-
-        LOG.info("Lance Sink closed, total written {} rows", totalWrittenRows);
-
-        super.close();
-    }
-
-    @Override
-    public void snapshotState(FunctionSnapshotContext context) throws Exception {
-        LOG.debug("Snapshot state, checkpointId: {}", context.getCheckpointId());
-
-        // Flush all buffered data at Checkpoint
-        flush();
-    }
-
-    @Override
-    public void initializeState(FunctionInitializationContext context) throws Exception {
-        LOG.debug("Initialize state, isRestored: {}", context.isRestored());
-        // State initialization (if recovery needed)
-    }
-
-    /**
-     * Get RowType
-     */
-    public RowType getRowType() {
-        return rowType;
-    }
-
-    /**
-     * Get configuration options
-     */
-    public LanceOptions getOptions() {
-        return options;
-    }
-
-    /**
-     * Get total written row count
-     */
-    public long getTotalWrittenRows() {
-        return totalWrittenRows;
-    }
-
-    /**
-     * Recursively delete directory
-     */
-    private void deleteDirectory(Path path) throws IOException {
-        if (Files.isDirectory(path)) {
-            Files.list(path).forEach(child -> {
+  /** Recursively delete directory */
+  private void deleteDirectory(Path path) throws IOException {
+    if (Files.isDirectory(path)) {
+      Files.list(path)
+          .forEach(
+              child -> {
                 try {
-                    deleteDirectory(child);
+                  deleteDirectory(child);
                 } catch (IOException e) {
-                    LOG.warn("Failed to delete file: {}", child, e);
+                  LOG.warn("Failed to delete file: {}", child, e);
                 }
-            });
-        }
-        Files.deleteIfExists(path);
+              });
+    }
+    Files.deleteIfExists(path);
+  }
+
+  /** Builder pattern constructor */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** LanceSink Builder */
+  public static class Builder {
+    private String path;
+    private int batchSize = 1024;
+    private LanceOptions.WriteMode writeMode = LanceOptions.WriteMode.APPEND;
+    private int maxRowsPerFile = 1000000;
+    private RowType rowType;
+
+    public Builder path(String path) {
+      this.path = path;
+      return this;
     }
 
-    /**
-     * Builder pattern constructor
-     */
-    public static Builder builder() {
-        return new Builder();
+    public Builder batchSize(int batchSize) {
+      this.batchSize = batchSize;
+      return this;
     }
 
-    /**
-     * LanceSink Builder
-     */
-    public static class Builder {
-        private String path;
-        private int batchSize = 1024;
-        private LanceOptions.WriteMode writeMode = LanceOptions.WriteMode.APPEND;
-        private int maxRowsPerFile = 1000000;
-        private RowType rowType;
-
-        public Builder path(String path) {
-            this.path = path;
-            return this;
-        }
-
-        public Builder batchSize(int batchSize) {
-            this.batchSize = batchSize;
-            return this;
-        }
-
-        public Builder writeMode(LanceOptions.WriteMode writeMode) {
-            this.writeMode = writeMode;
-            return this;
-        }
-
-        public Builder maxRowsPerFile(int maxRowsPerFile) {
-            this.maxRowsPerFile = maxRowsPerFile;
-            return this;
-        }
-
-        public Builder rowType(RowType rowType) {
-            this.rowType = rowType;
-            return this;
-        }
-
-        public LanceSink build() {
-            if (path == null || path.isEmpty()) {
-                throw new IllegalArgumentException("Dataset path cannot be empty");
-            }
-
-            if (rowType == null) {
-                throw new IllegalArgumentException("RowType cannot be null");
-            }
-
-            LanceOptions options = LanceOptions.builder()
-                    .path(path)
-                    .writeBatchSize(batchSize)
-                    .writeMode(writeMode)
-                    .writeMaxRowsPerFile(maxRowsPerFile)
-                    .build();
-
-            return new LanceSink(options, rowType);
-        }
+    public Builder writeMode(LanceOptions.WriteMode writeMode) {
+      this.writeMode = writeMode;
+      return this;
     }
+
+    public Builder maxRowsPerFile(int maxRowsPerFile) {
+      this.maxRowsPerFile = maxRowsPerFile;
+      return this;
+    }
+
+    public Builder rowType(RowType rowType) {
+      this.rowType = rowType;
+      return this;
+    }
+
+    public LanceSink build() {
+      if (path == null || path.isEmpty()) {
+        throw new IllegalArgumentException("Dataset path cannot be empty");
+      }
+
+      if (rowType == null) {
+        throw new IllegalArgumentException("RowType cannot be null");
+      }
+
+      LanceOptions options =
+          LanceOptions.builder()
+              .path(path)
+              .writeBatchSize(batchSize)
+              .writeMode(writeMode)
+              .writeMaxRowsPerFile(maxRowsPerFile)
+              .build();
+
+      return new LanceSink(options, rowType);
+    }
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/LanceSink.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceSink.java
@@ -52,9 +52,9 @@ import java.util.Optional;
 
 /**
  * Lance Sink implementation.
- * 
+ *
  * <p>Writes Flink RowData to Lance dataset, supports batch writing and Checkpoint.
- * 
+ *
  * <p>Usage example:
  * <pre>{@code
  * LanceOptions options = LanceOptions.builder()
@@ -62,7 +62,7 @@ import java.util.Optional;
  *     .writeBatchSize(1024)
  *     .writeMode(WriteMode.APPEND)
  *     .build();
- * 
+ *
  * LanceSink sink = new LanceSink(options, rowType);
  * dataStream.addSink(sink);
  * }</pre>
@@ -98,41 +98,41 @@ public class LanceSink extends RichSinkFunction<RowData> implements Checkpointed
     @Override
     public void open(Configuration parameters) throws Exception {
         super.open(parameters);
-        
+
         LOG.info("Opening Lance Sink: {}", options.getPath());
-        
+
         this.allocator = new RootAllocator(Long.MAX_VALUE);
         this.buffer = new ArrayList<>(options.getWriteBatchSize());
         this.totalWrittenRows = 0;
         this.isFirstWrite = true;
-        
+
         // Initialize converter and Schema
         this.converter = new RowDataConverter(rowType);
         this.arrowSchema = LanceTypeConverter.toArrowSchema(rowType);
-        
+
         // Check if dataset exists
         String datasetPath = options.getPath();
         if (datasetPath == null || datasetPath.isEmpty()) {
             throw new IllegalArgumentException("Lance dataset path cannot be empty");
         }
-        
+
         Path path = Paths.get(datasetPath);
         this.datasetExists = Files.exists(path);
-        
+
         // If overwrite mode and dataset exists, delete first
         if (datasetExists && options.getWriteMode() == LanceOptions.WriteMode.OVERWRITE) {
             LOG.info("Overwrite mode, deleting existing dataset: {}", datasetPath);
             deleteDirectory(path);
             this.datasetExists = false;
         }
-        
+
         LOG.info("Lance Sink opened, Schema: {}", rowType);
     }
 
     @Override
     public void invoke(RowData value, Context context) throws Exception {
         buffer.add(value);
-        
+
         // When buffer reaches batch size, execute write
         if (buffer.size() >= options.getWriteBatchSize()) {
             flush();
@@ -146,20 +146,20 @@ public class LanceSink extends RichSinkFunction<RowData> implements Checkpointed
         if (buffer.isEmpty()) {
             return;
         }
-        
+
         LOG.debug("Flushing buffer, row count: {}", buffer.size());
-        
+
         try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
             // Convert RowData to VectorSchemaRoot
             converter.toVectorSchemaRoot(buffer, root);
-            
+
             String datasetPath = options.getPath();
-            
+
             // Build write parameters
             WriteParams writeParams = new WriteParams.Builder()
                     .withMaxRowsPerFile(options.getWriteMaxRowsPerFile())
                     .build();
-            
+
             // Create Fragment
             List<FragmentMetadata> fragments = Fragment.create(
                     datasetPath,
@@ -167,7 +167,7 @@ public class LanceSink extends RichSinkFunction<RowData> implements Checkpointed
                     root,
                     writeParams
             );
-            
+
             if (!datasetExists) {
                 // Create new dataset (using Overwrite operation)
                 FragmentOperation.Overwrite overwrite = new FragmentOperation.Overwrite(fragments, arrowSchema);
@@ -192,14 +192,18 @@ public class LanceSink extends RichSinkFunction<RowData> implements Checkpointed
                             existingDataset.close();
                         }
 
-                        FragmentOperation.Append append = new FragmentOperation.Append(fragments);
-                        dataset = append.commit(allocator, datasetPath, Optional.of(readVersion), Collections.emptyMap());
+                        FragmentOperation.Append append =
+                                new FragmentOperation.Append(fragments);
+                        dataset = append.commit(
+                                allocator, datasetPath,
+                                Optional.of(readVersion),
+                                Collections.emptyMap());
                     }
                 }
-            
+
             totalWrittenRows += buffer.size();
             LOG.debug("Written {} rows, total: {} rows", buffer.size(), totalWrittenRows);
-            
+
             buffer.clear();
         } catch (Exception e) {
             throw new IOException("Failed to write Lance dataset", e);
@@ -223,7 +227,7 @@ public class LanceSink extends RichSinkFunction<RowData> implements Checkpointed
             }
             dataset = null;
         }
-        
+
         if (allocator != null) {
             try {
                 allocator.close();
@@ -232,16 +236,16 @@ public class LanceSink extends RichSinkFunction<RowData> implements Checkpointed
             }
             allocator = null;
         }
-        
+
         LOG.info("Lance Sink closed, total written {} rows", totalWrittenRows);
-        
+
         super.close();
     }
 
     @Override
     public void snapshotState(FunctionSnapshotContext context) throws Exception {
         LOG.debug("Snapshot state, checkpointId: {}", context.getCheckpointId());
-        
+
         // Flush all buffered data at Checkpoint
         flush();
     }
@@ -335,7 +339,7 @@ public class LanceSink extends RichSinkFunction<RowData> implements Checkpointed
             if (path == null || path.isEmpty()) {
                 throw new IllegalArgumentException("Dataset path cannot be empty");
             }
-            
+
             if (rowType == null) {
                 throw new IllegalArgumentException("RowType cannot be null");
             }

--- a/src/main/java/org/apache/flink/connector/lance/LanceSink.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceSink.java
@@ -23,6 +23,7 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.lance.config.LanceDatasetFactory;
 import org.apache.flink.connector.lance.config.LanceOptions;
 import org.apache.flink.connector.lance.converter.LanceTypeConverter;
 import org.apache.flink.connector.lance.converter.RowDataConverter;
@@ -175,7 +176,7 @@ public class LanceSink extends RichSinkFunction<RowData> implements Checkpointed
           isFirstWrite = false;
         } else {
           // Append mode: need to get current dataset version
-          Dataset existingDataset = Dataset.open(datasetPath, allocator);
+          Dataset existingDataset = LanceDatasetFactory.open(datasetPath, allocator);
           long readVersion;
           try {
             readVersion = existingDataset.version();

--- a/src/main/java/org/apache/flink/connector/lance/LanceSource.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceSource.java
@@ -23,6 +23,7 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.lance.config.LanceDatasetFactory;
 import org.apache.flink.connector.lance.config.LanceOptions;
 import org.apache.flink.connector.lance.converter.LanceTypeConverter;
 import org.apache.flink.connector.lance.converter.RowDataConverter;
@@ -32,9 +33,6 @@ import org.apache.flink.table.types.logical.RowType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
@@ -113,17 +111,7 @@ public class LanceSource extends RichParallelSourceFunction<RowData> {
     this.allocator = new RootAllocator(Long.MAX_VALUE);
 
     // Open Lance dataset
-    String datasetPath = options.getPath();
-    if (datasetPath == null || datasetPath.isEmpty()) {
-      throw new IllegalArgumentException("Lance dataset path cannot be empty");
-    }
-
-    Path path = Paths.get(datasetPath);
-    try {
-      this.dataset = Dataset.open(path.toString(), allocator);
-    } catch (Exception e) {
-      throw new IOException("Cannot open Lance dataset: " + datasetPath, e);
-    }
+    this.dataset = LanceDatasetFactory.open(options.getPath(), allocator);
 
     // Initialize RowDataConverter
     RowType actualRowType = this.rowType;

--- a/src/main/java/org/apache/flink/connector/lance/LanceSource.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceSource.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.connector.lance;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.lance.config.LanceOptions;
 import org.apache.flink.connector.lance.converter.LanceTypeConverter;
@@ -47,10 +46,10 @@ import java.util.List;
 
 /**
  * Lance data source implementation.
- * 
+ *
  * <p>Reads data from Lance dataset and converts to Flink RowData.
  * <p>Supports column pruning, predicate push-down and Limit push-down optimization.
- * 
+ *
  * <p>Usage example:
  * <pre>{@code
  * LanceOptions options = LanceOptions.builder()
@@ -58,7 +57,7 @@ import java.util.List;
  *     .readBatchSize(1024)
  *     .readLimit(100L)  // Limit push-down
  *     .build();
- * 
+ *
  * LanceSource source = new LanceSource(options, rowType);
  * DataStream<RowData> stream = env.addSource(source);
  * }</pre>
@@ -88,10 +87,10 @@ public class LanceSource extends RichParallelSourceFunction<RowData> {
     public LanceSource(LanceOptions options, RowType rowType) {
         this.options = options;
         this.rowType = rowType;
-        
+
         List<String> columns = options.getReadColumns();
-        this.selectedColumns = columns != null && !columns.isEmpty() 
-                ? columns.toArray(new String[0]) 
+        this.selectedColumns = columns != null && !columns.isEmpty()
+                ? columns.toArray(new String[0])
                 : null;
         this.readLimit = options.getReadLimit();
     }
@@ -108,29 +107,29 @@ public class LanceSource extends RichParallelSourceFunction<RowData> {
     @Override
     public void open(Configuration parameters) throws Exception {
         super.open(parameters);
-        
+
         LOG.info("Opening Lance data source: {}", options.getPath());
         if (readLimit != null) {
             LOG.info("Limit push-down enabled, max read rows: {}", readLimit);
         }
-        
+
         this.running = true;
         this.emittedCount = 0;
         this.allocator = new RootAllocator(Long.MAX_VALUE);
-        
+
         // Open Lance dataset
         String datasetPath = options.getPath();
         if (datasetPath == null || datasetPath.isEmpty()) {
             throw new IllegalArgumentException("Lance dataset path cannot be empty");
         }
-        
+
         Path path = Paths.get(datasetPath);
         try {
             this.dataset = Dataset.open(path.toString(), allocator);
         } catch (Exception e) {
             throw new IOException("Cannot open Lance dataset: " + datasetPath, e);
         }
-        
+
         // Initialize RowDataConverter
         RowType actualRowType = this.rowType;
         if (actualRowType == null) {
@@ -139,19 +138,19 @@ public class LanceSource extends RichParallelSourceFunction<RowData> {
             actualRowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
         }
         this.converter = new RowDataConverter(actualRowType);
-        
+
         LOG.info("Lance data source opened, Schema: {}", actualRowType);
     }
 
     @Override
     public void run(SourceContext<RowData> ctx) throws Exception {
         LOG.info("Start reading Lance dataset: {}", options.getPath());
-        
+
         int subtaskIndex = getRuntimeContext().getIndexOfThisSubtask();
         int numSubtasks = getRuntimeContext().getNumberOfParallelSubtasks();
-        
+
         String filter = options.getReadFilter();
-        
+
         // If filter condition exists, use Dataset level scan (only execute on first subtask to avoid duplicate data)
         if (filter != null && !filter.isEmpty()) {
             if (subtaskIndex == 0) {
@@ -171,21 +170,21 @@ public class LanceSource extends RichParallelSourceFunction<RowData> {
         } else {
             // Without filter condition and Limit, use Fragment level parallel scan
             List<Fragment> fragments = dataset.getFragments();
-            LOG.info("Dataset has {} Fragments, current subtask {}/{}", 
+            LOG.info("Dataset has {} Fragments, current subtask {}/{}",
                     fragments.size(), subtaskIndex, numSubtasks);
-            
+
             // Assign Fragments by subtask
             for (int i = 0; i < fragments.size() && running && !isLimitReached(); i++) {
                 // Simple round-robin assignment strategy
                 if (i % numSubtasks != subtaskIndex) {
                     continue;
                 }
-                
+
                 Fragment fragment = fragments.get(i);
                 readFragment(ctx, fragment);
             }
         }
-        
+
         LOG.info("Lance data source read completed, total emitted {} rows", emittedCount);
     }
 
@@ -195,30 +194,30 @@ public class LanceSource extends RichParallelSourceFunction<RowData> {
     private void readDatasetWithFilter(SourceContext<RowData> ctx) throws Exception {
         // Build scan options
         ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder();
-        
+
         // Set batch size
         scanOptionsBuilder.batchSize(options.getReadBatchSize());
-        
+
         // Set column filter
         if (selectedColumns != null && selectedColumns.length > 0) {
             scanOptionsBuilder.columns(Arrays.asList(selectedColumns));
         }
-        
+
         // Set data filter condition
         String filter = options.getReadFilter();
         if (filter != null && !filter.isEmpty()) {
             LOG.info("Applying filter condition: {}", filter);
             scanOptionsBuilder.filter(filter);
         }
-        
+
         ScanOptions scanOptions = scanOptionsBuilder.build();
-        
+
         // Use Dataset level scan
         try (LanceScanner scanner = dataset.newScan(scanOptions)) {
             try (ArrowReader reader = scanner.scanBatches()) {
                 while (reader.loadNextBatch() && running && !isLimitReached()) {
                     VectorSchemaRoot root = reader.getVectorSchemaRoot();
-                    
+
                     // Convert to RowData and output
                     List<RowData> rows = converter.toRowDataList(root);
                     synchronized (ctx.getCheckpointLock()) {
@@ -233,7 +232,7 @@ public class LanceSource extends RichParallelSourceFunction<RowData> {
                 }
             }
         }
-        
+
         if (isLimitReached()) {
             LOG.info("Reached Limit ({}), stop reading", readLimit);
         }
@@ -244,28 +243,28 @@ public class LanceSource extends RichParallelSourceFunction<RowData> {
      */
     private void readFragment(SourceContext<RowData> ctx, Fragment fragment) throws Exception {
         LOG.debug("Reading Fragment: {}", fragment.getId());
-        
+
         // Build scan options
         ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder();
-        
+
         // Set batch size
         scanOptionsBuilder.batchSize(options.getReadBatchSize());
-        
+
         // Set column filter
         if (selectedColumns != null && selectedColumns.length > 0) {
             scanOptionsBuilder.columns(Arrays.asList(selectedColumns));
         }
-        
+
         // Note: Fragment level scan does not use filter, filter is only supported at Dataset level
-        
+
         ScanOptions scanOptions = scanOptionsBuilder.build();
-        
+
         // Create Scanner and read data
         try (LanceScanner scanner = fragment.newScan(scanOptions)) {
             try (ArrowReader reader = scanner.scanBatches()) {
                 while (reader.loadNextBatch() && running && !isLimitReached()) {
                     VectorSchemaRoot root = reader.getVectorSchemaRoot();
-                    
+
                     // Convert to RowData and output
                     List<RowData> rows = converter.toRowDataList(root);
                     synchronized (ctx.getCheckpointLock()) {
@@ -298,9 +297,9 @@ public class LanceSource extends RichParallelSourceFunction<RowData> {
     @Override
     public void close() throws Exception {
         LOG.info("Closing Lance data source");
-        
+
         this.running = false;
-        
+
         if (dataset != null) {
             try {
                 dataset.close();
@@ -309,7 +308,7 @@ public class LanceSource extends RichParallelSourceFunction<RowData> {
             }
             dataset = null;
         }
-        
+
         if (allocator != null) {
             try {
                 allocator.close();
@@ -318,7 +317,7 @@ public class LanceSource extends RichParallelSourceFunction<RowData> {
             }
             allocator = null;
         }
-        
+
         super.close();
     }
 

--- a/src/main/java/org/apache/flink/connector/lance/LanceSource.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceSource.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,16 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance;
-
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.connector.lance.config.LanceOptions;
-import org.apache.flink.connector.lance.converter.LanceTypeConverter;
-import org.apache.flink.connector.lance.converter.RowDataConverter;
-import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.logical.RowType;
 
 import com.lancedb.lance.Dataset;
 import com.lancedb.lance.Fragment;
@@ -35,6 +22,13 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.lance.config.LanceOptions;
+import org.apache.flink.connector.lance.converter.LanceTypeConverter;
+import org.apache.flink.connector.lance.converter.RowDataConverter;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,9 +42,11 @@ import java.util.List;
  * Lance data source implementation.
  *
  * <p>Reads data from Lance dataset and converts to Flink RowData.
+ *
  * <p>Supports column pruning, predicate push-down and Limit push-down optimization.
  *
  * <p>Usage example:
+ *
  * <pre>{@code
  * LanceOptions options = LanceOptions.builder()
  *     .path("/path/to/lance/dataset")
@@ -64,346 +60,334 @@ import java.util.List;
  */
 public class LanceSource extends RichParallelSourceFunction<RowData> {
 
-    private static final long serialVersionUID = 1L;
-    private static final Logger LOG = LoggerFactory.getLogger(LanceSource.class);
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(LanceSource.class);
 
-    private final LanceOptions options;
-    private final RowType rowType;
-    private final String[] selectedColumns;
-    private final Long readLimit;  // Added: Limit push-down
+  private final LanceOptions options;
+  private final RowType rowType;
+  private final String[] selectedColumns;
+  private final Long readLimit; // Added: Limit push-down
 
-    private transient volatile boolean running;
-    private transient BufferAllocator allocator;
-    private transient Dataset dataset;
-    private transient RowDataConverter converter;
-    private transient long emittedCount;  // Added: emitted row count
+  private transient volatile boolean running;
+  private transient BufferAllocator allocator;
+  private transient Dataset dataset;
+  private transient RowDataConverter converter;
+  private transient long emittedCount; // Added: emitted row count
 
-    /**
-     * Create LanceSource
-     *
-     * @param options Lance configuration options
-     * @param rowType Flink RowType
-     */
-    public LanceSource(LanceOptions options, RowType rowType) {
-        this.options = options;
-        this.rowType = rowType;
+  /**
+   * Create LanceSource
+   *
+   * @param options Lance configuration options
+   * @param rowType Flink RowType
+   */
+  public LanceSource(LanceOptions options, RowType rowType) {
+    this.options = options;
+    this.rowType = rowType;
 
-        List<String> columns = options.getReadColumns();
-        this.selectedColumns = columns != null && !columns.isEmpty()
-                ? columns.toArray(new String[0])
-                : null;
-        this.readLimit = options.getReadLimit();
+    List<String> columns = options.getReadColumns();
+    this.selectedColumns =
+        columns != null && !columns.isEmpty() ? columns.toArray(new String[0]) : null;
+    this.readLimit = options.getReadLimit();
+  }
+
+  /**
+   * Create LanceSource (auto-infer Schema)
+   *
+   * @param options Lance configuration options
+   */
+  public LanceSource(LanceOptions options) {
+    this(options, null);
+  }
+
+  @Override
+  public void open(Configuration parameters) throws Exception {
+    super.open(parameters);
+
+    LOG.info("Opening Lance data source: {}", options.getPath());
+    if (readLimit != null) {
+      LOG.info("Limit push-down enabled, max read rows: {}", readLimit);
     }
 
-    /**
-     * Create LanceSource (auto-infer Schema)
-     *
-     * @param options Lance configuration options
-     */
-    public LanceSource(LanceOptions options) {
-        this(options, null);
+    this.running = true;
+    this.emittedCount = 0;
+    this.allocator = new RootAllocator(Long.MAX_VALUE);
+
+    // Open Lance dataset
+    String datasetPath = options.getPath();
+    if (datasetPath == null || datasetPath.isEmpty()) {
+      throw new IllegalArgumentException("Lance dataset path cannot be empty");
     }
 
-    @Override
-    public void open(Configuration parameters) throws Exception {
-        super.open(parameters);
-
-        LOG.info("Opening Lance data source: {}", options.getPath());
-        if (readLimit != null) {
-            LOG.info("Limit push-down enabled, max read rows: {}", readLimit);
-        }
-
-        this.running = true;
-        this.emittedCount = 0;
-        this.allocator = new RootAllocator(Long.MAX_VALUE);
-
-        // Open Lance dataset
-        String datasetPath = options.getPath();
-        if (datasetPath == null || datasetPath.isEmpty()) {
-            throw new IllegalArgumentException("Lance dataset path cannot be empty");
-        }
-
-        Path path = Paths.get(datasetPath);
-        try {
-            this.dataset = Dataset.open(path.toString(), allocator);
-        } catch (Exception e) {
-            throw new IOException("Cannot open Lance dataset: " + datasetPath, e);
-        }
-
-        // Initialize RowDataConverter
-        RowType actualRowType = this.rowType;
-        if (actualRowType == null) {
-            // Infer RowType from dataset Schema
-            Schema arrowSchema = dataset.getSchema();
-            actualRowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
-        }
-        this.converter = new RowDataConverter(actualRowType);
-
-        LOG.info("Lance data source opened, Schema: {}", actualRowType);
+    Path path = Paths.get(datasetPath);
+    try {
+      this.dataset = Dataset.open(path.toString(), allocator);
+    } catch (Exception e) {
+      throw new IOException("Cannot open Lance dataset: " + datasetPath, e);
     }
 
-    @Override
-    public void run(SourceContext<RowData> ctx) throws Exception {
-        LOG.info("Start reading Lance dataset: {}", options.getPath());
+    // Initialize RowDataConverter
+    RowType actualRowType = this.rowType;
+    if (actualRowType == null) {
+      // Infer RowType from dataset Schema
+      Schema arrowSchema = dataset.getSchema();
+      actualRowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
+    }
+    this.converter = new RowDataConverter(actualRowType);
 
-        int subtaskIndex = getRuntimeContext().getIndexOfThisSubtask();
-        int numSubtasks = getRuntimeContext().getNumberOfParallelSubtasks();
+    LOG.info("Lance data source opened, Schema: {}", actualRowType);
+  }
 
-        String filter = options.getReadFilter();
+  @Override
+  public void run(SourceContext<RowData> ctx) throws Exception {
+    LOG.info("Start reading Lance dataset: {}", options.getPath());
 
-        // If filter condition exists, use Dataset level scan (only execute on first subtask to avoid duplicate data)
-        if (filter != null && !filter.isEmpty()) {
-            if (subtaskIndex == 0) {
-                LOG.info("Using Dataset level scan (with filter condition)");
-                readDatasetWithFilter(ctx);
-            } else {
-                LOG.info("Subtask {} skipped (only subtask 0 executes in filter mode)", subtaskIndex);
+    int subtaskIndex = getRuntimeContext().getIndexOfThisSubtask();
+    int numSubtasks = getRuntimeContext().getNumberOfParallelSubtasks();
+
+    String filter = options.getReadFilter();
+
+    // If filter condition exists, use Dataset level scan (only execute on first subtask to avoid
+    // duplicate data)
+    if (filter != null && !filter.isEmpty()) {
+      if (subtaskIndex == 0) {
+        LOG.info("Using Dataset level scan (with filter condition)");
+        readDatasetWithFilter(ctx);
+      } else {
+        LOG.info("Subtask {} skipped (only subtask 0 executes in filter mode)", subtaskIndex);
+      }
+    } else if (readLimit != null) {
+      // With Limit, only execute on first subtask to avoid duplicate data
+      if (subtaskIndex == 0) {
+        LOG.info("Using Dataset level scan (with Limit)");
+        readDatasetWithFilter(ctx);
+      } else {
+        LOG.info("Subtask {} skipped (only subtask 0 executes in Limit mode)", subtaskIndex);
+      }
+    } else {
+      // Without filter condition and Limit, use Fragment level parallel scan
+      List<Fragment> fragments = dataset.getFragments();
+      LOG.info(
+          "Dataset has {} Fragments, current subtask {}/{}",
+          fragments.size(),
+          subtaskIndex,
+          numSubtasks);
+
+      // Assign Fragments by subtask
+      for (int i = 0; i < fragments.size() && running && !isLimitReached(); i++) {
+        // Simple round-robin assignment strategy
+        if (i % numSubtasks != subtaskIndex) {
+          continue;
+        }
+
+        Fragment fragment = fragments.get(i);
+        readFragment(ctx, fragment);
+      }
+    }
+
+    LOG.info("Lance data source read completed, total emitted {} rows", emittedCount);
+  }
+
+  /** Use Dataset level scan (supports filter conditions and Limit) */
+  private void readDatasetWithFilter(SourceContext<RowData> ctx) throws Exception {
+    // Build scan options
+    ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder();
+
+    // Set batch size
+    scanOptionsBuilder.batchSize(options.getReadBatchSize());
+
+    // Set column filter
+    if (selectedColumns != null && selectedColumns.length > 0) {
+      scanOptionsBuilder.columns(Arrays.asList(selectedColumns));
+    }
+
+    // Set data filter condition
+    String filter = options.getReadFilter();
+    if (filter != null && !filter.isEmpty()) {
+      LOG.info("Applying filter condition: {}", filter);
+      scanOptionsBuilder.filter(filter);
+    }
+
+    ScanOptions scanOptions = scanOptionsBuilder.build();
+
+    // Use Dataset level scan
+    try (LanceScanner scanner = dataset.newScan(scanOptions)) {
+      try (ArrowReader reader = scanner.scanBatches()) {
+        while (reader.loadNextBatch() && running && !isLimitReached()) {
+          VectorSchemaRoot root = reader.getVectorSchemaRoot();
+
+          // Convert to RowData and output
+          List<RowData> rows = converter.toRowDataList(root);
+          synchronized (ctx.getCheckpointLock()) {
+            for (RowData row : rows) {
+              if (isLimitReached()) {
+                break;
+              }
+              ctx.collect(row);
+              emittedCount++;
             }
-        } else if (readLimit != null) {
-            // With Limit, only execute on first subtask to avoid duplicate data
-            if (subtaskIndex == 0) {
-                LOG.info("Using Dataset level scan (with Limit)");
-                readDatasetWithFilter(ctx);
-            } else {
-                LOG.info("Subtask {} skipped (only subtask 0 executes in Limit mode)", subtaskIndex);
+          }
+        }
+      }
+    }
+
+    if (isLimitReached()) {
+      LOG.info("Reached Limit ({}), stop reading", readLimit);
+    }
+  }
+
+  /** Read single Fragment (without filter condition, but supports Limit) */
+  private void readFragment(SourceContext<RowData> ctx, Fragment fragment) throws Exception {
+    LOG.debug("Reading Fragment: {}", fragment.getId());
+
+    // Build scan options
+    ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder();
+
+    // Set batch size
+    scanOptionsBuilder.batchSize(options.getReadBatchSize());
+
+    // Set column filter
+    if (selectedColumns != null && selectedColumns.length > 0) {
+      scanOptionsBuilder.columns(Arrays.asList(selectedColumns));
+    }
+
+    // Note: Fragment level scan does not use filter, filter is only supported at Dataset level
+
+    ScanOptions scanOptions = scanOptionsBuilder.build();
+
+    // Create Scanner and read data
+    try (LanceScanner scanner = fragment.newScan(scanOptions)) {
+      try (ArrowReader reader = scanner.scanBatches()) {
+        while (reader.loadNextBatch() && running && !isLimitReached()) {
+          VectorSchemaRoot root = reader.getVectorSchemaRoot();
+
+          // Convert to RowData and output
+          List<RowData> rows = converter.toRowDataList(root);
+          synchronized (ctx.getCheckpointLock()) {
+            for (RowData row : rows) {
+              if (isLimitReached()) {
+                break;
+              }
+              ctx.collect(row);
+              emittedCount++;
             }
-        } else {
-            // Without filter condition and Limit, use Fragment level parallel scan
-            List<Fragment> fragments = dataset.getFragments();
-            LOG.info("Dataset has {} Fragments, current subtask {}/{}",
-                    fragments.size(), subtaskIndex, numSubtasks);
-
-            // Assign Fragments by subtask
-            for (int i = 0; i < fragments.size() && running && !isLimitReached(); i++) {
-                // Simple round-robin assignment strategy
-                if (i % numSubtasks != subtaskIndex) {
-                    continue;
-                }
-
-                Fragment fragment = fragments.get(i);
-                readFragment(ctx, fragment);
-            }
+          }
         }
+      }
+    }
+  }
 
-        LOG.info("Lance data source read completed, total emitted {} rows", emittedCount);
+  /** Check if Limit has been reached */
+  private boolean isLimitReached() {
+    return readLimit != null && emittedCount >= readLimit;
+  }
+
+  @Override
+  public void cancel() {
+    LOG.info("Cancel Lance data source");
+    this.running = false;
+  }
+
+  @Override
+  public void close() throws Exception {
+    LOG.info("Closing Lance data source");
+
+    this.running = false;
+
+    if (dataset != null) {
+      try {
+        dataset.close();
+      } catch (Exception e) {
+        LOG.warn("Error closing Lance dataset", e);
+      }
+      dataset = null;
     }
 
-    /**
-     * Use Dataset level scan (supports filter conditions and Limit)
-     */
-    private void readDatasetWithFilter(SourceContext<RowData> ctx) throws Exception {
-        // Build scan options
-        ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder();
-
-        // Set batch size
-        scanOptionsBuilder.batchSize(options.getReadBatchSize());
-
-        // Set column filter
-        if (selectedColumns != null && selectedColumns.length > 0) {
-            scanOptionsBuilder.columns(Arrays.asList(selectedColumns));
-        }
-
-        // Set data filter condition
-        String filter = options.getReadFilter();
-        if (filter != null && !filter.isEmpty()) {
-            LOG.info("Applying filter condition: {}", filter);
-            scanOptionsBuilder.filter(filter);
-        }
-
-        ScanOptions scanOptions = scanOptionsBuilder.build();
-
-        // Use Dataset level scan
-        try (LanceScanner scanner = dataset.newScan(scanOptions)) {
-            try (ArrowReader reader = scanner.scanBatches()) {
-                while (reader.loadNextBatch() && running && !isLimitReached()) {
-                    VectorSchemaRoot root = reader.getVectorSchemaRoot();
-
-                    // Convert to RowData and output
-                    List<RowData> rows = converter.toRowDataList(root);
-                    synchronized (ctx.getCheckpointLock()) {
-                        for (RowData row : rows) {
-                            if (isLimitReached()) {
-                                break;
-                            }
-                            ctx.collect(row);
-                            emittedCount++;
-                        }
-                    }
-                }
-            }
-        }
-
-        if (isLimitReached()) {
-            LOG.info("Reached Limit ({}), stop reading", readLimit);
-        }
+    if (allocator != null) {
+      try {
+        allocator.close();
+      } catch (Exception e) {
+        LOG.warn("Error closing memory allocator", e);
+      }
+      allocator = null;
     }
 
-    /**
-     * Read single Fragment (without filter condition, but supports Limit)
-     */
-    private void readFragment(SourceContext<RowData> ctx, Fragment fragment) throws Exception {
-        LOG.debug("Reading Fragment: {}", fragment.getId());
+    super.close();
+  }
 
-        // Build scan options
-        ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder();
+  /** Get RowType */
+  public RowType getRowType() {
+    return rowType;
+  }
 
-        // Set batch size
-        scanOptionsBuilder.batchSize(options.getReadBatchSize());
+  /** Get configuration options */
+  public LanceOptions getOptions() {
+    return options;
+  }
 
-        // Set column filter
-        if (selectedColumns != null && selectedColumns.length > 0) {
-            scanOptionsBuilder.columns(Arrays.asList(selectedColumns));
-        }
+  /** Get selected columns */
+  public String[] getSelectedColumns() {
+    return selectedColumns;
+  }
 
-        // Note: Fragment level scan does not use filter, filter is only supported at Dataset level
+  /** Builder pattern constructor */
+  public static Builder builder() {
+    return new Builder();
+  }
 
-        ScanOptions scanOptions = scanOptionsBuilder.build();
+  /** LanceSource Builder */
+  public static class Builder {
+    private String path;
+    private int batchSize = 1024;
+    private List<String> columns;
+    private String filter;
+    private Long limit; // Added
+    private RowType rowType;
 
-        // Create Scanner and read data
-        try (LanceScanner scanner = fragment.newScan(scanOptions)) {
-            try (ArrowReader reader = scanner.scanBatches()) {
-                while (reader.loadNextBatch() && running && !isLimitReached()) {
-                    VectorSchemaRoot root = reader.getVectorSchemaRoot();
-
-                    // Convert to RowData and output
-                    List<RowData> rows = converter.toRowDataList(root);
-                    synchronized (ctx.getCheckpointLock()) {
-                        for (RowData row : rows) {
-                            if (isLimitReached()) {
-                                break;
-                            }
-                            ctx.collect(row);
-                            emittedCount++;
-                        }
-                    }
-                }
-            }
-        }
+    public Builder path(String path) {
+      this.path = path;
+      return this;
     }
 
-    /**
-     * Check if Limit has been reached
-     */
-    private boolean isLimitReached() {
-        return readLimit != null && emittedCount >= readLimit;
+    public Builder batchSize(int batchSize) {
+      this.batchSize = batchSize;
+      return this;
     }
 
-    @Override
-    public void cancel() {
-        LOG.info("Cancel Lance data source");
-        this.running = false;
+    public Builder columns(List<String> columns) {
+      this.columns = columns;
+      return this;
     }
 
-    @Override
-    public void close() throws Exception {
-        LOG.info("Closing Lance data source");
-
-        this.running = false;
-
-        if (dataset != null) {
-            try {
-                dataset.close();
-            } catch (Exception e) {
-                LOG.warn("Error closing Lance dataset", e);
-            }
-            dataset = null;
-        }
-
-        if (allocator != null) {
-            try {
-                allocator.close();
-            } catch (Exception e) {
-                LOG.warn("Error closing memory allocator", e);
-            }
-            allocator = null;
-        }
-
-        super.close();
+    public Builder filter(String filter) {
+      this.filter = filter;
+      return this;
     }
 
-    /**
-     * Get RowType
-     */
-    public RowType getRowType() {
-        return rowType;
+    public Builder limit(Long limit) {
+      this.limit = limit;
+      return this;
     }
 
-    /**
-     * Get configuration options
-     */
-    public LanceOptions getOptions() {
-        return options;
+    public Builder rowType(RowType rowType) {
+      this.rowType = rowType;
+      return this;
     }
 
-    /**
-     * Get selected columns
-     */
-    public String[] getSelectedColumns() {
-        return selectedColumns;
+    public LanceSource build() {
+      if (path == null || path.isEmpty()) {
+        throw new IllegalArgumentException("Dataset path cannot be empty");
+      }
+
+      LanceOptions options =
+          LanceOptions.builder()
+              .path(path)
+              .readBatchSize(batchSize)
+              .readColumns(columns)
+              .readFilter(filter)
+              .readLimit(limit)
+              .build();
+
+      return new LanceSource(options, rowType);
     }
-
-    /**
-     * Builder pattern constructor
-     */
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    /**
-     * LanceSource Builder
-     */
-    public static class Builder {
-        private String path;
-        private int batchSize = 1024;
-        private List<String> columns;
-        private String filter;
-        private Long limit;  // Added
-        private RowType rowType;
-
-        public Builder path(String path) {
-            this.path = path;
-            return this;
-        }
-
-        public Builder batchSize(int batchSize) {
-            this.batchSize = batchSize;
-            return this;
-        }
-
-        public Builder columns(List<String> columns) {
-            this.columns = columns;
-            return this;
-        }
-
-        public Builder filter(String filter) {
-            this.filter = filter;
-            return this;
-        }
-
-        public Builder limit(Long limit) {
-            this.limit = limit;
-            return this;
-        }
-
-        public Builder rowType(RowType rowType) {
-            this.rowType = rowType;
-            return this;
-        }
-
-        public LanceSource build() {
-            if (path == null || path.isEmpty()) {
-                throw new IllegalArgumentException("Dataset path cannot be empty");
-            }
-
-            LanceOptions options = LanceOptions.builder()
-                    .path(path)
-                    .readBatchSize(batchSize)
-                    .readColumns(columns)
-                    .readFilter(filter)
-                    .readLimit(limit)
-                    .build();
-
-            return new LanceSource(options, rowType);
-        }
-    }
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/LanceSplit.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceSplit.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance;
 
 import org.apache.flink.core.io.InputSplit;
@@ -30,92 +25,83 @@ import java.util.Objects;
  */
 public class LanceSplit implements InputSplit, Serializable {
 
-    private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-    /**
-     * Split number
-     */
-    private final int splitNumber;
+  /** Split number */
+  private final int splitNumber;
 
-    /**
-     * Fragment ID
-     */
-    private final int fragmentId;
+  /** Fragment ID */
+  private final int fragmentId;
 
-    /**
-     * Dataset path
-     */
-    private final String datasetPath;
+  /** Dataset path */
+  private final String datasetPath;
 
-    /**
-     * Row count in Fragment (estimated)
-     */
-    private final long rowCount;
+  /** Row count in Fragment (estimated) */
+  private final long rowCount;
 
-    /**
-     * Create LanceSplit
-     *
-     * @param splitNumber Split number
-     * @param fragmentId Fragment ID
-     * @param datasetPath Dataset path
-     * @param rowCount Row count
-     */
-    public LanceSplit(int splitNumber, int fragmentId, String datasetPath, long rowCount) {
-        this.splitNumber = splitNumber;
-        this.fragmentId = fragmentId;
-        this.datasetPath = datasetPath;
-        this.rowCount = rowCount;
-    }
+  /**
+   * Create LanceSplit
+   *
+   * @param splitNumber Split number
+   * @param fragmentId Fragment ID
+   * @param datasetPath Dataset path
+   * @param rowCount Row count
+   */
+  public LanceSplit(int splitNumber, int fragmentId, String datasetPath, long rowCount) {
+    this.splitNumber = splitNumber;
+    this.fragmentId = fragmentId;
+    this.datasetPath = datasetPath;
+    this.rowCount = rowCount;
+  }
 
-    @Override
-    public int getSplitNumber() {
-        return splitNumber;
-    }
+  @Override
+  public int getSplitNumber() {
+    return splitNumber;
+  }
 
-    /**
-     * Get Fragment ID
-     */
-    public int getFragmentId() {
-        return fragmentId;
-    }
+  /** Get Fragment ID */
+  public int getFragmentId() {
+    return fragmentId;
+  }
 
-    /**
-     * Get dataset path
-     */
-    public String getDatasetPath() {
-        return datasetPath;
-    }
+  /** Get dataset path */
+  public String getDatasetPath() {
+    return datasetPath;
+  }
 
-    /**
-     * Get row count
-     */
-    public long getRowCount() {
-        return rowCount;
-    }
+  /** Get row count */
+  public long getRowCount() {
+    return rowCount;
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        LanceSplit that = (LanceSplit) o;
-        return splitNumber == that.splitNumber &&
-                fragmentId == that.fragmentId &&
-                rowCount == that.rowCount &&
-                Objects.equals(datasetPath, that.datasetPath);
-    }
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    LanceSplit that = (LanceSplit) o;
+    return splitNumber == that.splitNumber
+        && fragmentId == that.fragmentId
+        && rowCount == that.rowCount
+        && Objects.equals(datasetPath, that.datasetPath);
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(splitNumber, fragmentId, datasetPath, rowCount);
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(splitNumber, fragmentId, datasetPath, rowCount);
+  }
 
-    @Override
-    public String toString() {
-        return "LanceSplit{" +
-                "splitNumber=" + splitNumber +
-                ", fragmentId=" + fragmentId +
-                ", datasetPath='" + datasetPath + '\'' +
-                ", rowCount=" + rowCount +
-                '}';
-    }
+  @Override
+  public String toString() {
+    return "LanceSplit{"
+        + "splitNumber="
+        + splitNumber
+        + ", fragmentId="
+        + fragmentId
+        + ", datasetPath='"
+        + datasetPath
+        + '\''
+        + ", rowCount="
+        + rowCount
+        + '}';
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/LanceSplit.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceSplit.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 
 /**
  * Lance data split.
- * 
+ *
  * <p>Represents a Fragment in Lance dataset, used for parallel data reading.
  */
 public class LanceSplit implements InputSplit, Serializable {

--- a/src/main/java/org/apache/flink/connector/lance/LanceVectorSearch.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceVectorSearch.java
@@ -49,9 +49,9 @@ import java.util.Objects;
 
 /**
  * Lance vector search implementation.
- * 
+ *
  * <p>Supports KNN search with L2, Cosine, and Dot distance metrics.
- * 
+ *
  * <p>Usage example:
  * <pre>{@code
  * LanceVectorSearch search = LanceVectorSearch.builder()
@@ -60,7 +60,7 @@ import java.util.Objects;
  *     .metricType(MetricType.L2)
  *     .nprobes(20)
  *     .build();
- * 
+ *
  * List<SearchResult> results = search.search(queryVector, 10);
  * }</pre>
  */
@@ -95,17 +95,17 @@ public class LanceVectorSearch implements Closeable, Serializable {
      */
     public void open() throws IOException {
         LOG.info("Opening vector search, dataset: {}", datasetPath);
-        
+
         this.allocator = new RootAllocator(Long.MAX_VALUE);
-        
+
         try {
             this.dataset = Dataset.open(datasetPath, allocator);
-            
+
             // Get Schema and create converter
             Schema arrowSchema = dataset.getSchema();
             this.rowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
             this.converter = new RowDataConverter(rowType);
-            
+
         } catch (Exception e) {
             throw new IOException("Cannot open dataset: " + datasetPath, e);
         }
@@ -134,14 +134,14 @@ public class LanceVectorSearch implements Closeable, Serializable {
         if (dataset == null) {
             open();
         }
-        
+
         LOG.debug("Executing vector search, k={}, vector dimension={}", k, queryVector.length);
-        
+
         // Validate query vector
         validateQueryVector(queryVector);
-        
+
         List<SearchResult> results = new ArrayList<>();
-        
+
         try {
             // Build vector query
             Query.Builder queryBuilder = new Query.Builder()
@@ -151,37 +151,37 @@ public class LanceVectorSearch implements Closeable, Serializable {
                     .setNprobes(nprobes)
                     .setDistanceType(toDistanceType(metricType))
                     .setUseIndex(true);
-            
+
             if (ef > 0) {
                 queryBuilder.setEf(ef);
             }
-            
+
             if (refineFactor != null && refineFactor > 0) {
                 queryBuilder.setRefineFactor(refineFactor);
             }
-            
+
             Query query = queryBuilder.build();
-            
+
             // Build scan options
             ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder()
                     .nearest(query)
                     .withRowId(true);
-            
+
             if (filter != null && !filter.isEmpty()) {
                 scanOptionsBuilder.filter(filter);
             }
-            
+
             ScanOptions scanOptions = scanOptionsBuilder.build();
-            
+
             // Execute search
             try (LanceScanner scanner = dataset.newScan(scanOptions)) {
                 try (ArrowReader reader = scanner.scanBatches()) {
                     while (reader.loadNextBatch()) {
                         VectorSchemaRoot root = reader.getVectorSchemaRoot();
-                        
+
                         // Convert to RowData
                         List<RowData> rows = converter.toRowDataList(root);
-                        
+
                         // Try to get distance score (if _distance column exists)
                         Float8Vector distanceVector = null;
                         try {
@@ -189,7 +189,7 @@ public class LanceVectorSearch implements Closeable, Serializable {
                         } catch (Exception e) {
                             // _distance column may not exist
                         }
-                        
+
                         for (int i = 0; i < rows.size(); i++) {
                             double distance = 0.0;
                             if (distanceVector != null && !distanceVector.isNull(i)) {
@@ -200,10 +200,10 @@ public class LanceVectorSearch implements Closeable, Serializable {
                     }
                 }
             }
-            
+
             LOG.debug("Search completed, returned {} results", results.size());
             return results;
-            
+
         } catch (Exception e) {
             throw new IOException("Vector search failed", e);
         }
@@ -219,20 +219,20 @@ public class LanceVectorSearch implements Closeable, Serializable {
     public List<RowData> searchRowData(float[] queryVector, int k) throws IOException {
         List<SearchResult> results = search(queryVector, k);
         List<RowData> rowDataList = new ArrayList<>(results.size());
-        
+
         for (SearchResult result : results) {
             // Append distance score to RowData
             GenericRowData rowWithDistance = new GenericRowData(rowType.getFieldCount() + 1);
             RowData originalRow = result.getRowData();
-            
+
             for (int i = 0; i < rowType.getFieldCount(); i++) {
                 rowWithDistance.setField(i, getFieldValue(originalRow, i));
             }
             rowWithDistance.setField(rowType.getFieldCount(), result.getDistance());
-            
+
             rowDataList.add(rowWithDistance);
         }
-        
+
         return rowDataList;
     }
 
@@ -243,12 +243,12 @@ public class LanceVectorSearch implements Closeable, Serializable {
         if (rowData.isNullAt(index)) {
             return null;
         }
-        
+
         // Simplified handling, should get based on field type in practice
         if (rowData instanceof GenericRowData) {
             return ((GenericRowData) rowData).getField(index);
         }
-        
+
         return null;
     }
 
@@ -259,7 +259,7 @@ public class LanceVectorSearch implements Closeable, Serializable {
         if (queryVector == null || queryVector.length == 0) {
             throw new IllegalArgumentException("Query vector cannot be empty");
         }
-        
+
         // Check for NaN or Infinity values
         for (float value : queryVector) {
             if (Float.isNaN(value) || Float.isInfinite(value)) {
@@ -294,7 +294,7 @@ public class LanceVectorSearch implements Closeable, Serializable {
             }
             dataset = null;
         }
-        
+
         if (allocator != null) {
             try {
                 allocator.close();

--- a/src/main/java/org/apache/flink/connector/lance/LanceVectorSearch.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceVectorSearch.java
@@ -19,11 +19,11 @@ import com.lancedb.lance.ipc.LanceScanner;
 import com.lancedb.lance.ipc.Query;
 import com.lancedb.lance.ipc.ScanOptions;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.flink.connector.lance.config.LanceDatasetFactory;
 import org.apache.flink.connector.lance.config.LanceOptions;
 import org.apache.flink.connector.lance.config.LanceOptions.MetricType;
 import org.apache.flink.connector.lance.converter.LanceTypeConverter;
@@ -89,10 +89,10 @@ public class LanceVectorSearch implements Closeable, Serializable {
   public void open() throws IOException {
     LOG.info("Opening vector search, dataset: {}", datasetPath);
 
-    this.allocator = new RootAllocator(Long.MAX_VALUE);
+    this.allocator = LanceDatasetFactory.createAllocator();
 
     try {
-      this.dataset = Dataset.open(datasetPath, allocator);
+      this.dataset = LanceDatasetFactory.open(datasetPath, allocator);
 
       // Get Schema and create converter
       Schema arrowSchema = dataset.getSchema();

--- a/src/main/java/org/apache/flink/connector/lance/LanceVectorSearch.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceVectorSearch.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,16 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance;
-
-import org.apache.flink.connector.lance.config.LanceOptions;
-import org.apache.flink.connector.lance.config.LanceOptions.MetricType;
-import org.apache.flink.connector.lance.converter.LanceTypeConverter;
-import org.apache.flink.connector.lance.converter.RowDataConverter;
-import org.apache.flink.table.data.GenericRowData;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.logical.RowType;
 
 import com.lancedb.lance.Dataset;
 import com.lancedb.lance.index.DistanceType;
@@ -37,6 +24,13 @@ import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.flink.connector.lance.config.LanceOptions;
+import org.apache.flink.connector.lance.config.LanceOptions.MetricType;
+import org.apache.flink.connector.lance.converter.LanceTypeConverter;
+import org.apache.flink.connector.lance.converter.RowDataConverter;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +47,7 @@ import java.util.Objects;
  * <p>Supports KNN search with L2, Cosine, and Dot distance metrics.
  *
  * <p>Usage example:
+ *
  * <pre>{@code
  * LanceVectorSearch search = LanceVectorSearch.builder()
  *     .datasetPath("/path/to/dataset")
@@ -66,385 +61,362 @@ import java.util.Objects;
  */
 public class LanceVectorSearch implements Closeable, Serializable {
 
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(LanceVectorSearch.class);
+
+  private final String datasetPath;
+  private final String columnName;
+  private final MetricType metricType;
+  private final int nprobes;
+  private final int ef;
+  private final Integer refineFactor;
+
+  private transient BufferAllocator allocator;
+  private transient Dataset dataset;
+  private transient RowType rowType;
+  private transient RowDataConverter converter;
+
+  private LanceVectorSearch(Builder builder) {
+    this.datasetPath = builder.datasetPath;
+    this.columnName = builder.columnName;
+    this.metricType = builder.metricType;
+    this.nprobes = builder.nprobes;
+    this.ef = builder.ef;
+    this.refineFactor = builder.refineFactor;
+  }
+
+  /** Open dataset connection */
+  public void open() throws IOException {
+    LOG.info("Opening vector search, dataset: {}", datasetPath);
+
+    this.allocator = new RootAllocator(Long.MAX_VALUE);
+
+    try {
+      this.dataset = Dataset.open(datasetPath, allocator);
+
+      // Get Schema and create converter
+      Schema arrowSchema = dataset.getSchema();
+      this.rowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
+      this.converter = new RowDataConverter(rowType);
+
+    } catch (Exception e) {
+      throw new IOException("Cannot open dataset: " + datasetPath, e);
+    }
+  }
+
+  /**
+   * Execute vector search
+   *
+   * @param queryVector Query vector
+   * @param k Number of nearest neighbors to return
+   * @return List of search results
+   */
+  public List<SearchResult> search(float[] queryVector, int k) throws IOException {
+    return search(queryVector, k, null);
+  }
+
+  /**
+   * Execute vector search (with filter condition)
+   *
+   * @param queryVector Query vector
+   * @param k Number of nearest neighbors to return
+   * @param filter Filter condition (SQL WHERE syntax)
+   * @return List of search results
+   */
+  public List<SearchResult> search(float[] queryVector, int k, String filter) throws IOException {
+    if (dataset == null) {
+      open();
+    }
+
+    LOG.debug("Executing vector search, k={}, vector dimension={}", k, queryVector.length);
+
+    // Validate query vector
+    validateQueryVector(queryVector);
+
+    List<SearchResult> results = new ArrayList<>();
+
+    try {
+      // Build vector query
+      Query.Builder queryBuilder =
+          new Query.Builder()
+              .setColumn(columnName)
+              .setKey(queryVector)
+              .setK(k)
+              .setNprobes(nprobes)
+              .setDistanceType(toDistanceType(metricType))
+              .setUseIndex(true);
+
+      if (ef > 0) {
+        queryBuilder.setEf(ef);
+      }
+
+      if (refineFactor != null && refineFactor > 0) {
+        queryBuilder.setRefineFactor(refineFactor);
+      }
+
+      Query query = queryBuilder.build();
+
+      // Build scan options
+      ScanOptions.Builder scanOptionsBuilder =
+          new ScanOptions.Builder().nearest(query).withRowId(true);
+
+      if (filter != null && !filter.isEmpty()) {
+        scanOptionsBuilder.filter(filter);
+      }
+
+      ScanOptions scanOptions = scanOptionsBuilder.build();
+
+      // Execute search
+      try (LanceScanner scanner = dataset.newScan(scanOptions)) {
+        try (ArrowReader reader = scanner.scanBatches()) {
+          while (reader.loadNextBatch()) {
+            VectorSchemaRoot root = reader.getVectorSchemaRoot();
+
+            // Convert to RowData
+            List<RowData> rows = converter.toRowDataList(root);
+
+            // Try to get distance score (if _distance column exists)
+            Float8Vector distanceVector = null;
+            try {
+              distanceVector = (Float8Vector) root.getVector("_distance");
+            } catch (Exception e) {
+              // _distance column may not exist
+            }
+
+            for (int i = 0; i < rows.size(); i++) {
+              double distance = 0.0;
+              if (distanceVector != null && !distanceVector.isNull(i)) {
+                distance = distanceVector.get(i);
+              }
+              results.add(new SearchResult(rows.get(i), distance));
+            }
+          }
+        }
+      }
+
+      LOG.debug("Search completed, returned {} results", results.size());
+      return results;
+
+    } catch (Exception e) {
+      throw new IOException("Vector search failed", e);
+    }
+  }
+
+  /**
+   * Execute vector search (return RowData list)
+   *
+   * @param queryVector Query vector
+   * @param k Number of nearest neighbors to return
+   * @return RowData list
+   */
+  public List<RowData> searchRowData(float[] queryVector, int k) throws IOException {
+    List<SearchResult> results = search(queryVector, k);
+    List<RowData> rowDataList = new ArrayList<>(results.size());
+
+    for (SearchResult result : results) {
+      // Append distance score to RowData
+      GenericRowData rowWithDistance = new GenericRowData(rowType.getFieldCount() + 1);
+      RowData originalRow = result.getRowData();
+
+      for (int i = 0; i < rowType.getFieldCount(); i++) {
+        rowWithDistance.setField(i, getFieldValue(originalRow, i));
+      }
+      rowWithDistance.setField(rowType.getFieldCount(), result.getDistance());
+
+      rowDataList.add(rowWithDistance);
+    }
+
+    return rowDataList;
+  }
+
+  /** Get field value from RowData */
+  private Object getFieldValue(RowData rowData, int index) {
+    if (rowData.isNullAt(index)) {
+      return null;
+    }
+
+    // Simplified handling, should get based on field type in practice
+    if (rowData instanceof GenericRowData) {
+      return ((GenericRowData) rowData).getField(index);
+    }
+
+    return null;
+  }
+
+  /** Validate query vector */
+  private void validateQueryVector(float[] queryVector) throws IOException {
+    if (queryVector == null || queryVector.length == 0) {
+      throw new IllegalArgumentException("Query vector cannot be empty");
+    }
+
+    // Check for NaN or Infinity values
+    for (float value : queryVector) {
+      if (Float.isNaN(value) || Float.isInfinite(value)) {
+        throw new IllegalArgumentException(
+            "Query vector contains invalid values (NaN or Infinity)");
+      }
+    }
+  }
+
+  /** Convert distance metric type */
+  private DistanceType toDistanceType(MetricType metricType) {
+    switch (metricType) {
+      case L2:
+        return DistanceType.L2;
+      case COSINE:
+        return DistanceType.Cosine;
+      case DOT:
+        return DistanceType.Dot;
+      default:
+        return DistanceType.L2;
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (dataset != null) {
+      try {
+        dataset.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close dataset", e);
+      }
+      dataset = null;
+    }
+
+    if (allocator != null) {
+      try {
+        allocator.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close allocator", e);
+      }
+      allocator = null;
+    }
+  }
+
+  /** Get RowType */
+  public RowType getRowType() {
+    return rowType;
+  }
+
+  /** Create builder */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Create vector searcher from LanceOptions */
+  public static LanceVectorSearch fromOptions(LanceOptions options) {
+    return builder()
+        .datasetPath(options.getPath())
+        .columnName(options.getVectorColumn())
+        .metricType(options.getVectorMetric())
+        .nprobes(options.getVectorNprobes())
+        .ef(options.getVectorEf())
+        .refineFactor(options.getVectorRefineFactor())
+        .build();
+  }
+
+  /** Builder */
+  public static class Builder {
+    private String datasetPath;
+    private String columnName;
+    private MetricType metricType = MetricType.L2;
+    private int nprobes = 20;
+    private int ef = 100;
+    private Integer refineFactor;
+
+    public Builder datasetPath(String datasetPath) {
+      this.datasetPath = datasetPath;
+      return this;
+    }
+
+    public Builder columnName(String columnName) {
+      this.columnName = columnName;
+      return this;
+    }
+
+    public Builder metricType(MetricType metricType) {
+      this.metricType = metricType;
+      return this;
+    }
+
+    public Builder nprobes(int nprobes) {
+      this.nprobes = nprobes;
+      return this;
+    }
+
+    public Builder ef(int ef) {
+      this.ef = ef;
+      return this;
+    }
+
+    public Builder refineFactor(Integer refineFactor) {
+      this.refineFactor = refineFactor;
+      return this;
+    }
+
+    public LanceVectorSearch build() {
+      validate();
+      return new LanceVectorSearch(this);
+    }
+
+    private void validate() {
+      if (datasetPath == null || datasetPath.isEmpty()) {
+        throw new IllegalArgumentException("Dataset path cannot be empty");
+      }
+      if (columnName == null || columnName.isEmpty()) {
+        throw new IllegalArgumentException("Column name cannot be empty");
+      }
+      if (nprobes <= 0) {
+        throw new IllegalArgumentException("nprobes must be greater than 0");
+      }
+    }
+  }
+
+  /** Search result */
+  public static class SearchResult implements Serializable {
     private static final long serialVersionUID = 1L;
-    private static final Logger LOG = LoggerFactory.getLogger(LanceVectorSearch.class);
 
-    private final String datasetPath;
-    private final String columnName;
-    private final MetricType metricType;
-    private final int nprobes;
-    private final int ef;
-    private final Integer refineFactor;
+    private final RowData rowData;
+    private final double distance;
 
-    private transient BufferAllocator allocator;
-    private transient Dataset dataset;
-    private transient RowType rowType;
-    private transient RowDataConverter converter;
-
-    private LanceVectorSearch(Builder builder) {
-        this.datasetPath = builder.datasetPath;
-        this.columnName = builder.columnName;
-        this.metricType = builder.metricType;
-        this.nprobes = builder.nprobes;
-        this.ef = builder.ef;
-        this.refineFactor = builder.refineFactor;
+    public SearchResult(RowData rowData, double distance) {
+      this.rowData = rowData;
+      this.distance = distance;
     }
 
-    /**
-     * Open dataset connection
-     */
-    public void open() throws IOException {
-        LOG.info("Opening vector search, dataset: {}", datasetPath);
-
-        this.allocator = new RootAllocator(Long.MAX_VALUE);
-
-        try {
-            this.dataset = Dataset.open(datasetPath, allocator);
-
-            // Get Schema and create converter
-            Schema arrowSchema = dataset.getSchema();
-            this.rowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
-            this.converter = new RowDataConverter(rowType);
-
-        } catch (Exception e) {
-            throw new IOException("Cannot open dataset: " + datasetPath, e);
-        }
+    public RowData getRowData() {
+      return rowData;
     }
 
-    /**
-     * Execute vector search
-     *
-     * @param queryVector Query vector
-     * @param k Number of nearest neighbors to return
-     * @return List of search results
-     */
-    public List<SearchResult> search(float[] queryVector, int k) throws IOException {
-        return search(queryVector, k, null);
+    public double getDistance() {
+      return distance;
     }
 
-    /**
-     * Execute vector search (with filter condition)
-     *
-     * @param queryVector Query vector
-     * @param k Number of nearest neighbors to return
-     * @param filter Filter condition (SQL WHERE syntax)
-     * @return List of search results
-     */
-    public List<SearchResult> search(float[] queryVector, int k, String filter) throws IOException {
-        if (dataset == null) {
-            open();
-        }
-
-        LOG.debug("Executing vector search, k={}, vector dimension={}", k, queryVector.length);
-
-        // Validate query vector
-        validateQueryVector(queryVector);
-
-        List<SearchResult> results = new ArrayList<>();
-
-        try {
-            // Build vector query
-            Query.Builder queryBuilder = new Query.Builder()
-                    .setColumn(columnName)
-                    .setKey(queryVector)
-                    .setK(k)
-                    .setNprobes(nprobes)
-                    .setDistanceType(toDistanceType(metricType))
-                    .setUseIndex(true);
-
-            if (ef > 0) {
-                queryBuilder.setEf(ef);
-            }
-
-            if (refineFactor != null && refineFactor > 0) {
-                queryBuilder.setRefineFactor(refineFactor);
-            }
-
-            Query query = queryBuilder.build();
-
-            // Build scan options
-            ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder()
-                    .nearest(query)
-                    .withRowId(true);
-
-            if (filter != null && !filter.isEmpty()) {
-                scanOptionsBuilder.filter(filter);
-            }
-
-            ScanOptions scanOptions = scanOptionsBuilder.build();
-
-            // Execute search
-            try (LanceScanner scanner = dataset.newScan(scanOptions)) {
-                try (ArrowReader reader = scanner.scanBatches()) {
-                    while (reader.loadNextBatch()) {
-                        VectorSchemaRoot root = reader.getVectorSchemaRoot();
-
-                        // Convert to RowData
-                        List<RowData> rows = converter.toRowDataList(root);
-
-                        // Try to get distance score (if _distance column exists)
-                        Float8Vector distanceVector = null;
-                        try {
-                            distanceVector = (Float8Vector) root.getVector("_distance");
-                        } catch (Exception e) {
-                            // _distance column may not exist
-                        }
-
-                        for (int i = 0; i < rows.size(); i++) {
-                            double distance = 0.0;
-                            if (distanceVector != null && !distanceVector.isNull(i)) {
-                                distance = distanceVector.get(i);
-                            }
-                            results.add(new SearchResult(rows.get(i), distance));
-                        }
-                    }
-                }
-            }
-
-            LOG.debug("Search completed, returned {} results", results.size());
-            return results;
-
-        } catch (Exception e) {
-            throw new IOException("Vector search failed", e);
-        }
-    }
-
-    /**
-     * Execute vector search (return RowData list)
-     *
-     * @param queryVector Query vector
-     * @param k Number of nearest neighbors to return
-     * @return RowData list
-     */
-    public List<RowData> searchRowData(float[] queryVector, int k) throws IOException {
-        List<SearchResult> results = search(queryVector, k);
-        List<RowData> rowDataList = new ArrayList<>(results.size());
-
-        for (SearchResult result : results) {
-            // Append distance score to RowData
-            GenericRowData rowWithDistance = new GenericRowData(rowType.getFieldCount() + 1);
-            RowData originalRow = result.getRowData();
-
-            for (int i = 0; i < rowType.getFieldCount(); i++) {
-                rowWithDistance.setField(i, getFieldValue(originalRow, i));
-            }
-            rowWithDistance.setField(rowType.getFieldCount(), result.getDistance());
-
-            rowDataList.add(rowWithDistance);
-        }
-
-        return rowDataList;
-    }
-
-    /**
-     * Get field value from RowData
-     */
-    private Object getFieldValue(RowData rowData, int index) {
-        if (rowData.isNullAt(index)) {
-            return null;
-        }
-
-        // Simplified handling, should get based on field type in practice
-        if (rowData instanceof GenericRowData) {
-            return ((GenericRowData) rowData).getField(index);
-        }
-
-        return null;
-    }
-
-    /**
-     * Validate query vector
-     */
-    private void validateQueryVector(float[] queryVector) throws IOException {
-        if (queryVector == null || queryVector.length == 0) {
-            throw new IllegalArgumentException("Query vector cannot be empty");
-        }
-
-        // Check for NaN or Infinity values
-        for (float value : queryVector) {
-            if (Float.isNaN(value) || Float.isInfinite(value)) {
-                throw new IllegalArgumentException("Query vector contains invalid values (NaN or Infinity)");
-            }
-        }
-    }
-
-    /**
-     * Convert distance metric type
-     */
-    private DistanceType toDistanceType(MetricType metricType) {
-        switch (metricType) {
-            case L2:
-                return DistanceType.L2;
-            case COSINE:
-                return DistanceType.Cosine;
-            case DOT:
-                return DistanceType.Dot;
-            default:
-                return DistanceType.L2;
-        }
+    /** Get similarity score (inverse or negative of distance, depending on distance type) */
+    public double getSimilarity() {
+      if (distance == 0) {
+        return 1.0;
+      }
+      // For L2 distance, use 1 / (1 + distance) as similarity
+      return 1.0 / (1.0 + distance);
     }
 
     @Override
-    public void close() throws IOException {
-        if (dataset != null) {
-            try {
-                dataset.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close dataset", e);
-            }
-            dataset = null;
-        }
-
-        if (allocator != null) {
-            try {
-                allocator.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close allocator", e);
-            }
-            allocator = null;
-        }
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      SearchResult that = (SearchResult) o;
+      return Double.compare(that.distance, distance) == 0 && Objects.equals(rowData, that.rowData);
     }
 
-    /**
-     * Get RowType
-     */
-    public RowType getRowType() {
-        return rowType;
+    @Override
+    public int hashCode() {
+      return Objects.hash(rowData, distance);
     }
 
-    /**
-     * Create builder
-     */
-    public static Builder builder() {
-        return new Builder();
+    @Override
+    public String toString() {
+      return "SearchResult{" + "rowData=" + rowData + ", distance=" + distance + '}';
     }
-
-    /**
-     * Create vector searcher from LanceOptions
-     */
-    public static LanceVectorSearch fromOptions(LanceOptions options) {
-        return builder()
-                .datasetPath(options.getPath())
-                .columnName(options.getVectorColumn())
-                .metricType(options.getVectorMetric())
-                .nprobes(options.getVectorNprobes())
-                .ef(options.getVectorEf())
-                .refineFactor(options.getVectorRefineFactor())
-                .build();
-    }
-
-    /**
-     * Builder
-     */
-    public static class Builder {
-        private String datasetPath;
-        private String columnName;
-        private MetricType metricType = MetricType.L2;
-        private int nprobes = 20;
-        private int ef = 100;
-        private Integer refineFactor;
-
-        public Builder datasetPath(String datasetPath) {
-            this.datasetPath = datasetPath;
-            return this;
-        }
-
-        public Builder columnName(String columnName) {
-            this.columnName = columnName;
-            return this;
-        }
-
-        public Builder metricType(MetricType metricType) {
-            this.metricType = metricType;
-            return this;
-        }
-
-        public Builder nprobes(int nprobes) {
-            this.nprobes = nprobes;
-            return this;
-        }
-
-        public Builder ef(int ef) {
-            this.ef = ef;
-            return this;
-        }
-
-        public Builder refineFactor(Integer refineFactor) {
-            this.refineFactor = refineFactor;
-            return this;
-        }
-
-        public LanceVectorSearch build() {
-            validate();
-            return new LanceVectorSearch(this);
-        }
-
-        private void validate() {
-            if (datasetPath == null || datasetPath.isEmpty()) {
-                throw new IllegalArgumentException("Dataset path cannot be empty");
-            }
-            if (columnName == null || columnName.isEmpty()) {
-                throw new IllegalArgumentException("Column name cannot be empty");
-            }
-            if (nprobes <= 0) {
-                throw new IllegalArgumentException("nprobes must be greater than 0");
-            }
-        }
-    }
-
-    /**
-     * Search result
-     */
-    public static class SearchResult implements Serializable {
-        private static final long serialVersionUID = 1L;
-
-        private final RowData rowData;
-        private final double distance;
-
-        public SearchResult(RowData rowData, double distance) {
-            this.rowData = rowData;
-            this.distance = distance;
-        }
-
-        public RowData getRowData() {
-            return rowData;
-        }
-
-        public double getDistance() {
-            return distance;
-        }
-
-        /**
-         * Get similarity score (inverse or negative of distance, depending on distance type)
-         */
-        public double getSimilarity() {
-            if (distance == 0) {
-                return 1.0;
-            }
-            // For L2 distance, use 1 / (1 + distance) as similarity
-            return 1.0 / (1.0 + distance);
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            SearchResult that = (SearchResult) o;
-            return Double.compare(that.distance, distance) == 0 &&
-                    Objects.equals(rowData, that.rowData);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(rowData, distance);
-        }
-
-        @Override
-        public String toString() {
-            return "SearchResult{" +
-                    "rowData=" + rowData +
-                    ", distance=" + distance +
-                    '}';
-        }
-    }
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/aggregate/AggregateExecutor.java
+++ b/src/main/java/org/apache/flink/connector/lance/aggregate/AggregateExecutor.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.aggregate;
 
 import org.apache.flink.table.data.DecimalData;
@@ -26,7 +21,6 @@ import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,518 +36,492 @@ import java.util.Set;
 /**
  * Aggregate executor.
  *
- * <p>Executes aggregate calculations at data source side,
- * supports COUNT, SUM, AVG, MIN, MAX and other aggregate functions.
+ * <p>Executes aggregate calculations at data source side, supports COUNT, SUM, AVG, MIN, MAX and
+ * other aggregate functions.
  */
 public class AggregateExecutor implements Serializable {
 
-    private static final long serialVersionUID = 1L;
-    private static final Logger LOG = LoggerFactory.getLogger(AggregateExecutor.class);
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(AggregateExecutor.class);
 
-    private final AggregateInfo aggregateInfo;
-    private final RowType sourceRowType;
+  private final AggregateInfo aggregateInfo;
+  private final RowType sourceRowType;
 
-    // Aggregate state (by group key)
-    private transient Map<GroupKey, AggregateState> aggregateStates;
-    private transient boolean initialized;
+  // Aggregate state (by group key)
+  private transient Map<GroupKey, AggregateState> aggregateStates;
+  private transient boolean initialized;
 
-    public AggregateExecutor(AggregateInfo aggregateInfo, RowType sourceRowType) {
-        this.aggregateInfo = aggregateInfo;
-        this.sourceRowType = sourceRowType;
+  public AggregateExecutor(AggregateInfo aggregateInfo, RowType sourceRowType) {
+    this.aggregateInfo = aggregateInfo;
+    this.sourceRowType = sourceRowType;
+  }
+
+  /** Initialize aggregate executor */
+  public void init() {
+    this.aggregateStates = new HashMap<>();
+    this.initialized = true;
+    LOG.info("Initialized aggregate executor: {}", aggregateInfo);
+  }
+
+  /** Accumulate a row to aggregate state */
+  public void accumulate(RowData row) {
+    if (!initialized) {
+      init();
     }
 
-    /**
-     * Initialize aggregate executor
-     */
-    public void init() {
-        this.aggregateStates = new HashMap<>();
-        this.initialized = true;
-        LOG.info("Initialized aggregate executor: {}", aggregateInfo);
+    // Extract group key
+    GroupKey groupKey = extractGroupKey(row);
+
+    // Get or create aggregate state
+    AggregateState state =
+        aggregateStates.computeIfAbsent(
+            groupKey, k -> new AggregateState(aggregateInfo.getAggregateCalls().size()));
+
+    // Update state for each aggregate function
+    List<AggregateInfo.AggregateCall> calls = aggregateInfo.getAggregateCalls();
+    for (int i = 0; i < calls.size(); i++) {
+      AggregateInfo.AggregateCall call = calls.get(i);
+      accumulateCall(state, i, call, row);
     }
+  }
 
-    /**
-     * Accumulate a row to aggregate state
-     */
-    public void accumulate(RowData row) {
-        if (!initialized) {
-            init();
+  /** Accumulate single aggregate function */
+  private void accumulateCall(
+      AggregateState state, int index, AggregateInfo.AggregateCall call, RowData row) {
+    switch (call.getFunction()) {
+      case COUNT:
+        if (call.isCountStar()) {
+          // COUNT(*)
+          state.incrementCount(index);
+        } else {
+          // COUNT(column) - only count non-NULL values
+          int fieldIndex = getFieldIndex(call.getColumn());
+          if (fieldIndex >= 0 && !row.isNullAt(fieldIndex)) {
+            state.incrementCount(index);
+          }
         }
+        break;
 
-        // Extract group key
-        GroupKey groupKey = extractGroupKey(row);
-
-        // Get or create aggregate state
-        AggregateState state = aggregateStates.computeIfAbsent(groupKey,
-                k -> new AggregateState(aggregateInfo.getAggregateCalls().size()));
-
-        // Update state for each aggregate function
-        List<AggregateInfo.AggregateCall> calls = aggregateInfo.getAggregateCalls();
-        for (int i = 0; i < calls.size(); i++) {
-            AggregateInfo.AggregateCall call = calls.get(i);
-            accumulateCall(state, i, call, row);
+      case COUNT_DISTINCT:
+        if (call.getColumn() != null) {
+          int fieldIndex = getFieldIndex(call.getColumn());
+          if (fieldIndex >= 0 && !row.isNullAt(fieldIndex)) {
+            Object value = extractValue(row, fieldIndex);
+            state.addDistinctValue(index, value);
+          }
         }
-    }
+        break;
 
-    /**
-     * Accumulate single aggregate function
-     */
-    private void accumulateCall(AggregateState state, int index,
-                                 AggregateInfo.AggregateCall call, RowData row) {
-        switch (call.getFunction()) {
-            case COUNT:
-                if (call.isCountStar()) {
-                    // COUNT(*)
-                    state.incrementCount(index);
-                } else {
-                    // COUNT(column) - only count non-NULL values
-                    int fieldIndex = getFieldIndex(call.getColumn());
-                    if (fieldIndex >= 0 && !row.isNullAt(fieldIndex)) {
-                        state.incrementCount(index);
-                    }
-                }
-                break;
-
-            case COUNT_DISTINCT:
-                if (call.getColumn() != null) {
-                    int fieldIndex = getFieldIndex(call.getColumn());
-                    if (fieldIndex >= 0 && !row.isNullAt(fieldIndex)) {
-                        Object value = extractValue(row, fieldIndex);
-                        state.addDistinctValue(index, value);
-                    }
-                }
-                break;
-
-            case SUM:
-                if (call.getColumn() != null) {
-                    int fieldIndex = getFieldIndex(call.getColumn());
-                    if (fieldIndex >= 0 && !row.isNullAt(fieldIndex)) {
-                        Number value = extractNumericValue(row, fieldIndex);
-                        if (value != null) {
-                            state.addSum(index, value.doubleValue());
-                        }
-                    }
-                }
-                break;
-
-            case AVG:
-                if (call.getColumn() != null) {
-                    int fieldIndex = getFieldIndex(call.getColumn());
-                    if (fieldIndex >= 0 && !row.isNullAt(fieldIndex)) {
-                        Number value = extractNumericValue(row, fieldIndex);
-                        if (value != null) {
-                            state.addForAvg(index, value.doubleValue());
-                        }
-                    }
-                }
-                break;
-
-            case MIN:
-                if (call.getColumn() != null) {
-                    int fieldIndex = getFieldIndex(call.getColumn());
-                    if (fieldIndex >= 0 && !row.isNullAt(fieldIndex)) {
-                        Comparable<?> value = extractComparableValue(row, fieldIndex);
-                        if (value != null) {
-                            state.updateMin(index, value);
-                        }
-                    }
-                }
-                break;
-
-            case MAX:
-                if (call.getColumn() != null) {
-                    int fieldIndex = getFieldIndex(call.getColumn());
-                    if (fieldIndex >= 0 && !row.isNullAt(fieldIndex)) {
-                        Comparable<?> value = extractComparableValue(row, fieldIndex);
-                        if (value != null) {
-                            state.updateMax(index, value);
-                        }
-                    }
-                }
-                break;
-        }
-    }
-
-    /**
-     * Get aggregate results
-     */
-    public List<RowData> getResults() {
-        if (!initialized || aggregateStates.isEmpty()) {
-            // If no data, return default aggregate result
-            return getDefaultResults();
-        }
-
-        List<RowData> results = new ArrayList<>();
-        List<AggregateInfo.AggregateCall> calls = aggregateInfo.getAggregateCalls();
-        List<String> groupByCols = aggregateInfo.getGroupByColumns();
-
-        for (Map.Entry<GroupKey, AggregateState> entry : aggregateStates.entrySet()) {
-            GroupKey groupKey = entry.getKey();
-            AggregateState state = entry.getValue();
-
-            // Create result row: group columns + aggregate columns
-            int totalFields = groupByCols.size() + calls.size();
-            GenericRowData resultRow = new GenericRowData(totalFields);
-
-            // Fill group columns
-            for (int i = 0; i < groupByCols.size(); i++) {
-                resultRow.setField(i, groupKey.getValues()[i]);
+      case SUM:
+        if (call.getColumn() != null) {
+          int fieldIndex = getFieldIndex(call.getColumn());
+          if (fieldIndex >= 0 && !row.isNullAt(fieldIndex)) {
+            Number value = extractNumericValue(row, fieldIndex);
+            if (value != null) {
+              state.addSum(index, value.doubleValue());
             }
+          }
+        }
+        break;
 
-            // Fill aggregate results
-            for (int i = 0; i < calls.size(); i++) {
-                AggregateInfo.AggregateCall call = calls.get(i);
-                Object aggResult = getAggregateResult(state, i, call);
-                resultRow.setField(groupByCols.size() + i, aggResult);
+      case AVG:
+        if (call.getColumn() != null) {
+          int fieldIndex = getFieldIndex(call.getColumn());
+          if (fieldIndex >= 0 && !row.isNullAt(fieldIndex)) {
+            Number value = extractNumericValue(row, fieldIndex);
+            if (value != null) {
+              state.addForAvg(index, value.doubleValue());
             }
-
-            results.add(resultRow);
+          }
         }
+        break;
 
-        LOG.info("Aggregate execution completed, generated {} result rows", results.size());
-        return results;
-    }
-
-    /**
-     * Get default aggregate result when no data
-     */
-    private List<RowData> getDefaultResults() {
-        // If has GROUP BY, no data means no result
-        if (aggregateInfo.hasGroupBy()) {
-            return new ArrayList<>();
-        }
-
-        // No GROUP BY, return default aggregate values
-        List<AggregateInfo.AggregateCall> calls = aggregateInfo.getAggregateCalls();
-        GenericRowData resultRow = new GenericRowData(calls.size());
-
-        for (int i = 0; i < calls.size(); i++) {
-            AggregateInfo.AggregateCall call = calls.get(i);
-            switch (call.getFunction()) {
-                case COUNT:
-                case COUNT_DISTINCT:
-                    resultRow.setField(i, 0L);
-                    break;
-                default:
-                    resultRow.setField(i, null);
-                    break;
+      case MIN:
+        if (call.getColumn() != null) {
+          int fieldIndex = getFieldIndex(call.getColumn());
+          if (fieldIndex >= 0 && !row.isNullAt(fieldIndex)) {
+            Comparable<?> value = extractComparableValue(row, fieldIndex);
+            if (value != null) {
+              state.updateMin(index, value);
             }
+          }
         }
+        break;
 
-        List<RowData> results = new ArrayList<>();
-        results.add(resultRow);
-        return results;
-    }
-
-    /**
-     * Get single aggregate function result
-     */
-    private Object getAggregateResult(AggregateState state, int index,
-                                       AggregateInfo.AggregateCall call) {
-        switch (call.getFunction()) {
-            case COUNT:
-                return state.getCount(index);
-            case COUNT_DISTINCT:
-                return (long) state.getDistinctCount(index);
-            case SUM:
-                Double sum = state.getSum(index);
-                return sum != null ? sum : null;
-            case AVG:
-                Double avg = state.getAvg(index);
-                return avg != null ? avg : null;
-            case MIN:
-                return state.getMin(index);
-            case MAX:
-                return state.getMax(index);
-            default:
-                return null;
-        }
-    }
-
-    /**
-     * Extract group key
-     */
-    private GroupKey extractGroupKey(RowData row) {
-        List<String> groupByCols = aggregateInfo.getGroupByColumns();
-        if (groupByCols.isEmpty()) {
-            return GroupKey.EMPTY;
-        }
-
-        Object[] keyValues = new Object[groupByCols.size()];
-        for (int i = 0; i < groupByCols.size(); i++) {
-            int fieldIndex = getFieldIndex(groupByCols.get(i));
-            if (fieldIndex >= 0) {
-                keyValues[i] = extractValue(row, fieldIndex);
+      case MAX:
+        if (call.getColumn() != null) {
+          int fieldIndex = getFieldIndex(call.getColumn());
+          if (fieldIndex >= 0 && !row.isNullAt(fieldIndex)) {
+            Comparable<?> value = extractComparableValue(row, fieldIndex);
+            if (value != null) {
+              state.updateMax(index, value);
             }
+          }
         }
-        return new GroupKey(keyValues);
+        break;
+    }
+  }
+
+  /** Get aggregate results */
+  public List<RowData> getResults() {
+    if (!initialized || aggregateStates.isEmpty()) {
+      // If no data, return default aggregate result
+      return getDefaultResults();
     }
 
-    /**
-     * Get field index
-     */
-    private int getFieldIndex(String columnName) {
-        List<String> fieldNames = sourceRowType.getFieldNames();
-        return fieldNames.indexOf(columnName);
+    List<RowData> results = new ArrayList<>();
+    List<AggregateInfo.AggregateCall> calls = aggregateInfo.getAggregateCalls();
+    List<String> groupByCols = aggregateInfo.getGroupByColumns();
+
+    for (Map.Entry<GroupKey, AggregateState> entry : aggregateStates.entrySet()) {
+      GroupKey groupKey = entry.getKey();
+      AggregateState state = entry.getValue();
+
+      // Create result row: group columns + aggregate columns
+      int totalFields = groupByCols.size() + calls.size();
+      GenericRowData resultRow = new GenericRowData(totalFields);
+
+      // Fill group columns
+      for (int i = 0; i < groupByCols.size(); i++) {
+        resultRow.setField(i, groupKey.getValues()[i]);
+      }
+
+      // Fill aggregate results
+      for (int i = 0; i < calls.size(); i++) {
+        AggregateInfo.AggregateCall call = calls.get(i);
+        Object aggResult = getAggregateResult(state, i, call);
+        resultRow.setField(groupByCols.size() + i, aggResult);
+      }
+
+      results.add(resultRow);
     }
 
-    /**
-     * Extract field value
-     */
-    private Object extractValue(RowData row, int fieldIndex) {
-        if (row.isNullAt(fieldIndex)) {
-            return null;
-        }
+    LOG.info("Aggregate execution completed, generated {} result rows", results.size());
+    return results;
+  }
 
-        LogicalType fieldType = sourceRowType.getTypeAt(fieldIndex);
-        switch (fieldType.getTypeRoot()) {
-            case BOOLEAN:
-                return row.getBoolean(fieldIndex);
-            case TINYINT:
-                return row.getByte(fieldIndex);
-            case SMALLINT:
-                return row.getShort(fieldIndex);
-            case INTEGER:
-                return row.getInt(fieldIndex);
-            case BIGINT:
-                return row.getLong(fieldIndex);
-            case FLOAT:
-                return row.getFloat(fieldIndex);
-            case DOUBLE:
-                return row.getDouble(fieldIndex);
-            case CHAR:
-            case VARCHAR:
-                // Keep StringData type for group key and result output
-                return row.getString(fieldIndex);
-            case DECIMAL:
-                DecimalType decType = (DecimalType) fieldType;
-                DecimalData decData = row.getDecimal(fieldIndex, decType.getPrecision(), decType.getScale());
-                return decData != null ? decData.toBigDecimal() : null;
-            default:
-                return null;
-        }
+  /** Get default aggregate result when no data */
+  private List<RowData> getDefaultResults() {
+    // If has GROUP BY, no data means no result
+    if (aggregateInfo.hasGroupBy()) {
+      return new ArrayList<>();
     }
 
-    /**
-     * Extract numeric type field value
-     */
-    private Number extractNumericValue(RowData row, int fieldIndex) {
-        if (row.isNullAt(fieldIndex)) {
-            return null;
-        }
+    // No GROUP BY, return default aggregate values
+    List<AggregateInfo.AggregateCall> calls = aggregateInfo.getAggregateCalls();
+    GenericRowData resultRow = new GenericRowData(calls.size());
 
-        LogicalType fieldType = sourceRowType.getTypeAt(fieldIndex);
-        switch (fieldType.getTypeRoot()) {
-            case TINYINT:
-                return row.getByte(fieldIndex);
-            case SMALLINT:
-                return row.getShort(fieldIndex);
-            case INTEGER:
-                return row.getInt(fieldIndex);
-            case BIGINT:
-                return row.getLong(fieldIndex);
-            case FLOAT:
-                return row.getFloat(fieldIndex);
-            case DOUBLE:
-                return row.getDouble(fieldIndex);
-            case DECIMAL:
-                DecimalType decType = (DecimalType) fieldType;
-                DecimalData decData = row.getDecimal(fieldIndex, decType.getPrecision(), decType.getScale());
-                return decData != null ? decData.toBigDecimal() : null;
-            default:
-                return null;
-        }
+    for (int i = 0; i < calls.size(); i++) {
+      AggregateInfo.AggregateCall call = calls.get(i);
+      switch (call.getFunction()) {
+        case COUNT:
+        case COUNT_DISTINCT:
+          resultRow.setField(i, 0L);
+          break;
+        default:
+          resultRow.setField(i, null);
+          break;
+      }
     }
 
-    /**
-     * Extract comparable type field value
-     */
-    @SuppressWarnings("unchecked")
-    private Comparable<?> extractComparableValue(RowData row, int fieldIndex) {
-        Object value = extractValue(row, fieldIndex);
-        if (value instanceof Comparable) {
-            return (Comparable<?>) value;
-        }
+    List<RowData> results = new ArrayList<>();
+    results.add(resultRow);
+    return results;
+  }
+
+  /** Get single aggregate function result */
+  private Object getAggregateResult(
+      AggregateState state, int index, AggregateInfo.AggregateCall call) {
+    switch (call.getFunction()) {
+      case COUNT:
+        return state.getCount(index);
+      case COUNT_DISTINCT:
+        return (long) state.getDistinctCount(index);
+      case SUM:
+        Double sum = state.getSum(index);
+        return sum != null ? sum : null;
+      case AVG:
+        Double avg = state.getAvg(index);
+        return avg != null ? avg : null;
+      case MIN:
+        return state.getMin(index);
+      case MAX:
+        return state.getMax(index);
+      default:
         return null;
     }
+  }
 
-    /**
-     * Reset aggregate state
-     */
-    public void reset() {
-        if (aggregateStates != null) {
-            aggregateStates.clear();
-        }
+  /** Extract group key */
+  private GroupKey extractGroupKey(RowData row) {
+    List<String> groupByCols = aggregateInfo.getGroupByColumns();
+    if (groupByCols.isEmpty()) {
+      return GroupKey.EMPTY;
     }
 
-    /**
-     * Group key
-     */
-    private static class GroupKey implements Serializable {
-        private static final long serialVersionUID = 1L;
+    Object[] keyValues = new Object[groupByCols.size()];
+    for (int i = 0; i < groupByCols.size(); i++) {
+      int fieldIndex = getFieldIndex(groupByCols.get(i));
+      if (fieldIndex >= 0) {
+        keyValues[i] = extractValue(row, fieldIndex);
+      }
+    }
+    return new GroupKey(keyValues);
+  }
 
-        static final GroupKey EMPTY = new GroupKey(new Object[0]);
+  /** Get field index */
+  private int getFieldIndex(String columnName) {
+    List<String> fieldNames = sourceRowType.getFieldNames();
+    return fieldNames.indexOf(columnName);
+  }
 
-        private final Object[] values;
-        private final int hashCode;
-
-        GroupKey(Object[] values) {
-            this.values = values;
-            this.hashCode = Objects.hash((Object[]) values);
-        }
-
-        Object[] getValues() {
-            return values;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            GroupKey groupKey = (GroupKey) o;
-            return java.util.Arrays.equals(values, groupKey.values);
-        }
-
-        @Override
-        public int hashCode() {
-            return hashCode;
-        }
+  /** Extract field value */
+  private Object extractValue(RowData row, int fieldIndex) {
+    if (row.isNullAt(fieldIndex)) {
+      return null;
     }
 
-    /**
-     * Aggregate state
-     */
-    private static class AggregateState implements Serializable {
-        private static final long serialVersionUID = 1L;
+    LogicalType fieldType = sourceRowType.getTypeAt(fieldIndex);
+    switch (fieldType.getTypeRoot()) {
+      case BOOLEAN:
+        return row.getBoolean(fieldIndex);
+      case TINYINT:
+        return row.getByte(fieldIndex);
+      case SMALLINT:
+        return row.getShort(fieldIndex);
+      case INTEGER:
+        return row.getInt(fieldIndex);
+      case BIGINT:
+        return row.getLong(fieldIndex);
+      case FLOAT:
+        return row.getFloat(fieldIndex);
+      case DOUBLE:
+        return row.getDouble(fieldIndex);
+      case CHAR:
+      case VARCHAR:
+        // Keep StringData type for group key and result output
+        return row.getString(fieldIndex);
+      case DECIMAL:
+        DecimalType decType = (DecimalType) fieldType;
+        DecimalData decData =
+            row.getDecimal(fieldIndex, decType.getPrecision(), decType.getScale());
+        return decData != null ? decData.toBigDecimal() : null;
+      default:
+        return null;
+    }
+  }
 
-        private final long[] counts;
-        private final double[] sums;
-        private final long[] avgCounts;  // For calculating AVG
-        private final Comparable<?>[] mins;
-        private final Comparable<?>[] maxs;
-        private final Set<Object>[] distinctSets;
-
-        @SuppressWarnings("unchecked")
-        AggregateState(int numAggregates) {
-            this.counts = new long[numAggregates];
-            this.sums = new double[numAggregates];
-            this.avgCounts = new long[numAggregates];
-            this.mins = new Comparable<?>[numAggregates];
-            this.maxs = new Comparable<?>[numAggregates];
-            this.distinctSets = new Set[numAggregates];
-        }
-
-        void incrementCount(int index) {
-            counts[index]++;
-        }
-
-        long getCount(int index) {
-            return counts[index];
-        }
-
-        void addDistinctValue(int index, Object value) {
-            if (distinctSets[index] == null) {
-                distinctSets[index] = new HashSet<>();
-            }
-            distinctSets[index].add(value);
-        }
-
-        int getDistinctCount(int index) {
-            return distinctSets[index] != null ? distinctSets[index].size() : 0;
-        }
-
-        void addSum(int index, double value) {
-            sums[index] += value;
-            counts[index]++;  // Mark as has value
-        }
-
-        Double getSum(int index) {
-            return counts[index] > 0 ? sums[index] : null;
-        }
-
-        void addForAvg(int index, double value) {
-            sums[index] += value;
-            avgCounts[index]++;
-        }
-
-        Double getAvg(int index) {
-            return avgCounts[index] > 0 ? sums[index] / avgCounts[index] : null;
-        }
-
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        void updateMin(int index, Comparable<?> value) {
-            if (mins[index] == null || ((Comparable) value).compareTo(mins[index]) < 0) {
-                mins[index] = value;
-            }
-        }
-
-        Comparable<?> getMin(int index) {
-            return mins[index];
-        }
-
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        void updateMax(int index, Comparable<?> value) {
-            if (maxs[index] == null || ((Comparable) value).compareTo(maxs[index]) > 0) {
-                maxs[index] = value;
-            }
-        }
-
-        Comparable<?> getMax(int index) {
-            return maxs[index];
-        }
+  /** Extract numeric type field value */
+  private Number extractNumericValue(RowData row, int fieldIndex) {
+    if (row.isNullAt(fieldIndex)) {
+      return null;
     }
 
-    /**
-     * Build aggregate result RowType
-     */
-    public RowType buildResultRowType() {
-        List<String> groupByCols = aggregateInfo.getGroupByColumns();
-        List<AggregateInfo.AggregateCall> calls = aggregateInfo.getAggregateCalls();
+    LogicalType fieldType = sourceRowType.getTypeAt(fieldIndex);
+    switch (fieldType.getTypeRoot()) {
+      case TINYINT:
+        return row.getByte(fieldIndex);
+      case SMALLINT:
+        return row.getShort(fieldIndex);
+      case INTEGER:
+        return row.getInt(fieldIndex);
+      case BIGINT:
+        return row.getLong(fieldIndex);
+      case FLOAT:
+        return row.getFloat(fieldIndex);
+      case DOUBLE:
+        return row.getDouble(fieldIndex);
+      case DECIMAL:
+        DecimalType decType = (DecimalType) fieldType;
+        DecimalData decData =
+            row.getDecimal(fieldIndex, decType.getPrecision(), decType.getScale());
+        return decData != null ? decData.toBigDecimal() : null;
+      default:
+        return null;
+    }
+  }
 
-        List<RowType.RowField> fields = new ArrayList<>();
+  /** Extract comparable type field value */
+  @SuppressWarnings("unchecked")
+  private Comparable<?> extractComparableValue(RowData row, int fieldIndex) {
+    Object value = extractValue(row, fieldIndex);
+    if (value instanceof Comparable) {
+      return (Comparable<?>) value;
+    }
+    return null;
+  }
 
-        // Group columns
-        for (String col : groupByCols) {
-            int fieldIndex = getFieldIndex(col);
-            if (fieldIndex >= 0) {
-                LogicalType fieldType = sourceRowType.getTypeAt(fieldIndex);
-                fields.add(new RowType.RowField(col, fieldType));
-            }
-        }
+  /** Reset aggregate state */
+  public void reset() {
+    if (aggregateStates != null) {
+      aggregateStates.clear();
+    }
+  }
 
-        // Aggregate result columns
-        for (AggregateInfo.AggregateCall call : calls) {
-            String alias = call.getAlias() != null ? call.getAlias() :
-                    call.getFunction().name().toLowerCase() + "_" +
-                    (call.getColumn() != null ? call.getColumn() : "star");
-            LogicalType resultType = getAggregateResultType(call);
-            fields.add(new RowType.RowField(alias, resultType));
-        }
+  /** Group key */
+  private static class GroupKey implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-        return new RowType(fields);
+    static final GroupKey EMPTY = new GroupKey(new Object[0]);
+
+    private final Object[] values;
+    private final int hashCode;
+
+    GroupKey(Object[] values) {
+      this.values = values;
+      this.hashCode = Objects.hash((Object[]) values);
     }
 
-    /**
-     * Get aggregate function result type
-     */
-    private LogicalType getAggregateResultType(AggregateInfo.AggregateCall call) {
-        switch (call.getFunction()) {
-            case COUNT:
-            case COUNT_DISTINCT:
-                return new BigIntType();
-            case SUM:
-            case AVG:
-                return new DoubleType();
-            case MIN:
-            case MAX:
-                if (call.getColumn() != null) {
-                    int fieldIndex = getFieldIndex(call.getColumn());
-                    if (fieldIndex >= 0) {
-                        return sourceRowType.getTypeAt(fieldIndex);
-                    }
-                }
-                return new DoubleType();
-            default:
-                return new DoubleType();
-        }
+    Object[] getValues() {
+      return values;
     }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      GroupKey groupKey = (GroupKey) o;
+      return java.util.Arrays.equals(values, groupKey.values);
+    }
+
+    @Override
+    public int hashCode() {
+      return hashCode;
+    }
+  }
+
+  /** Aggregate state */
+  private static class AggregateState implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final long[] counts;
+    private final double[] sums;
+    private final long[] avgCounts; // For calculating AVG
+    private final Comparable<?>[] mins;
+    private final Comparable<?>[] maxs;
+    private final Set<Object>[] distinctSets;
+
+    @SuppressWarnings("unchecked")
+    AggregateState(int numAggregates) {
+      this.counts = new long[numAggregates];
+      this.sums = new double[numAggregates];
+      this.avgCounts = new long[numAggregates];
+      this.mins = new Comparable<?>[numAggregates];
+      this.maxs = new Comparable<?>[numAggregates];
+      this.distinctSets = new Set[numAggregates];
+    }
+
+    void incrementCount(int index) {
+      counts[index]++;
+    }
+
+    long getCount(int index) {
+      return counts[index];
+    }
+
+    void addDistinctValue(int index, Object value) {
+      if (distinctSets[index] == null) {
+        distinctSets[index] = new HashSet<>();
+      }
+      distinctSets[index].add(value);
+    }
+
+    int getDistinctCount(int index) {
+      return distinctSets[index] != null ? distinctSets[index].size() : 0;
+    }
+
+    void addSum(int index, double value) {
+      sums[index] += value;
+      counts[index]++; // Mark as has value
+    }
+
+    Double getSum(int index) {
+      return counts[index] > 0 ? sums[index] : null;
+    }
+
+    void addForAvg(int index, double value) {
+      sums[index] += value;
+      avgCounts[index]++;
+    }
+
+    Double getAvg(int index) {
+      return avgCounts[index] > 0 ? sums[index] / avgCounts[index] : null;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void updateMin(int index, Comparable<?> value) {
+      if (mins[index] == null || ((Comparable) value).compareTo(mins[index]) < 0) {
+        mins[index] = value;
+      }
+    }
+
+    Comparable<?> getMin(int index) {
+      return mins[index];
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    void updateMax(int index, Comparable<?> value) {
+      if (maxs[index] == null || ((Comparable) value).compareTo(maxs[index]) > 0) {
+        maxs[index] = value;
+      }
+    }
+
+    Comparable<?> getMax(int index) {
+      return maxs[index];
+    }
+  }
+
+  /** Build aggregate result RowType */
+  public RowType buildResultRowType() {
+    List<String> groupByCols = aggregateInfo.getGroupByColumns();
+    List<AggregateInfo.AggregateCall> calls = aggregateInfo.getAggregateCalls();
+
+    List<RowType.RowField> fields = new ArrayList<>();
+
+    // Group columns
+    for (String col : groupByCols) {
+      int fieldIndex = getFieldIndex(col);
+      if (fieldIndex >= 0) {
+        LogicalType fieldType = sourceRowType.getTypeAt(fieldIndex);
+        fields.add(new RowType.RowField(col, fieldType));
+      }
+    }
+
+    // Aggregate result columns
+    for (AggregateInfo.AggregateCall call : calls) {
+      String alias =
+          call.getAlias() != null
+              ? call.getAlias()
+              : call.getFunction().name().toLowerCase()
+                  + "_"
+                  + (call.getColumn() != null ? call.getColumn() : "star");
+      LogicalType resultType = getAggregateResultType(call);
+      fields.add(new RowType.RowField(alias, resultType));
+    }
+
+    return new RowType(fields);
+  }
+
+  /** Get aggregate function result type */
+  private LogicalType getAggregateResultType(AggregateInfo.AggregateCall call) {
+    switch (call.getFunction()) {
+      case COUNT:
+      case COUNT_DISTINCT:
+        return new BigIntType();
+      case SUM:
+      case AVG:
+        return new DoubleType();
+      case MIN:
+      case MAX:
+        if (call.getColumn() != null) {
+          int fieldIndex = getFieldIndex(call.getColumn());
+          if (fieldIndex >= 0) {
+            return sourceRowType.getTypeAt(fieldIndex);
+          }
+        }
+        return new DoubleType();
+      default:
+        return new DoubleType();
+    }
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/aggregate/AggregateExecutor.java
+++ b/src/main/java/org/apache/flink/connector/lance/aggregate/AggregateExecutor.java
@@ -41,8 +41,9 @@ import java.util.Set;
 
 /**
  * Aggregate executor.
- * 
- * <p>Executes aggregate calculations at data source side, supports COUNT, SUM, AVG, MIN, MAX and other aggregate functions.
+ *
+ * <p>Executes aggregate calculations at data source side,
+ * supports COUNT, SUM, AVG, MIN, MAX and other aggregate functions.
  */
 public class AggregateExecutor implements Serializable {
 
@@ -80,9 +81,9 @@ public class AggregateExecutor implements Serializable {
 
         // Extract group key
         GroupKey groupKey = extractGroupKey(row);
-        
+
         // Get or create aggregate state
-        AggregateState state = aggregateStates.computeIfAbsent(groupKey, 
+        AggregateState state = aggregateStates.computeIfAbsent(groupKey,
                 k -> new AggregateState(aggregateInfo.getAggregateCalls().size()));
 
         // Update state for each aggregate function
@@ -96,7 +97,7 @@ public class AggregateExecutor implements Serializable {
     /**
      * Accumulate single aggregate function
      */
-    private void accumulateCall(AggregateState state, int index, 
+    private void accumulateCall(AggregateState state, int index,
                                  AggregateInfo.AggregateCall call, RowData row) {
         switch (call.getFunction()) {
             case COUNT:
@@ -246,7 +247,7 @@ public class AggregateExecutor implements Serializable {
     /**
      * Get single aggregate function result
      */
-    private Object getAggregateResult(AggregateState state, int index, 
+    private Object getAggregateResult(AggregateState state, int index,
                                        AggregateInfo.AggregateCall call) {
         switch (call.getFunction()) {
             case COUNT:
@@ -389,7 +390,7 @@ public class AggregateExecutor implements Serializable {
      */
     private static class GroupKey implements Serializable {
         private static final long serialVersionUID = 1L;
-        
+
         static final GroupKey EMPTY = new GroupKey(new Object[0]);
 
         private final Object[] values;
@@ -521,8 +522,8 @@ public class AggregateExecutor implements Serializable {
 
         // Aggregate result columns
         for (AggregateInfo.AggregateCall call : calls) {
-            String alias = call.getAlias() != null ? call.getAlias() : 
-                    call.getFunction().name().toLowerCase() + "_" + 
+            String alias = call.getAlias() != null ? call.getAlias() :
+                    call.getFunction().name().toLowerCase() + "_" +
                     (call.getColumn() != null ? call.getColumn() : "star");
             LogicalType resultType = getAggregateResultType(call);
             fields.add(new RowType.RowField(alias, resultType));

--- a/src/main/java/org/apache/flink/connector/lance/aggregate/AggregateInfo.java
+++ b/src/main/java/org/apache/flink/connector/lance/aggregate/AggregateInfo.java
@@ -26,8 +26,9 @@ import java.util.Objects;
 
 /**
  * Aggregate information encapsulation class.
- * 
- * <p>Encapsulates information needed for aggregate push-down, including aggregate functions, target columns and group by columns.
+ *
+ * <p>Encapsulates information needed for aggregate push-down, including aggregate functions,
+ * target columns and group by columns.
  */
 public class AggregateInfo implements Serializable {
 
@@ -91,8 +92,8 @@ public class AggregateInfo implements Serializable {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             AggregateCall that = (AggregateCall) o;
-            return function == that.function && 
-                   Objects.equals(column, that.column) && 
+            return function == that.function &&
+                   Objects.equals(column, that.column) &&
                    Objects.equals(alias, that.alias);
         }
 
@@ -117,7 +118,7 @@ public class AggregateInfo implements Serializable {
     private AggregateInfo(Builder builder) {
         this.aggregateCalls = Collections.unmodifiableList(new ArrayList<>(builder.aggregateCalls));
         this.groupByColumns = Collections.unmodifiableList(new ArrayList<>(builder.groupByColumns));
-        this.groupByFieldIndices = builder.groupByFieldIndices != null ? 
+        this.groupByFieldIndices = builder.groupByFieldIndices != null ?
                 builder.groupByFieldIndices.clone() : new int[0];
     }
 
@@ -144,8 +145,8 @@ public class AggregateInfo implements Serializable {
      * Whether is simple COUNT(*) query (no group by)
      */
     public boolean isSimpleCountStar() {
-        return aggregateCalls.size() == 1 && 
-               aggregateCalls.get(0).isCountStar() && 
+        return aggregateCalls.size() == 1 &&
+               aggregateCalls.get(0).isCountStar() &&
                !hasGroupBy();
     }
 
@@ -167,7 +168,7 @@ public class AggregateInfo implements Serializable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         AggregateInfo that = (AggregateInfo) o;
-        return Objects.equals(aggregateCalls, that.aggregateCalls) && 
+        return Objects.equals(aggregateCalls, that.aggregateCalls) &&
                Objects.equals(groupByColumns, that.groupByColumns);
     }
 

--- a/src/main/java/org/apache/flink/connector/lance/aggregate/AggregateInfo.java
+++ b/src/main/java/org/apache/flink/connector/lance/aggregate/AggregateInfo.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.aggregate;
 
 import java.io.Serializable;
@@ -27,233 +22,217 @@ import java.util.Objects;
 /**
  * Aggregate information encapsulation class.
  *
- * <p>Encapsulates information needed for aggregate push-down, including aggregate functions,
- * target columns and group by columns.
+ * <p>Encapsulates information needed for aggregate push-down, including aggregate functions, target
+ * columns and group by columns.
  */
 public class AggregateInfo implements Serializable {
 
+  private static final long serialVersionUID = 1L;
+
+  /** Supported aggregate function types */
+  public enum AggregateFunction {
+    /** COUNT(*) or COUNT(column) */
+    COUNT,
+    /** COUNT(DISTINCT column) */
+    COUNT_DISTINCT,
+    /** SUM(column) */
+    SUM,
+    /** AVG(column) */
+    AVG,
+    /** MIN(column) */
+    MIN,
+    /** MAX(column) */
+    MAX
+  }
+
+  /** Single aggregate call information */
+  public static class AggregateCall implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    /**
-     * Supported aggregate function types
-     */
-    public enum AggregateFunction {
-        /** COUNT(*) or COUNT(column) */
-        COUNT,
-        /** COUNT(DISTINCT column) */
-        COUNT_DISTINCT,
-        /** SUM(column) */
-        SUM,
-        /** AVG(column) */
-        AVG,
-        /** MIN(column) */
-        MIN,
-        /** MAX(column) */
-        MAX
+    private final AggregateFunction function;
+    private final String column; // null means COUNT(*)
+    private final String alias; // alias for aggregate result
+
+    public AggregateCall(AggregateFunction function, String column, String alias) {
+      this.function = function;
+      this.column = column;
+      this.alias = alias;
     }
 
-    /**
-     * Single aggregate call information
-     */
-    public static class AggregateCall implements Serializable {
-        private static final long serialVersionUID = 1L;
-
-        private final AggregateFunction function;
-        private final String column;  // null means COUNT(*)
-        private final String alias;   // alias for aggregate result
-
-        public AggregateCall(AggregateFunction function, String column, String alias) {
-            this.function = function;
-            this.column = column;
-            this.alias = alias;
-        }
-
-        public AggregateFunction getFunction() {
-            return function;
-        }
-
-        public String getColumn() {
-            return column;
-        }
-
-        public String getAlias() {
-            return alias;
-        }
-
-        /**
-         * Whether is COUNT(*)
-         */
-        public boolean isCountStar() {
-            return function == AggregateFunction.COUNT && column == null;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            AggregateCall that = (AggregateCall) o;
-            return function == that.function &&
-                   Objects.equals(column, that.column) &&
-                   Objects.equals(alias, that.alias);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(function, column, alias);
-        }
-
-        @Override
-        public String toString() {
-            if (isCountStar()) {
-                return "COUNT(*)";
-            }
-            return function.name() + "(" + column + ")";
-        }
+    public AggregateFunction getFunction() {
+      return function;
     }
 
-    private final List<AggregateCall> aggregateCalls;
-    private final List<String> groupByColumns;
-    private final int[] groupByFieldIndices;
-
-    private AggregateInfo(Builder builder) {
-        this.aggregateCalls = Collections.unmodifiableList(new ArrayList<>(builder.aggregateCalls));
-        this.groupByColumns = Collections.unmodifiableList(new ArrayList<>(builder.groupByColumns));
-        this.groupByFieldIndices = builder.groupByFieldIndices != null ?
-                builder.groupByFieldIndices.clone() : new int[0];
+    public String getColumn() {
+      return column;
     }
 
-    public List<AggregateCall> getAggregateCalls() {
-        return aggregateCalls;
+    public String getAlias() {
+      return alias;
     }
 
-    public List<String> getGroupByColumns() {
-        return groupByColumns;
-    }
-
-    public int[] getGroupByFieldIndices() {
-        return groupByFieldIndices;
-    }
-
-    /**
-     * Whether has group by
-     */
-    public boolean hasGroupBy() {
-        return !groupByColumns.isEmpty();
-    }
-
-    /**
-     * Whether is simple COUNT(*) query (no group by)
-     */
-    public boolean isSimpleCountStar() {
-        return aggregateCalls.size() == 1 &&
-               aggregateCalls.get(0).isCountStar() &&
-               !hasGroupBy();
-    }
-
-    /**
-     * Get all required columns (aggregate columns + group by columns)
-     */
-    public List<String> getRequiredColumns() {
-        List<String> columns = new ArrayList<>(groupByColumns);
-        for (AggregateCall call : aggregateCalls) {
-            if (call.getColumn() != null && !columns.contains(call.getColumn())) {
-                columns.add(call.getColumn());
-            }
-        }
-        return columns;
+    /** Whether is COUNT(*) */
+    public boolean isCountStar() {
+      return function == AggregateFunction.COUNT && column == null;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        AggregateInfo that = (AggregateInfo) o;
-        return Objects.equals(aggregateCalls, that.aggregateCalls) &&
-               Objects.equals(groupByColumns, that.groupByColumns);
+      if (this == o) return true;
+      if (o == null || getClass() != o.getClass()) return false;
+      AggregateCall that = (AggregateCall) o;
+      return function == that.function
+          && Objects.equals(column, that.column)
+          && Objects.equals(alias, that.alias);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(aggregateCalls, groupByColumns);
+      return Objects.hash(function, column, alias);
     }
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder("AggregateInfo{");
-        sb.append("aggregates=").append(aggregateCalls);
-        if (hasGroupBy()) {
-            sb.append(", groupBy=").append(groupByColumns);
-        }
-        sb.append("}");
-        return sb.toString();
+      if (isCountStar()) {
+        return "COUNT(*)";
+      }
+      return function.name() + "(" + column + ")";
+    }
+  }
+
+  private final List<AggregateCall> aggregateCalls;
+  private final List<String> groupByColumns;
+  private final int[] groupByFieldIndices;
+
+  private AggregateInfo(Builder builder) {
+    this.aggregateCalls = Collections.unmodifiableList(new ArrayList<>(builder.aggregateCalls));
+    this.groupByColumns = Collections.unmodifiableList(new ArrayList<>(builder.groupByColumns));
+    this.groupByFieldIndices =
+        builder.groupByFieldIndices != null ? builder.groupByFieldIndices.clone() : new int[0];
+  }
+
+  public List<AggregateCall> getAggregateCalls() {
+    return aggregateCalls;
+  }
+
+  public List<String> getGroupByColumns() {
+    return groupByColumns;
+  }
+
+  public int[] getGroupByFieldIndices() {
+    return groupByFieldIndices;
+  }
+
+  /** Whether has group by */
+  public boolean hasGroupBy() {
+    return !groupByColumns.isEmpty();
+  }
+
+  /** Whether is simple COUNT(*) query (no group by) */
+  public boolean isSimpleCountStar() {
+    return aggregateCalls.size() == 1 && aggregateCalls.get(0).isCountStar() && !hasGroupBy();
+  }
+
+  /** Get all required columns (aggregate columns + group by columns) */
+  public List<String> getRequiredColumns() {
+    List<String> columns = new ArrayList<>(groupByColumns);
+    for (AggregateCall call : aggregateCalls) {
+      if (call.getColumn() != null && !columns.contains(call.getColumn())) {
+        columns.add(call.getColumn());
+      }
+    }
+    return columns;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    AggregateInfo that = (AggregateInfo) o;
+    return Objects.equals(aggregateCalls, that.aggregateCalls)
+        && Objects.equals(groupByColumns, that.groupByColumns);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(aggregateCalls, groupByColumns);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder("AggregateInfo{");
+    sb.append("aggregates=").append(aggregateCalls);
+    if (hasGroupBy()) {
+      sb.append(", groupBy=").append(groupByColumns);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** AggregateInfo builder */
+  public static class Builder {
+    private final List<AggregateCall> aggregateCalls = new ArrayList<>();
+    private final List<String> groupByColumns = new ArrayList<>();
+    private int[] groupByFieldIndices;
+
+    public Builder addAggregateCall(AggregateFunction function, String column, String alias) {
+      aggregateCalls.add(new AggregateCall(function, column, alias));
+      return this;
     }
 
-    public static Builder builder() {
-        return new Builder();
+    public Builder addAggregateCall(AggregateCall call) {
+      aggregateCalls.add(call);
+      return this;
     }
 
-    /**
-     * AggregateInfo builder
-     */
-    public static class Builder {
-        private final List<AggregateCall> aggregateCalls = new ArrayList<>();
-        private final List<String> groupByColumns = new ArrayList<>();
-        private int[] groupByFieldIndices;
-
-        public Builder addAggregateCall(AggregateFunction function, String column, String alias) {
-            aggregateCalls.add(new AggregateCall(function, column, alias));
-            return this;
-        }
-
-        public Builder addAggregateCall(AggregateCall call) {
-            aggregateCalls.add(call);
-            return this;
-        }
-
-        public Builder addCountStar(String alias) {
-            return addAggregateCall(AggregateFunction.COUNT, null, alias);
-        }
-
-        public Builder addCount(String column, String alias) {
-            return addAggregateCall(AggregateFunction.COUNT, column, alias);
-        }
-
-        public Builder addSum(String column, String alias) {
-            return addAggregateCall(AggregateFunction.SUM, column, alias);
-        }
-
-        public Builder addAvg(String column, String alias) {
-            return addAggregateCall(AggregateFunction.AVG, column, alias);
-        }
-
-        public Builder addMin(String column, String alias) {
-            return addAggregateCall(AggregateFunction.MIN, column, alias);
-        }
-
-        public Builder addMax(String column, String alias) {
-            return addAggregateCall(AggregateFunction.MAX, column, alias);
-        }
-
-        public Builder groupBy(List<String> columns) {
-            this.groupByColumns.addAll(columns);
-            return this;
-        }
-
-        public Builder groupBy(String... columns) {
-            Collections.addAll(this.groupByColumns, columns);
-            return this;
-        }
-
-        public Builder groupByFieldIndices(int[] indices) {
-            this.groupByFieldIndices = indices;
-            return this;
-        }
-
-        public AggregateInfo build() {
-            if (aggregateCalls.isEmpty()) {
-                throw new IllegalArgumentException("At least one aggregate function is required");
-            }
-            return new AggregateInfo(this);
-        }
+    public Builder addCountStar(String alias) {
+      return addAggregateCall(AggregateFunction.COUNT, null, alias);
     }
+
+    public Builder addCount(String column, String alias) {
+      return addAggregateCall(AggregateFunction.COUNT, column, alias);
+    }
+
+    public Builder addSum(String column, String alias) {
+      return addAggregateCall(AggregateFunction.SUM, column, alias);
+    }
+
+    public Builder addAvg(String column, String alias) {
+      return addAggregateCall(AggregateFunction.AVG, column, alias);
+    }
+
+    public Builder addMin(String column, String alias) {
+      return addAggregateCall(AggregateFunction.MIN, column, alias);
+    }
+
+    public Builder addMax(String column, String alias) {
+      return addAggregateCall(AggregateFunction.MAX, column, alias);
+    }
+
+    public Builder groupBy(List<String> columns) {
+      this.groupByColumns.addAll(columns);
+      return this;
+    }
+
+    public Builder groupBy(String... columns) {
+      Collections.addAll(this.groupByColumns, columns);
+      return this;
+    }
+
+    public Builder groupByFieldIndices(int[] indices) {
+      this.groupByFieldIndices = indices;
+      return this;
+    }
+
+    public AggregateInfo build() {
+      if (aggregateCalls.isEmpty()) {
+        throw new IllegalArgumentException("At least one aggregate function is required");
+      }
+      return new AggregateInfo(this);
+    }
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/catalog/LanceCatalogPathResolver.java
+++ b/src/main/java/org/apache/flink/connector/lance/catalog/LanceCatalogPathResolver.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.catalog;
+
+import java.io.Serializable;
+
+/**
+ * Resolves and manages warehouse paths for Lance Catalog.
+ *
+ * <p>Handles path normalization, database/table path construction, and remote storage detection.
+ * Supports local filesystem paths and S3/GCS/Azure remote storage URIs.
+ *
+ * <p>This class is immutable and thread-safe.
+ */
+public final class LanceCatalogPathResolver implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String warehouse;
+  private final boolean remote;
+
+  /**
+   * Create a path resolver for the given warehouse.
+   *
+   * @param warehouse Warehouse root path (local or remote URI)
+   */
+  public LanceCatalogPathResolver(String warehouse) {
+    this.warehouse = normalize(warehouse);
+    this.remote = detectRemote(warehouse);
+  }
+
+  /** Get the normalized warehouse path. */
+  public String getWarehouse() {
+    return warehouse;
+  }
+
+  /** Whether the warehouse uses remote storage (S3, GCS, Azure, etc.). */
+  public boolean isRemote() {
+    return remote;
+  }
+
+  /**
+   * Resolve database path under the warehouse.
+   *
+   * @param databaseName Database name
+   * @return Full path to the database directory
+   */
+  public String resolveDatabasePath(String databaseName) {
+    return warehouse + "/" + databaseName;
+  }
+
+  /**
+   * Resolve dataset (table) path under the warehouse.
+   *
+   * @param databaseName Database name
+   * @param tableName Table name
+   * @return Full path to the dataset
+   */
+  public String resolveTablePath(String databaseName, String tableName) {
+    return warehouse + "/" + databaseName + "/" + tableName;
+  }
+
+  /**
+   * Normalize a warehouse path: remove trailing slashes.
+   *
+   * @param path Raw path
+   * @return Normalized path
+   */
+  static String normalize(String path) {
+    if (path == null) {
+      return null;
+    }
+    while (path.endsWith("/") && path.length() > 1) {
+      path = path.substring(0, path.length() - 1);
+    }
+    return path;
+  }
+
+  /**
+   * Detect whether a path is a remote storage URI.
+   *
+   * @param path Path to check
+   * @return true if path starts with a known remote protocol prefix
+   */
+  static boolean detectRemote(String path) {
+    if (path == null) {
+      return false;
+    }
+    String lower = path.toLowerCase();
+    return lower.startsWith("s3://")
+        || lower.startsWith("s3a://")
+        || lower.startsWith("gs://")
+        || lower.startsWith("az://")
+        || lower.startsWith("https://")
+        || lower.startsWith("http://");
+  }
+}

--- a/src/main/java/org/apache/flink/connector/lance/catalog/LanceStorageProvider.java
+++ b/src/main/java/org/apache/flink/connector/lance/catalog/LanceStorageProvider.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.catalog;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Storage abstraction for Lance Catalog operations.
+ *
+ * <p>Encapsulates all filesystem / object-store interactions so that {@code LanceCatalog} can
+ * delegate storage-specific logic to concrete implementations.
+ *
+ * <p>Two built-in implementations:
+ *
+ * <ul>
+ *   <li>{@link LocalStorageProvider} — Local filesystem (default)
+ *   <li>{@link RemoteStorageProvider} — S3/GCS/Azure object storage
+ * </ul>
+ */
+public interface LanceStorageProvider extends Serializable {
+
+  /**
+   * Ensure the warehouse root and the default database directory exist.
+   *
+   * @param defaultDatabase Default database name
+   * @throws IOException if directories cannot be created
+   */
+  void initializeWarehouse(String defaultDatabase) throws IOException;
+
+  /**
+   * List all databases under the warehouse.
+   *
+   * @return List of database names
+   * @throws IOException on I/O error
+   */
+  List<String> listDatabases() throws IOException;
+
+  /**
+   * Check whether a database exists.
+   *
+   * @param databaseName Database name
+   * @return true if the database exists
+   */
+  boolean databaseExists(String databaseName);
+
+  /**
+   * Create a database directory.
+   *
+   * @param databaseName Database name
+   * @throws IOException if the directory cannot be created
+   */
+  void createDatabase(String databaseName) throws IOException;
+
+  /**
+   * Drop a database directory.
+   *
+   * @param databaseName Database name
+   * @param cascade if true, also delete contents
+   * @throws IOException on I/O error
+   */
+  void dropDatabase(String databaseName, boolean cascade) throws IOException;
+
+  /**
+   * List all Lance datasets (tables) in a database.
+   *
+   * @param databaseName Database name
+   * @return List of table names
+   * @throws IOException on I/O error
+   */
+  List<String> listTables(String databaseName) throws IOException;
+
+  /**
+   * Check whether a table (Lance dataset) exists.
+   *
+   * @param databaseName Database name
+   * @param tableName Table name
+   * @return true if the table exists
+   */
+  boolean tableExists(String databaseName, String tableName);
+
+  /**
+   * Delete a table (Lance dataset) from storage.
+   *
+   * @param databaseName Database name
+   * @param tableName Table name
+   * @throws IOException on I/O error
+   */
+  void dropTable(String databaseName, String tableName) throws IOException;
+
+  /**
+   * Rename a table (Lance dataset).
+   *
+   * @param databaseName Database name
+   * @param oldTableName Current table name
+   * @param newTableName New table name
+   * @throws IOException on I/O error
+   */
+  void renameTable(String databaseName, String oldTableName, String newTableName)
+      throws IOException;
+
+  /**
+   * Register a table in the metadata store (for remote storage that tracks tables in-memory).
+   *
+   * @param databaseName Database name
+   * @param tableName Table name
+   */
+  void registerTable(String databaseName, String tableName);
+
+  /** Configure storage environment (e.g., S3 credentials). No-op for local storage. */
+  void configureEnvironment();
+}

--- a/src/main/java/org/apache/flink/connector/lance/catalog/LocalStorageProvider.java
+++ b/src/main/java/org/apache/flink/connector/lance/catalog/LocalStorageProvider.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.catalog;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Local filesystem implementation of {@link LanceStorageProvider}.
+ *
+ * <p>Manages databases as directories and tables as subdirectories containing Lance dataset files.
+ * A valid Lance dataset directory contains a {@code _versions} subdirectory.
+ */
+public final class LocalStorageProvider implements LanceStorageProvider {
+
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(LocalStorageProvider.class);
+
+  private final LanceCatalogPathResolver pathResolver;
+
+  public LocalStorageProvider(LanceCatalogPathResolver pathResolver) {
+    this.pathResolver = pathResolver;
+  }
+
+  @Override
+  public void initializeWarehouse(String defaultDatabase) throws IOException {
+    Path warehousePath = Paths.get(pathResolver.getWarehouse());
+    if (!Files.exists(warehousePath)) {
+      Files.createDirectories(warehousePath);
+    }
+
+    Path defaultDbPath = warehousePath.resolve(defaultDatabase);
+    if (!Files.exists(defaultDbPath)) {
+      Files.createDirectories(defaultDbPath);
+    }
+  }
+
+  @Override
+  public List<String> listDatabases() throws IOException {
+    Path warehousePath = Paths.get(pathResolver.getWarehouse());
+    if (!Files.exists(warehousePath)) {
+      return Collections.emptyList();
+    }
+
+    return Files.list(warehousePath)
+        .filter(Files::isDirectory)
+        .map(path -> path.getFileName().toString())
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public boolean databaseExists(String databaseName) {
+    Path dbPath = Paths.get(pathResolver.resolveDatabasePath(databaseName));
+    return Files.exists(dbPath) && Files.isDirectory(dbPath);
+  }
+
+  @Override
+  public void createDatabase(String databaseName) throws IOException {
+    Path dbPath = Paths.get(pathResolver.resolveDatabasePath(databaseName));
+    Files.createDirectories(dbPath);
+    LOG.info("Created database directory: {}", dbPath);
+  }
+
+  @Override
+  public void dropDatabase(String databaseName, boolean cascade) throws IOException {
+    Path dbPath = Paths.get(pathResolver.resolveDatabasePath(databaseName));
+    deleteDirectory(dbPath);
+    LOG.info("Deleted database directory: {}", dbPath);
+  }
+
+  @Override
+  public List<String> listTables(String databaseName) throws IOException {
+    Path dbPath = Paths.get(pathResolver.resolveDatabasePath(databaseName));
+    return Files.list(dbPath)
+        .filter(Files::isDirectory)
+        .filter(path -> Files.exists(path.resolve("_versions")))
+        .map(path -> path.getFileName().toString())
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public boolean tableExists(String databaseName, String tableName) {
+    Path datasetPath = Paths.get(pathResolver.resolveTablePath(databaseName, tableName));
+    return Files.exists(datasetPath)
+        && Files.isDirectory(datasetPath)
+        && Files.exists(datasetPath.resolve("_versions"));
+  }
+
+  @Override
+  public void dropTable(String databaseName, String tableName) throws IOException {
+    Path datasetPath = Paths.get(pathResolver.resolveTablePath(databaseName, tableName));
+    deleteDirectory(datasetPath);
+    LOG.info("Deleted table directory: {}", datasetPath);
+  }
+
+  @Override
+  public void renameTable(String databaseName, String oldTableName, String newTableName)
+      throws IOException {
+    Path oldPath = Paths.get(pathResolver.resolveTablePath(databaseName, oldTableName));
+    Path newPath = Paths.get(pathResolver.resolveTablePath(databaseName, newTableName));
+    Files.move(oldPath, newPath);
+    LOG.info("Renamed table: {} -> {}", oldPath, newPath);
+  }
+
+  @Override
+  public void registerTable(String databaseName, String tableName) {
+    // No-op for local storage — tables are registered by their presence on disk
+  }
+
+  @Override
+  public void configureEnvironment() {
+    // No-op for local storage
+  }
+
+  /** Recursively delete a directory tree. */
+  private void deleteDirectory(Path path) throws IOException {
+    if (Files.isDirectory(path)) {
+      Files.list(path)
+          .forEach(
+              child -> {
+                try {
+                  deleteDirectory(child);
+                } catch (IOException e) {
+                  LOG.warn("Failed to delete: {}", child, e);
+                }
+              });
+    }
+    Files.deleteIfExists(path);
+  }
+}

--- a/src/main/java/org/apache/flink/connector/lance/catalog/RemoteStorageProvider.java
+++ b/src/main/java/org/apache/flink/connector/lance/catalog/RemoteStorageProvider.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.catalog;
+
+import com.lancedb.lance.Dataset;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.flink.connector.lance.config.LanceDatasetFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+/**
+ * Remote object-store (S3/GCS/Azure) implementation of {@link LanceStorageProvider}.
+ *
+ * <p>Because remote object stores do not have a true directory hierarchy, this provider maintains
+ * in-memory registries of known databases and tables. Actual existence is verified lazily by
+ * attempting to open the Lance dataset.
+ *
+ * <p>Remote storage credentials are configured via {@link StorageEnvironmentManager}.
+ */
+public final class RemoteStorageProvider implements LanceStorageProvider {
+
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(RemoteStorageProvider.class);
+
+  private final LanceCatalogPathResolver pathResolver;
+  private final Map<String, String> storageOptions;
+
+  // In-memory registries for known databases and tables
+  private final Set<String> knownDatabases = ConcurrentHashMap.newKeySet();
+  private final Set<String> knownTables = ConcurrentHashMap.newKeySet();
+
+  // Transient allocator for probing dataset existence
+  private transient BufferAllocator allocator;
+
+  public RemoteStorageProvider(
+      LanceCatalogPathResolver pathResolver, Map<String, String> storageOptions) {
+    this.pathResolver = pathResolver;
+    this.storageOptions = storageOptions;
+  }
+
+  /** Set the allocator (called from LanceCatalog.open). */
+  public void setAllocator(BufferAllocator allocator) {
+    this.allocator = allocator;
+  }
+
+  @Override
+  public void initializeWarehouse(String defaultDatabase) {
+    knownDatabases.add(defaultDatabase);
+    LOG.info(
+        "Remote storage mode enabled, registered default database: {}, storage config count: {}",
+        defaultDatabase,
+        storageOptions.size());
+  }
+
+  @Override
+  public List<String> listDatabases() {
+    return new ArrayList<>(knownDatabases);
+  }
+
+  @Override
+  public boolean databaseExists(String databaseName) {
+    // For remote storage, assume database always exists if known or by default
+    return knownDatabases.contains(databaseName) || true;
+  }
+
+  @Override
+  public void createDatabase(String databaseName) {
+    knownDatabases.add(databaseName);
+    LOG.info("Registered remote database: {}", databaseName);
+  }
+
+  @Override
+  public void dropDatabase(String databaseName, boolean cascade) throws IOException {
+    if (cascade) {
+      String prefix = databaseName + "/";
+      List<String> tablesToRemove =
+          knownTables.stream().filter(t -> t.startsWith(prefix)).collect(Collectors.toList());
+      knownTables.removeAll(tablesToRemove);
+    }
+    knownDatabases.remove(databaseName);
+    LOG.info("Removed remote database record: {}", databaseName);
+  }
+
+  @Override
+  public List<String> listTables(String databaseName) {
+    String prefix = databaseName + "/";
+    return knownTables.stream()
+        .filter(t -> t.startsWith(prefix))
+        .map(t -> t.substring(prefix.length()))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public boolean tableExists(String databaseName, String tableName) {
+    String tableKey = databaseName + "/" + tableName;
+    if (knownTables.contains(tableKey)) {
+      return true;
+    }
+
+    // Try to open dataset to verify existence
+    try {
+      configureEnvironment();
+      String datasetPath = pathResolver.resolveTablePath(databaseName, tableName);
+      Dataset dataset = LanceDatasetFactory.open(datasetPath, allocator);
+      dataset.close();
+      knownTables.add(tableKey);
+      return true;
+    } catch (Exception e) {
+      LOG.debug("Table does not exist or cannot be accessed: {}/{}", databaseName, tableName, e);
+      return false;
+    }
+  }
+
+  @Override
+  public void dropTable(String databaseName, String tableName) {
+    String tableKey = databaseName + "/" + tableName;
+    knownTables.remove(tableKey);
+    String datasetPath = pathResolver.resolveTablePath(databaseName, tableName);
+    LOG.warn(
+        "Remote storage mode: table record removed, but actual data needs manual deletion"
+            + " from storage: {}",
+        datasetPath);
+  }
+
+  @Override
+  public void renameTable(String databaseName, String oldTableName, String newTableName) {
+    throw new UnsupportedOperationException("Remote storage mode does not support renaming tables");
+  }
+
+  @Override
+  public void registerTable(String databaseName, String tableName) {
+    String tableKey = databaseName + "/" + tableName;
+    knownTables.add(tableKey);
+  }
+
+  @Override
+  public void configureEnvironment() {
+    StorageEnvironmentManager.configure(storageOptions);
+  }
+
+  /** Get storage options (for building table connector options). */
+  public Map<String, String> getStorageOptions() {
+    return storageOptions;
+  }
+
+  /** Get known databases set (for testing). */
+  Set<String> getKnownDatabases() {
+    return knownDatabases;
+  }
+
+  /** Get known tables set (for testing). */
+  Set<String> getKnownTables() {
+    return knownTables;
+  }
+
+  /** Clear all in-memory registries. */
+  public void clear() {
+    knownDatabases.clear();
+    knownTables.clear();
+  }
+}

--- a/src/main/java/org/apache/flink/connector/lance/catalog/StorageEnvironmentManager.java
+++ b/src/main/java/org/apache/flink/connector/lance/catalog/StorageEnvironmentManager.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.catalog;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Manages S3/remote storage environment configuration for Lance SDK.
+ *
+ * <p>Lance's Rust backend reads AWS credentials from environment variables / system properties.
+ * This class encapsulates the mapping between user-provided storage options and the system
+ * properties that Lance expects.
+ *
+ * <p>Supported configuration keys (user-facing → system property):
+ *
+ * <ul>
+ *   <li>{@code aws_access_key_id} → {@code AWS_ACCESS_KEY_ID}
+ *   <li>{@code aws_secret_access_key} → {@code AWS_SECRET_ACCESS_KEY}
+ *   <li>{@code aws_region} → {@code AWS_DEFAULT_REGION}
+ *   <li>{@code aws_endpoint} → {@code AWS_ENDPOINT}
+ *   <li>{@code aws_virtual_hosted_style_request} → {@code AWS_VIRTUAL_HOSTED_STYLE_REQUEST}
+ *   <li>{@code allow_http} → {@code AWS_ALLOW_HTTP}
+ * </ul>
+ *
+ * <p>This class also converts storage options into table-level connector options (e.g., {@code
+ * s3-access-key}).
+ */
+public final class StorageEnvironmentManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StorageEnvironmentManager.class);
+
+  /** Mapping from internal storage option keys to system property names. */
+  private static final Map<String, String> KEY_TO_SYS_PROP;
+
+  static {
+    Map<String, String> m = new HashMap<>();
+    m.put("aws_access_key_id", "AWS_ACCESS_KEY_ID");
+    m.put("aws_secret_access_key", "AWS_SECRET_ACCESS_KEY");
+    m.put("aws_region", "AWS_DEFAULT_REGION");
+    m.put("aws_endpoint", "AWS_ENDPOINT");
+    m.put("aws_virtual_hosted_style_request", "AWS_VIRTUAL_HOSTED_STYLE_REQUEST");
+    m.put("allow_http", "AWS_ALLOW_HTTP");
+    KEY_TO_SYS_PROP = Collections.unmodifiableMap(m);
+  }
+
+  /** Mapping from internal storage option keys to table-level connector option keys. */
+  private static final Map<String, String> KEY_TO_TABLE_OPT;
+
+  static {
+    Map<String, String> m = new HashMap<>();
+    m.put("aws_access_key_id", "s3-access-key");
+    m.put("aws_secret_access_key", "s3-secret-key");
+    m.put("aws_region", "s3-region");
+    m.put("aws_endpoint", "s3-endpoint");
+    KEY_TO_TABLE_OPT = Collections.unmodifiableMap(m);
+  }
+
+  private StorageEnvironmentManager() {
+    // Utility class
+  }
+
+  /**
+   * Configure system properties for remote storage access.
+   *
+   * <p>This sets JVM system properties that Lance's Rust backend reads to authenticate with S3 or
+   * other cloud storage.
+   *
+   * @param storageOptions Storage configuration options from the catalog
+   */
+  public static void configure(Map<String, String> storageOptions) {
+    if (storageOptions == null || storageOptions.isEmpty()) {
+      return;
+    }
+
+    for (Map.Entry<String, String> entry : KEY_TO_SYS_PROP.entrySet()) {
+      String value = storageOptions.get(entry.getKey());
+      if (value != null) {
+        System.setProperty(entry.getValue(), value);
+      }
+    }
+
+    LOG.debug("Configured remote storage environment variables");
+  }
+
+  /**
+   * Convert internal storage options into table-level connector options.
+   *
+   * <p>Used when building {@code CatalogTable} options so downstream connectors can also access
+   * storage credentials.
+   *
+   * @param storageOptions Internal storage options
+   * @return Table-level connector options (e.g., s3-access-key, s3-secret-key)
+   */
+  public static Map<String, String> toTableOptions(Map<String, String> storageOptions) {
+    if (storageOptions == null || storageOptions.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, String> tableOpts = new HashMap<>();
+    for (Map.Entry<String, String> entry : KEY_TO_TABLE_OPT.entrySet()) {
+      String value = storageOptions.get(entry.getKey());
+      if (value != null) {
+        tableOpts.put(entry.getValue(), value);
+      }
+    }
+    return tableOpts;
+  }
+}

--- a/src/main/java/org/apache/flink/connector/lance/config/LanceDatasetFactory.java
+++ b/src/main/java/org/apache/flink/connector/lance/config/LanceDatasetFactory.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.config;
+
+import com.lancedb.lance.Dataset;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+/**
+ * Unified factory for opening and managing Lance {@link Dataset} instances.
+ *
+ * <p>Eliminates duplicated Dataset.open / allocator management logic scattered across the codebase.
+ * Every class that needs to open a Lance dataset should go through this factory.
+ *
+ * <p>Two usage patterns are supported:
+ *
+ * <ul>
+ *   <li><b>Auto-managed</b>: Use {@link #openManaged(String)} to get a {@link ManagedDataset} that
+ *       owns both the allocator and the dataset. Close it when done.
+ *   <li><b>External allocator</b>: Use {@link #open(String, BufferAllocator)} when the caller owns
+ *       the allocator lifecycle.
+ * </ul>
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ * // Auto-managed (recommended for short-lived usage)
+ * try (LanceDatasetFactory.ManagedDataset md = LanceDatasetFactory.openManaged("/data/ds")) {
+ *     Dataset ds = md.getDataset();
+ *     // use ds...
+ * }
+ *
+ * // External allocator
+ * BufferAllocator alloc = new RootAllocator(Long.MAX_VALUE);
+ * Dataset ds = LanceDatasetFactory.open("/data/ds", alloc);
+ * // caller is responsible for closing ds and alloc
+ * }</pre>
+ */
+public final class LanceDatasetFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LanceDatasetFactory.class);
+
+  private LanceDatasetFactory() {
+    // Utility class — no instantiation
+  }
+
+  /**
+   * Open a Lance Dataset with the given allocator.
+   *
+   * @param datasetPath Path to the Lance dataset (local or remote)
+   * @param allocator Arrow BufferAllocator to use
+   * @return Opened Dataset
+   * @throws IOException if the path is invalid or the dataset cannot be opened
+   */
+  public static Dataset open(String datasetPath, BufferAllocator allocator) throws IOException {
+    validatePath(datasetPath);
+
+    try {
+      Dataset dataset = Dataset.open(datasetPath, allocator);
+      LOG.debug("Opened Lance dataset: {}", datasetPath);
+      return dataset;
+    } catch (Exception e) {
+      throw new IOException("Failed to open Lance dataset: " + datasetPath, e);
+    }
+  }
+
+  /**
+   * Open a Lance Dataset with a self-managed allocator.
+   *
+   * <p>The returned {@link ManagedDataset} owns both the allocator and the dataset; closing it
+   * releases both resources.
+   *
+   * @param datasetPath Path to the Lance dataset
+   * @return A {@link ManagedDataset} wrapping the dataset and its allocator
+   * @throws IOException if the dataset cannot be opened
+   */
+  public static ManagedDataset openManaged(String datasetPath) throws IOException {
+    validatePath(datasetPath);
+
+    BufferAllocator allocator = createAllocator();
+    try {
+      Dataset dataset = Dataset.open(datasetPath, allocator);
+      LOG.debug("Opened managed Lance dataset: {}", datasetPath);
+      return new ManagedDataset(dataset, allocator);
+    } catch (Exception e) {
+      // Clean up allocator on failure
+      closeQuietly(allocator);
+      throw new IOException("Failed to open Lance dataset: " + datasetPath, e);
+    }
+  }
+
+  /**
+   * Create a new {@link RootAllocator} with unbounded capacity.
+   *
+   * @return A new BufferAllocator
+   */
+  public static BufferAllocator createAllocator() {
+    return new RootAllocator(Long.MAX_VALUE);
+  }
+
+  /**
+   * Quietly close a {@link Dataset}, logging but not propagating exceptions.
+   *
+   * @param dataset Dataset to close (nullable)
+   */
+  public static void closeQuietly(Dataset dataset) {
+    if (dataset != null) {
+      try {
+        dataset.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close dataset", e);
+      }
+    }
+  }
+
+  /**
+   * Quietly close a {@link BufferAllocator}, logging but not propagating exceptions.
+   *
+   * @param allocator Allocator to close (nullable)
+   */
+  public static void closeQuietly(BufferAllocator allocator) {
+    if (allocator != null) {
+      try {
+        allocator.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close allocator", e);
+      }
+    }
+  }
+
+  /**
+   * Validate a dataset path.
+   *
+   * @param datasetPath The path to validate
+   * @throws IllegalArgumentException if the path is null or empty
+   */
+  public static void validatePath(String datasetPath) {
+    if (datasetPath == null || datasetPath.isEmpty()) {
+      throw new IllegalArgumentException("Lance dataset path must not be null or empty");
+    }
+  }
+
+  /**
+   * A {@link Closeable} wrapper that owns both a {@link Dataset} and its {@link BufferAllocator}.
+   *
+   * <p>Closing a ManagedDataset will close the dataset first, then the allocator.
+   */
+  public static final class ManagedDataset implements Closeable {
+    private final Dataset dataset;
+    private final BufferAllocator allocator;
+
+    ManagedDataset(Dataset dataset, BufferAllocator allocator) {
+      this.dataset = dataset;
+      this.allocator = allocator;
+    }
+
+    /** Get the underlying Dataset. */
+    public Dataset getDataset() {
+      return dataset;
+    }
+
+    /** Get the underlying BufferAllocator. */
+    public BufferAllocator getAllocator() {
+      return allocator;
+    }
+
+    @Override
+    public void close() throws IOException {
+      closeQuietly(dataset);
+      closeQuietly(allocator);
+    }
+  }
+}

--- a/src/main/java/org/apache/flink/connector/lance/config/LanceIndexOptions.java
+++ b/src/main/java/org/apache/flink/connector/lance/config/LanceIndexOptions.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.config;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Immutable configuration for Lance vector index building.
+ *
+ * <p>Contains all index-related options: index type, column, partition count, PQ/HNSW parameters.
+ *
+ * <p>Use {@link Builder} to construct instances.
+ */
+public final class LanceIndexOptions implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String columnName;
+  private final LanceOptions.IndexType indexType;
+  private final LanceOptions.MetricType metricType;
+  private final int numPartitions;
+  private final Integer numSubVectors;
+  private final int numBits;
+  private final int maxLevel;
+  private final int m;
+  private final int efConstruction;
+
+  private LanceIndexOptions(Builder builder) {
+    this.columnName = builder.columnName;
+    this.indexType = builder.indexType;
+    this.metricType = builder.metricType;
+    this.numPartitions = builder.numPartitions;
+    this.numSubVectors = builder.numSubVectors;
+    this.numBits = builder.numBits;
+    this.maxLevel = builder.maxLevel;
+    this.m = builder.m;
+    this.efConstruction = builder.efConstruction;
+  }
+
+  /** Index column name. */
+  public String getColumnName() {
+    return columnName;
+  }
+
+  /** Vector index type (IVF_PQ, IVF_HNSW, IVF_FLAT). */
+  public LanceOptions.IndexType getIndexType() {
+    return indexType;
+  }
+
+  /** Distance metric type (L2, Cosine, Dot). */
+  public LanceOptions.MetricType getMetricType() {
+    return metricType;
+  }
+
+  /** Number of IVF partitions. */
+  public int getNumPartitions() {
+    return numPartitions;
+  }
+
+  /** Number of PQ sub-vectors (null for auto-calculation). */
+  public Integer getNumSubVectors() {
+    return numSubVectors;
+  }
+
+  /** PQ quantization bits. */
+  public int getNumBits() {
+    return numBits;
+  }
+
+  /** HNSW max level. */
+  public int getMaxLevel() {
+    return maxLevel;
+  }
+
+  /** HNSW connections per level M. */
+  public int getM() {
+    return m;
+  }
+
+  /** HNSW construction search width ef_construction. */
+  public int getEfConstruction() {
+    return efConstruction;
+  }
+
+  /** Create a new Builder. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    LanceIndexOptions that = (LanceIndexOptions) o;
+    return numPartitions == that.numPartitions
+        && numBits == that.numBits
+        && maxLevel == that.maxLevel
+        && m == that.m
+        && efConstruction == that.efConstruction
+        && Objects.equals(columnName, that.columnName)
+        && indexType == that.indexType
+        && metricType == that.metricType
+        && Objects.equals(numSubVectors, that.numSubVectors);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        columnName,
+        indexType,
+        metricType,
+        numPartitions,
+        numSubVectors,
+        numBits,
+        maxLevel,
+        m,
+        efConstruction);
+  }
+
+  @Override
+  public String toString() {
+    return "LanceIndexOptions{"
+        + "columnName='"
+        + columnName
+        + '\''
+        + ", indexType="
+        + indexType
+        + ", metricType="
+        + metricType
+        + ", numPartitions="
+        + numPartitions
+        + ", numSubVectors="
+        + numSubVectors
+        + ", numBits="
+        + numBits
+        + ", maxLevel="
+        + maxLevel
+        + ", m="
+        + m
+        + ", efConstruction="
+        + efConstruction
+        + '}';
+  }
+
+  /** Builder for {@link LanceIndexOptions}. */
+  public static class Builder {
+    private String columnName;
+    private LanceOptions.IndexType indexType = LanceOptions.IndexType.IVF_PQ;
+    private LanceOptions.MetricType metricType = LanceOptions.MetricType.L2;
+    private int numPartitions = 256;
+    private Integer numSubVectors;
+    private int numBits = 8;
+    private int maxLevel = 7;
+    private int m = 16;
+    private int efConstruction = 100;
+
+    public Builder columnName(String columnName) {
+      this.columnName = columnName;
+      return this;
+    }
+
+    public Builder indexType(LanceOptions.IndexType indexType) {
+      this.indexType = indexType;
+      return this;
+    }
+
+    public Builder metricType(LanceOptions.MetricType metricType) {
+      this.metricType = metricType;
+      return this;
+    }
+
+    public Builder numPartitions(int numPartitions) {
+      this.numPartitions = numPartitions;
+      return this;
+    }
+
+    public Builder numSubVectors(Integer numSubVectors) {
+      this.numSubVectors = numSubVectors;
+      return this;
+    }
+
+    public Builder numBits(int numBits) {
+      this.numBits = numBits;
+      return this;
+    }
+
+    public Builder maxLevel(int maxLevel) {
+      this.maxLevel = maxLevel;
+      return this;
+    }
+
+    public Builder maxEdges(int m) {
+      this.m = m;
+      return this;
+    }
+
+    public Builder efConstruction(int efConstruction) {
+      this.efConstruction = efConstruction;
+      return this;
+    }
+
+    /** Build with validation. */
+    public LanceIndexOptions build() {
+      if (numPartitions <= 0) {
+        throw new IllegalArgumentException(
+            "index.num-partitions must be > 0, current value: " + numPartitions);
+      }
+      if (numSubVectors != null && numSubVectors <= 0) {
+        throw new IllegalArgumentException(
+            "index.num-sub-vectors must be > 0, current value: " + numSubVectors);
+      }
+      if (numBits <= 0 || numBits > 16) {
+        throw new IllegalArgumentException(
+            "index.num-bits must be between 1 and 16, current value: " + numBits);
+      }
+      if (maxLevel <= 0) {
+        throw new IllegalArgumentException(
+            "index.max-level must be > 0, current value: " + maxLevel);
+      }
+      if (m <= 0) {
+        throw new IllegalArgumentException("index.m must be greater than 0, current value: " + m);
+      }
+      if (efConstruction <= 0) {
+        throw new IllegalArgumentException(
+            "index.ef-construction must be > 0, current value: " + efConstruction);
+      }
+      return new LanceIndexOptions(this);
+    }
+  }
+}

--- a/src/main/java/org/apache/flink/connector/lance/config/LanceOptions.java
+++ b/src/main/java/org/apache/flink/connector/lance/config/LanceOptions.java
@@ -30,7 +30,7 @@ import java.util.Objects;
 
 /**
  * Lance connector configuration options.
- * 
+ *
  * <p>Defines all configuration items for Source, Sink, vector index and vector search.
  */
 public class LanceOptions implements Serializable {
@@ -281,7 +281,9 @@ public class LanceOptions implements Serializable {
                     return mode;
                 }
             }
-            throw new IllegalArgumentException("Unsupported write mode: " + value + ", supported modes: append, overwrite");
+            throw new IllegalArgumentException(
+                    "Unsupported write mode: " + value
+                            + ", supported modes: append, overwrite");
         }
     }
 
@@ -311,7 +313,9 @@ public class LanceOptions implements Serializable {
                     return type;
                 }
             }
-            throw new IllegalArgumentException("Unsupported index type: " + value + ", supported types: IVF_PQ, IVF_HNSW, IVF_FLAT");
+            throw new IllegalArgumentException(
+                    "Unsupported index type: " + value
+                            + ", supported types: IVF_PQ, IVF_HNSW, IVF_FLAT");
         }
     }
 
@@ -341,7 +345,9 @@ public class LanceOptions implements Serializable {
                     return type;
                 }
             }
-            throw new IllegalArgumentException("Unsupported metric type: " + value + ", supported types: L2, Cosine, Dot");
+            throw new IllegalArgumentException(
+                    "Unsupported metric type: " + value
+                            + ", supported types: L2, Cosine, Dot");
         }
     }
 
@@ -719,42 +725,58 @@ public class LanceOptions implements Serializable {
         private void validate() {
             // Validate read batch size
             if (readBatchSize <= 0) {
-                throw new IllegalArgumentException("read.batch-size must be greater than 0, current value: " + readBatchSize);
+                throw new IllegalArgumentException(
+                        "read.batch-size must be greater than 0, current value: "
+                                + readBatchSize);
             }
 
             // Validate Limit (if set)
             if (readLimit != null && readLimit < 0) {
-                throw new IllegalArgumentException("read.limit must be greater than or equal to 0, current value: " + readLimit);
+                throw new IllegalArgumentException(
+                        "read.limit must be >= 0, current value: "
+                                + readLimit);
             }
 
             // Validate write batch size
             if (writeBatchSize <= 0) {
-                throw new IllegalArgumentException("write.batch-size must be greater than 0, current value: " + writeBatchSize);
+                throw new IllegalArgumentException(
+                        "write.batch-size must be greater than 0, current value: "
+                                + writeBatchSize);
             }
 
             // Validate max rows per file
             if (writeMaxRowsPerFile <= 0) {
-                throw new IllegalArgumentException("write.max-rows-per-file must be greater than 0, current value: " + writeMaxRowsPerFile);
+                throw new IllegalArgumentException(
+                        "write.max-rows-per-file must be > 0, current value: "
+                                + writeMaxRowsPerFile);
             }
 
             // Validate index partition count
             if (indexNumPartitions <= 0) {
-                throw new IllegalArgumentException("index.num-partitions must be greater than 0, current value: " + indexNumPartitions);
+                throw new IllegalArgumentException(
+                        "index.num-partitions must be > 0, current value: "
+                                + indexNumPartitions);
             }
 
             // Validate PQ sub-vector count
             if (indexNumSubVectors != null && indexNumSubVectors <= 0) {
-                throw new IllegalArgumentException("index.num-sub-vectors must be greater than 0, current value: " + indexNumSubVectors);
+                throw new IllegalArgumentException(
+                        "index.num-sub-vectors must be > 0, current value: "
+                                + indexNumSubVectors);
             }
 
             // Validate PQ quantization bits
             if (indexNumBits <= 0 || indexNumBits > 16) {
-                throw new IllegalArgumentException("index.num-bits must be between 1 and 16, current value: " + indexNumBits);
+                throw new IllegalArgumentException(
+                        "index.num-bits must be between 1 and 16, current value: "
+                                + indexNumBits);
             }
 
             // Validate HNSW parameters
             if (indexMaxLevel <= 0) {
-                throw new IllegalArgumentException("index.max-level must be greater than 0, current value: " + indexMaxLevel);
+                throw new IllegalArgumentException(
+                        "index.max-level must be > 0, current value: "
+                                + indexMaxLevel);
             }
 
             if (indexM <= 0) {
@@ -762,12 +784,16 @@ public class LanceOptions implements Serializable {
             }
 
             if (indexEfConstruction <= 0) {
-                throw new IllegalArgumentException("index.ef-construction must be greater than 0, current value: " + indexEfConstruction);
+                throw new IllegalArgumentException(
+                        "index.ef-construction must be > 0, current value: "
+                                + indexEfConstruction);
             }
 
             // Validate vector search parameters
             if (vectorNprobes <= 0) {
-                throw new IllegalArgumentException("vector.nprobes must be greater than 0, current value: " + vectorNprobes);
+                throw new IllegalArgumentException(
+                        "vector.nprobes must be > 0, current value: "
+                                + vectorNprobes);
             }
 
             if (vectorEf <= 0) {
@@ -775,7 +801,9 @@ public class LanceOptions implements Serializable {
             }
 
             if (vectorRefineFactor != null && vectorRefineFactor <= 0) {
-                throw new IllegalArgumentException("vector.refine-factor must be greater than 0, current value: " + vectorRefineFactor);
+                throw new IllegalArgumentException(
+                        "vector.refine-factor must be > 0, current value: "
+                                + vectorRefineFactor);
             }
         }
     }

--- a/src/main/java/org/apache/flink/connector/lance/config/LanceOptions.java
+++ b/src/main/java/org/apache/flink/connector/lance/config/LanceOptions.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.config;
 
 import org.apache.flink.configuration.ConfigOption;
@@ -35,843 +30,819 @@ import java.util.Objects;
  */
 public class LanceOptions implements Serializable {
 
-    private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-    // ==================== Common Configuration ====================
+  // ==================== Common Configuration ====================
 
-    /**
-     * Lance dataset path
-     */
-    public static final ConfigOption<String> PATH = ConfigOptions
-            .key("path")
-            .stringType()
-            .noDefaultValue()
-            .withDescription("Path to Lance dataset (required)");
+  /** Lance dataset path */
+  public static final ConfigOption<String> PATH =
+      ConfigOptions.key("path")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("Path to Lance dataset (required)");
 
-    // ==================== Source Configuration ====================
+  // ==================== Source Configuration ====================
 
-    /**
-     * Read batch size
-     */
-    public static final ConfigOption<Integer> READ_BATCH_SIZE = ConfigOptions
-            .key("read.batch-size")
-            .intType()
-            .defaultValue(1024)
-            .withDescription("Batch size for reading, default 1024");
+  /** Read batch size */
+  public static final ConfigOption<Integer> READ_BATCH_SIZE =
+      ConfigOptions.key("read.batch-size")
+          .intType()
+          .defaultValue(1024)
+          .withDescription("Batch size for reading, default 1024");
 
-    /**
-     * Read row limit (Limit push-down)
-     */
-    public static final ConfigOption<Long> READ_LIMIT = ConfigOptions
-            .key("read.limit")
-            .longType()
-            .noDefaultValue()
-            .withDescription("Maximum number of rows to read (for Limit push-down)");
+  /** Read row limit (Limit push-down) */
+  public static final ConfigOption<Long> READ_LIMIT =
+      ConfigOptions.key("read.limit")
+          .longType()
+          .noDefaultValue()
+          .withDescription("Maximum number of rows to read (for Limit push-down)");
 
-    /**
-     * List of columns to read (comma separated)
-     */
-    public static final ConfigOption<String> READ_COLUMNS = ConfigOptions
-            .key("read.columns")
-            .stringType()
-            .noDefaultValue()
-            .withDescription("List of columns to read, comma separated. Empty reads all columns");
+  /** List of columns to read (comma separated) */
+  public static final ConfigOption<String> READ_COLUMNS =
+      ConfigOptions.key("read.columns")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("List of columns to read, comma separated. Empty reads all columns");
 
-    /**
-     * Data filter condition
-     */
-    public static final ConfigOption<String> READ_FILTER = ConfigOptions
-            .key("read.filter")
-            .stringType()
-            .noDefaultValue()
-            .withDescription("Data filter condition, using SQL WHERE clause syntax");
+  /** Data filter condition */
+  public static final ConfigOption<String> READ_FILTER =
+      ConfigOptions.key("read.filter")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("Data filter condition, using SQL WHERE clause syntax");
 
-    // ==================== Sink Configuration ====================
+  // ==================== Sink Configuration ====================
 
-    /**
-     * Write batch size
-     */
-    public static final ConfigOption<Integer> WRITE_BATCH_SIZE = ConfigOptions
-            .key("write.batch-size")
-            .intType()
-            .defaultValue(1024)
-            .withDescription("Batch size for writing, default 1024");
+  /** Write batch size */
+  public static final ConfigOption<Integer> WRITE_BATCH_SIZE =
+      ConfigOptions.key("write.batch-size")
+          .intType()
+          .defaultValue(1024)
+          .withDescription("Batch size for writing, default 1024");
 
-    /**
-     * Write mode: append or overwrite
-     */
-    public static final ConfigOption<String> WRITE_MODE = ConfigOptions
-            .key("write.mode")
-            .stringType()
-            .defaultValue("append")
-            .withDescription("Write mode: append or overwrite, default append");
+  /** Write mode: append or overwrite */
+  public static final ConfigOption<String> WRITE_MODE =
+      ConfigOptions.key("write.mode")
+          .stringType()
+          .defaultValue("append")
+          .withDescription("Write mode: append or overwrite, default append");
 
-    /**
-     * Maximum rows per file
-     */
-    public static final ConfigOption<Integer> WRITE_MAX_ROWS_PER_FILE = ConfigOptions
-            .key("write.max-rows-per-file")
-            .intType()
-            .defaultValue(1000000)
-            .withDescription("Maximum rows per data file, default 1000000");
+  /** Maximum rows per file */
+  public static final ConfigOption<Integer> WRITE_MAX_ROWS_PER_FILE =
+      ConfigOptions.key("write.max-rows-per-file")
+          .intType()
+          .defaultValue(1000000)
+          .withDescription("Maximum rows per data file, default 1000000");
 
-    // ==================== Vector Index Configuration ====================
+  // ==================== Vector Index Configuration ====================
 
-    /**
-     * Index type: IVF_PQ, IVF_HNSW, IVF_FLAT
-     */
-    public static final ConfigOption<String> INDEX_TYPE = ConfigOptions
-            .key("index.type")
-            .stringType()
-            .defaultValue("IVF_PQ")
-            .withDescription("Vector index type: IVF_PQ, IVF_HNSW, IVF_FLAT, default IVF_PQ");
+  /** Index type: IVF_PQ, IVF_HNSW, IVF_FLAT */
+  public static final ConfigOption<String> INDEX_TYPE =
+      ConfigOptions.key("index.type")
+          .stringType()
+          .defaultValue("IVF_PQ")
+          .withDescription("Vector index type: IVF_PQ, IVF_HNSW, IVF_FLAT, default IVF_PQ");
 
-    /**
-     * Index column name
-     */
-    public static final ConfigOption<String> INDEX_COLUMN = ConfigOptions
-            .key("index.column")
-            .stringType()
-            .noDefaultValue()
-            .withDescription("Vector column name for indexing (required)");
+  /** Index column name */
+  public static final ConfigOption<String> INDEX_COLUMN =
+      ConfigOptions.key("index.column")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("Vector column name for indexing (required)");
 
-    /**
-     * IVF partition count
-     */
-    public static final ConfigOption<Integer> INDEX_NUM_PARTITIONS = ConfigOptions
-            .key("index.num-partitions")
-            .intType()
-            .defaultValue(256)
-            .withDescription("Number of IVF index partitions, default 256");
+  /** IVF partition count */
+  public static final ConfigOption<Integer> INDEX_NUM_PARTITIONS =
+      ConfigOptions.key("index.num-partitions")
+          .intType()
+          .defaultValue(256)
+          .withDescription("Number of IVF index partitions, default 256");
 
-    /**
-     * PQ sub-vector count
-     */
-    public static final ConfigOption<Integer> INDEX_NUM_SUB_VECTORS = ConfigOptions
-            .key("index.num-sub-vectors")
-            .intType()
-            .noDefaultValue()
-            .withDescription("Number of PQ index sub-vectors, default auto-calculated");
+  /** PQ sub-vector count */
+  public static final ConfigOption<Integer> INDEX_NUM_SUB_VECTORS =
+      ConfigOptions.key("index.num-sub-vectors")
+          .intType()
+          .noDefaultValue()
+          .withDescription("Number of PQ index sub-vectors, default auto-calculated");
 
-    /**
-     * PQ quantization bits
-     */
-    public static final ConfigOption<Integer> INDEX_NUM_BITS = ConfigOptions
-            .key("index.num-bits")
-            .intType()
-            .defaultValue(8)
-            .withDescription("PQ quantization bits, default 8");
+  /** PQ quantization bits */
+  public static final ConfigOption<Integer> INDEX_NUM_BITS =
+      ConfigOptions.key("index.num-bits")
+          .intType()
+          .defaultValue(8)
+          .withDescription("PQ quantization bits, default 8");
 
-    /**
-     * HNSW max level
-     */
-    public static final ConfigOption<Integer> INDEX_MAX_LEVEL = ConfigOptions
-            .key("index.max-level")
-            .intType()
-            .defaultValue(7)
-            .withDescription("HNSW index max level, default 7");
+  /** HNSW max level */
+  public static final ConfigOption<Integer> INDEX_MAX_LEVEL =
+      ConfigOptions.key("index.max-level")
+          .intType()
+          .defaultValue(7)
+          .withDescription("HNSW index max level, default 7");
 
-    /**
-     * HNSW connections per level M
-     */
-    public static final ConfigOption<Integer> INDEX_M = ConfigOptions
-            .key("index.m")
-            .intType()
-            .defaultValue(16)
-            .withDescription("HNSW connections per level M, default 16");
+  /** HNSW connections per level M */
+  public static final ConfigOption<Integer> INDEX_M =
+      ConfigOptions.key("index.m")
+          .intType()
+          .defaultValue(16)
+          .withDescription("HNSW connections per level M, default 16");
 
-    /**
-     * HNSW construction search width
-     */
-    public static final ConfigOption<Integer> INDEX_EF_CONSTRUCTION = ConfigOptions
-            .key("index.ef-construction")
-            .intType()
-            .defaultValue(100)
-            .withDescription("HNSW construction search width ef_construction, default 100");
+  /** HNSW construction search width */
+  public static final ConfigOption<Integer> INDEX_EF_CONSTRUCTION =
+      ConfigOptions.key("index.ef-construction")
+          .intType()
+          .defaultValue(100)
+          .withDescription("HNSW construction search width ef_construction, default 100");
 
-    // ==================== Vector Search Configuration ====================
+  // ==================== Vector Search Configuration ====================
 
-    /**
-     * Vector search column name
-     */
-    public static final ConfigOption<String> VECTOR_COLUMN = ConfigOptions
-            .key("vector.column")
-            .stringType()
-            .noDefaultValue()
-            .withDescription("Vector search column name (required)");
+  /** Vector search column name */
+  public static final ConfigOption<String> VECTOR_COLUMN =
+      ConfigOptions.key("vector.column")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("Vector search column name (required)");
 
-    /**
-     * Distance metric type: L2, Cosine, Dot
-     */
-    public static final ConfigOption<String> VECTOR_METRIC = ConfigOptions
-            .key("vector.metric")
-            .stringType()
-            .defaultValue("L2")
-            .withDescription("Vector distance metric type: L2 (Euclidean), Cosine, Dot, default L2");
+  /** Distance metric type: L2, Cosine, Dot */
+  public static final ConfigOption<String> VECTOR_METRIC =
+      ConfigOptions.key("vector.metric")
+          .stringType()
+          .defaultValue("L2")
+          .withDescription("Vector distance metric type: L2 (Euclidean), Cosine, Dot, default L2");
 
-    /**
-     * IVF search probe count
-     */
-    public static final ConfigOption<Integer> VECTOR_NPROBES = ConfigOptions
-            .key("vector.nprobes")
-            .intType()
-            .defaultValue(20)
-            .withDescription("Number of IVF index search probes, default 20");
+  /** IVF search probe count */
+  public static final ConfigOption<Integer> VECTOR_NPROBES =
+      ConfigOptions.key("vector.nprobes")
+          .intType()
+          .defaultValue(20)
+          .withDescription("Number of IVF index search probes, default 20");
 
-    /**
-     * HNSW search width
-     */
-    public static final ConfigOption<Integer> VECTOR_EF = ConfigOptions
-            .key("vector.ef")
-            .intType()
-            .defaultValue(100)
-            .withDescription("HNSW search width ef, default 100");
+  /** HNSW search width */
+  public static final ConfigOption<Integer> VECTOR_EF =
+      ConfigOptions.key("vector.ef")
+          .intType()
+          .defaultValue(100)
+          .withDescription("HNSW search width ef, default 100");
 
-    /**
-     * Refine factor
-     */
-    public static final ConfigOption<Integer> VECTOR_REFINE_FACTOR = ConfigOptions
-            .key("vector.refine-factor")
-            .intType()
-            .noDefaultValue()
-            .withDescription("Vector search refine factor for improving recall");
+  /** Refine factor */
+  public static final ConfigOption<Integer> VECTOR_REFINE_FACTOR =
+      ConfigOptions.key("vector.refine-factor")
+          .intType()
+          .noDefaultValue()
+          .withDescription("Vector search refine factor for improving recall");
 
-    // ==================== Catalog Configuration ====================
+  // ==================== Catalog Configuration ====================
 
-    /**
-     * Default database name
-     */
-    public static final ConfigOption<String> DEFAULT_DATABASE = ConfigOptions
-            .key("default-database")
-            .stringType()
-            .defaultValue("default")
-            .withDescription("Catalog default database name, default 'default'");
+  /** Default database name */
+  public static final ConfigOption<String> DEFAULT_DATABASE =
+      ConfigOptions.key("default-database")
+          .stringType()
+          .defaultValue("default")
+          .withDescription("Catalog default database name, default 'default'");
 
-    /**
-     * Warehouse path
-     */
-    public static final ConfigOption<String> WAREHOUSE = ConfigOptions
-            .key("warehouse")
-            .stringType()
-            .noDefaultValue()
-            .withDescription("Lance data warehouse path (required)");
+  /** Warehouse path */
+  public static final ConfigOption<String> WAREHOUSE =
+      ConfigOptions.key("warehouse")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("Lance data warehouse path (required)");
 
-    // ==================== Write Mode Enum ====================
+  // ==================== Write Mode Enum ====================
 
-    /**
-     * Write mode enum
-     */
-    public enum WriteMode {
-        APPEND("append"),
-        OVERWRITE("overwrite");
+  /** Write mode enum */
+  public enum WriteMode {
+    APPEND("append"),
+    OVERWRITE("overwrite");
 
-        private final String value;
+    private final String value;
 
-        WriteMode(String value) {
-            this.value = value;
-        }
-
-        public String getValue() {
-            return value;
-        }
-
-        public static WriteMode fromValue(String value) {
-            for (WriteMode mode : values()) {
-                if (mode.value.equalsIgnoreCase(value)) {
-                    return mode;
-                }
-            }
-            throw new IllegalArgumentException(
-                    "Unsupported write mode: " + value
-                            + ", supported modes: append, overwrite");
-        }
+    WriteMode(String value) {
+      this.value = value;
     }
 
-    // ==================== Index Type Enum ====================
-
-    /**
-     * Index type enum
-     */
-    public enum IndexType {
-        IVF_PQ("IVF_PQ"),
-        IVF_HNSW("IVF_HNSW"),
-        IVF_FLAT("IVF_FLAT");
-
-        private final String value;
-
-        IndexType(String value) {
-            this.value = value;
-        }
-
-        public String getValue() {
-            return value;
-        }
-
-        public static IndexType fromValue(String value) {
-            for (IndexType type : values()) {
-                if (type.value.equalsIgnoreCase(value)) {
-                    return type;
-                }
-            }
-            throw new IllegalArgumentException(
-                    "Unsupported index type: " + value
-                            + ", supported types: IVF_PQ, IVF_HNSW, IVF_FLAT");
-        }
+    public String getValue() {
+      return value;
     }
 
-    // ==================== Metric Type Enum ====================
-
-    /**
-     * Distance metric type enum
-     */
-    public enum MetricType {
-        L2("L2"),
-        COSINE("Cosine"),
-        DOT("Dot");
-
-        private final String value;
-
-        MetricType(String value) {
-            this.value = value;
+    public static WriteMode fromValue(String value) {
+      for (WriteMode mode : values()) {
+        if (mode.value.equalsIgnoreCase(value)) {
+          return mode;
         }
+      }
+      throw new IllegalArgumentException(
+          "Unsupported write mode: " + value + ", supported modes: append, overwrite");
+    }
+  }
 
-        public String getValue() {
-            return value;
-        }
+  // ==================== Index Type Enum ====================
 
-        public static MetricType fromValue(String value) {
-            for (MetricType type : values()) {
-                if (type.value.equalsIgnoreCase(value)) {
-                    return type;
-                }
-            }
-            throw new IllegalArgumentException(
-                    "Unsupported metric type: " + value
-                            + ", supported types: L2, Cosine, Dot");
-        }
+  /** Index type enum */
+  public enum IndexType {
+    IVF_PQ("IVF_PQ"),
+    IVF_HNSW("IVF_HNSW"),
+    IVF_FLAT("IVF_FLAT");
+
+    private final String value;
+
+    IndexType(String value) {
+      this.value = value;
     }
 
-    // ==================== Configuration Class ====================
-
-    private final String path;
-    private final int readBatchSize;
-    private final Long readLimit;
-    private final List<String> readColumns;
-    private final String readFilter;
-    private final int writeBatchSize;
-    private final WriteMode writeMode;
-    private final int writeMaxRowsPerFile;
-    private final IndexType indexType;
-    private final String indexColumn;
-    private final int indexNumPartitions;
-    private final Integer indexNumSubVectors;
-    private final int indexNumBits;
-    private final int indexMaxLevel;
-    private final int indexM;
-    private final int indexEfConstruction;
-    private final String vectorColumn;
-    private final MetricType vectorMetric;
-    private final int vectorNprobes;
-    private final int vectorEf;
-    private final Integer vectorRefineFactor;
-    private final String defaultDatabase;
-    private final String warehouse;
-
-    private LanceOptions(Builder builder) {
-        this.path = builder.path;
-        this.readBatchSize = builder.readBatchSize;
-        this.readLimit = builder.readLimit;
-        this.readColumns = builder.readColumns;
-        this.readFilter = builder.readFilter;
-        this.writeBatchSize = builder.writeBatchSize;
-        this.writeMode = builder.writeMode;
-        this.writeMaxRowsPerFile = builder.writeMaxRowsPerFile;
-        this.indexType = builder.indexType;
-        this.indexColumn = builder.indexColumn;
-        this.indexNumPartitions = builder.indexNumPartitions;
-        this.indexNumSubVectors = builder.indexNumSubVectors;
-        this.indexNumBits = builder.indexNumBits;
-        this.indexMaxLevel = builder.indexMaxLevel;
-        this.indexM = builder.indexM;
-        this.indexEfConstruction = builder.indexEfConstruction;
-        this.vectorColumn = builder.vectorColumn;
-        this.vectorMetric = builder.vectorMetric;
-        this.vectorNprobes = builder.vectorNprobes;
-        this.vectorEf = builder.vectorEf;
-        this.vectorRefineFactor = builder.vectorRefineFactor;
-        this.defaultDatabase = builder.defaultDatabase;
-        this.warehouse = builder.warehouse;
+    public String getValue() {
+      return value;
     }
 
-    // ==================== Getter Methods ====================
+    public static IndexType fromValue(String value) {
+      for (IndexType type : values()) {
+        if (type.value.equalsIgnoreCase(value)) {
+          return type;
+        }
+      }
+      throw new IllegalArgumentException(
+          "Unsupported index type: " + value + ", supported types: IVF_PQ, IVF_HNSW, IVF_FLAT");
+    }
+  }
 
-    public String getPath() {
-        return path;
+  // ==================== Metric Type Enum ====================
+
+  /** Distance metric type enum */
+  public enum MetricType {
+    L2("L2"),
+    COSINE("Cosine"),
+    DOT("Dot");
+
+    private final String value;
+
+    MetricType(String value) {
+      this.value = value;
     }
 
-    public int getReadBatchSize() {
-        return readBatchSize;
+    public String getValue() {
+      return value;
     }
 
-    public Long getReadLimit() {
-        return readLimit;
+    public static MetricType fromValue(String value) {
+      for (MetricType type : values()) {
+        if (type.value.equalsIgnoreCase(value)) {
+          return type;
+        }
+      }
+      throw new IllegalArgumentException(
+          "Unsupported metric type: " + value + ", supported types: L2, Cosine, Dot");
+    }
+  }
+
+  // ==================== Configuration Class ====================
+
+  private final String path;
+  private final int readBatchSize;
+  private final Long readLimit;
+  private final List<String> readColumns;
+  private final String readFilter;
+  private final int writeBatchSize;
+  private final WriteMode writeMode;
+  private final int writeMaxRowsPerFile;
+  private final IndexType indexType;
+  private final String indexColumn;
+  private final int indexNumPartitions;
+  private final Integer indexNumSubVectors;
+  private final int indexNumBits;
+  private final int indexMaxLevel;
+  private final int indexM;
+  private final int indexEfConstruction;
+  private final String vectorColumn;
+  private final MetricType vectorMetric;
+  private final int vectorNprobes;
+  private final int vectorEf;
+  private final Integer vectorRefineFactor;
+  private final String defaultDatabase;
+  private final String warehouse;
+
+  private LanceOptions(Builder builder) {
+    this.path = builder.path;
+    this.readBatchSize = builder.readBatchSize;
+    this.readLimit = builder.readLimit;
+    this.readColumns = builder.readColumns;
+    this.readFilter = builder.readFilter;
+    this.writeBatchSize = builder.writeBatchSize;
+    this.writeMode = builder.writeMode;
+    this.writeMaxRowsPerFile = builder.writeMaxRowsPerFile;
+    this.indexType = builder.indexType;
+    this.indexColumn = builder.indexColumn;
+    this.indexNumPartitions = builder.indexNumPartitions;
+    this.indexNumSubVectors = builder.indexNumSubVectors;
+    this.indexNumBits = builder.indexNumBits;
+    this.indexMaxLevel = builder.indexMaxLevel;
+    this.indexM = builder.indexM;
+    this.indexEfConstruction = builder.indexEfConstruction;
+    this.vectorColumn = builder.vectorColumn;
+    this.vectorMetric = builder.vectorMetric;
+    this.vectorNprobes = builder.vectorNprobes;
+    this.vectorEf = builder.vectorEf;
+    this.vectorRefineFactor = builder.vectorRefineFactor;
+    this.defaultDatabase = builder.defaultDatabase;
+    this.warehouse = builder.warehouse;
+  }
+
+  // ==================== Getter Methods ====================
+
+  public String getPath() {
+    return path;
+  }
+
+  public int getReadBatchSize() {
+    return readBatchSize;
+  }
+
+  public Long getReadLimit() {
+    return readLimit;
+  }
+
+  public List<String> getReadColumns() {
+    return readColumns;
+  }
+
+  public String getReadFilter() {
+    return readFilter;
+  }
+
+  public int getWriteBatchSize() {
+    return writeBatchSize;
+  }
+
+  public WriteMode getWriteMode() {
+    return writeMode;
+  }
+
+  public int getWriteMaxRowsPerFile() {
+    return writeMaxRowsPerFile;
+  }
+
+  public IndexType getIndexType() {
+    return indexType;
+  }
+
+  public String getIndexColumn() {
+    return indexColumn;
+  }
+
+  public int getIndexNumPartitions() {
+    return indexNumPartitions;
+  }
+
+  public Integer getIndexNumSubVectors() {
+    return indexNumSubVectors;
+  }
+
+  public int getIndexNumBits() {
+    return indexNumBits;
+  }
+
+  public int getIndexMaxLevel() {
+    return indexMaxLevel;
+  }
+
+  public int getIndexM() {
+    return indexM;
+  }
+
+  public int getIndexEfConstruction() {
+    return indexEfConstruction;
+  }
+
+  public String getVectorColumn() {
+    return vectorColumn;
+  }
+
+  public MetricType getVectorMetric() {
+    return vectorMetric;
+  }
+
+  public int getVectorNprobes() {
+    return vectorNprobes;
+  }
+
+  public int getVectorEf() {
+    return vectorEf;
+  }
+
+  public Integer getVectorRefineFactor() {
+    return vectorRefineFactor;
+  }
+
+  public String getDefaultDatabase() {
+    return defaultDatabase;
+  }
+
+  public String getWarehouse() {
+    return warehouse;
+  }
+
+  // ==================== Builder ====================
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Create LanceOptions from Flink Configuration */
+  public static LanceOptions fromConfiguration(Configuration config) {
+    Builder builder = builder();
+
+    // Common configuration
+    if (config.contains(PATH)) {
+      builder.path(config.get(PATH));
     }
 
-    public List<String> getReadColumns() {
-        return readColumns;
+    // Source configuration
+    builder.readBatchSize(config.get(READ_BATCH_SIZE));
+    if (config.contains(READ_LIMIT)) {
+      builder.readLimit(config.get(READ_LIMIT));
+    }
+    if (config.contains(READ_COLUMNS)) {
+      String columnsStr = config.get(READ_COLUMNS);
+      if (columnsStr != null && !columnsStr.isEmpty()) {
+        builder.readColumns(Arrays.asList(columnsStr.split(",")));
+      }
+    }
+    if (config.contains(READ_FILTER)) {
+      builder.readFilter(config.get(READ_FILTER));
     }
 
-    public String getReadFilter() {
-        return readFilter;
+    // Sink configuration
+    builder.writeBatchSize(config.get(WRITE_BATCH_SIZE));
+    builder.writeMode(WriteMode.fromValue(config.get(WRITE_MODE)));
+    builder.writeMaxRowsPerFile(config.get(WRITE_MAX_ROWS_PER_FILE));
+
+    // Index configuration
+    builder.indexType(IndexType.fromValue(config.get(INDEX_TYPE)));
+    if (config.contains(INDEX_COLUMN)) {
+      builder.indexColumn(config.get(INDEX_COLUMN));
+    }
+    builder.indexNumPartitions(config.get(INDEX_NUM_PARTITIONS));
+    if (config.contains(INDEX_NUM_SUB_VECTORS)) {
+      builder.indexNumSubVectors(config.get(INDEX_NUM_SUB_VECTORS));
+    }
+    builder.indexNumBits(config.get(INDEX_NUM_BITS));
+    builder.indexMaxLevel(config.get(INDEX_MAX_LEVEL));
+    builder.indexM(config.get(INDEX_M));
+    builder.indexEfConstruction(config.get(INDEX_EF_CONSTRUCTION));
+
+    // Vector search configuration
+    if (config.contains(VECTOR_COLUMN)) {
+      builder.vectorColumn(config.get(VECTOR_COLUMN));
+    }
+    builder.vectorMetric(MetricType.fromValue(config.get(VECTOR_METRIC)));
+    builder.vectorNprobes(config.get(VECTOR_NPROBES));
+    builder.vectorEf(config.get(VECTOR_EF));
+    if (config.contains(VECTOR_REFINE_FACTOR)) {
+      builder.vectorRefineFactor(config.get(VECTOR_REFINE_FACTOR));
     }
 
-    public int getWriteBatchSize() {
-        return writeBatchSize;
+    // Catalog configuration
+    builder.defaultDatabase(config.get(DEFAULT_DATABASE));
+    if (config.contains(WAREHOUSE)) {
+      builder.warehouse(config.get(WAREHOUSE));
     }
 
-    public WriteMode getWriteMode() {
-        return writeMode;
+    return builder.build();
+  }
+
+  /** Configuration builder */
+  public static class Builder {
+    private String path;
+    private int readBatchSize = 1024;
+    private Long readLimit;
+    private List<String> readColumns = Collections.emptyList();
+    private String readFilter;
+    private int writeBatchSize = 1024;
+    private WriteMode writeMode = WriteMode.APPEND;
+    private int writeMaxRowsPerFile = 1000000;
+    private IndexType indexType = IndexType.IVF_PQ;
+    private String indexColumn;
+    private int indexNumPartitions = 256;
+    private Integer indexNumSubVectors;
+    private int indexNumBits = 8;
+    private int indexMaxLevel = 7;
+    private int indexM = 16;
+    private int indexEfConstruction = 100;
+    private String vectorColumn;
+    private MetricType vectorMetric = MetricType.L2;
+    private int vectorNprobes = 20;
+    private int vectorEf = 100;
+    private Integer vectorRefineFactor;
+    private String defaultDatabase = "default";
+    private String warehouse;
+
+    public Builder path(String path) {
+      this.path = path;
+      return this;
     }
 
-    public int getWriteMaxRowsPerFile() {
-        return writeMaxRowsPerFile;
+    public Builder readBatchSize(int readBatchSize) {
+      this.readBatchSize = readBatchSize;
+      return this;
     }
 
-    public IndexType getIndexType() {
-        return indexType;
+    public Builder readLimit(Long readLimit) {
+      this.readLimit = readLimit;
+      return this;
     }
 
-    public String getIndexColumn() {
-        return indexColumn;
+    public Builder readColumns(List<String> readColumns) {
+      this.readColumns = readColumns != null ? readColumns : Collections.emptyList();
+      return this;
     }
 
-    public int getIndexNumPartitions() {
-        return indexNumPartitions;
+    public Builder readFilter(String readFilter) {
+      this.readFilter = readFilter;
+      return this;
     }
 
-    public Integer getIndexNumSubVectors() {
-        return indexNumSubVectors;
+    public Builder writeBatchSize(int writeBatchSize) {
+      this.writeBatchSize = writeBatchSize;
+      return this;
     }
 
-    public int getIndexNumBits() {
-        return indexNumBits;
+    public Builder writeMode(WriteMode writeMode) {
+      this.writeMode = writeMode;
+      return this;
     }
 
-    public int getIndexMaxLevel() {
-        return indexMaxLevel;
+    public Builder writeMaxRowsPerFile(int writeMaxRowsPerFile) {
+      this.writeMaxRowsPerFile = writeMaxRowsPerFile;
+      return this;
     }
 
-    public int getIndexM() {
-        return indexM;
+    public Builder indexType(IndexType indexType) {
+      this.indexType = indexType;
+      return this;
     }
 
-    public int getIndexEfConstruction() {
-        return indexEfConstruction;
+    public Builder indexColumn(String indexColumn) {
+      this.indexColumn = indexColumn;
+      return this;
     }
 
-    public String getVectorColumn() {
-        return vectorColumn;
+    public Builder indexNumPartitions(int indexNumPartitions) {
+      this.indexNumPartitions = indexNumPartitions;
+      return this;
     }
 
-    public MetricType getVectorMetric() {
-        return vectorMetric;
+    public Builder indexNumSubVectors(Integer indexNumSubVectors) {
+      this.indexNumSubVectors = indexNumSubVectors;
+      return this;
     }
 
-    public int getVectorNprobes() {
-        return vectorNprobes;
+    public Builder indexNumBits(int indexNumBits) {
+      this.indexNumBits = indexNumBits;
+      return this;
     }
 
-    public int getVectorEf() {
-        return vectorEf;
+    public Builder indexMaxLevel(int indexMaxLevel) {
+      this.indexMaxLevel = indexMaxLevel;
+      return this;
     }
 
-    public Integer getVectorRefineFactor() {
-        return vectorRefineFactor;
+    public Builder indexM(int indexM) {
+      this.indexM = indexM;
+      return this;
     }
 
-    public String getDefaultDatabase() {
-        return defaultDatabase;
+    public Builder indexEfConstruction(int indexEfConstruction) {
+      this.indexEfConstruction = indexEfConstruction;
+      return this;
     }
 
-    public String getWarehouse() {
-        return warehouse;
+    public Builder vectorColumn(String vectorColumn) {
+      this.vectorColumn = vectorColumn;
+      return this;
     }
 
-    // ==================== Builder ====================
-
-    public static Builder builder() {
-        return new Builder();
+    public Builder vectorMetric(MetricType vectorMetric) {
+      this.vectorMetric = vectorMetric;
+      return this;
     }
 
-    /**
-     * Create LanceOptions from Flink Configuration
-     */
-    public static LanceOptions fromConfiguration(Configuration config) {
-        Builder builder = builder();
-
-        // Common configuration
-        if (config.contains(PATH)) {
-            builder.path(config.get(PATH));
-        }
-
-        // Source configuration
-        builder.readBatchSize(config.get(READ_BATCH_SIZE));
-        if (config.contains(READ_LIMIT)) {
-            builder.readLimit(config.get(READ_LIMIT));
-        }
-        if (config.contains(READ_COLUMNS)) {
-            String columnsStr = config.get(READ_COLUMNS);
-            if (columnsStr != null && !columnsStr.isEmpty()) {
-                builder.readColumns(Arrays.asList(columnsStr.split(",")));
-            }
-        }
-        if (config.contains(READ_FILTER)) {
-            builder.readFilter(config.get(READ_FILTER));
-        }
-
-        // Sink configuration
-        builder.writeBatchSize(config.get(WRITE_BATCH_SIZE));
-        builder.writeMode(WriteMode.fromValue(config.get(WRITE_MODE)));
-        builder.writeMaxRowsPerFile(config.get(WRITE_MAX_ROWS_PER_FILE));
-
-        // Index configuration
-        builder.indexType(IndexType.fromValue(config.get(INDEX_TYPE)));
-        if (config.contains(INDEX_COLUMN)) {
-            builder.indexColumn(config.get(INDEX_COLUMN));
-        }
-        builder.indexNumPartitions(config.get(INDEX_NUM_PARTITIONS));
-        if (config.contains(INDEX_NUM_SUB_VECTORS)) {
-            builder.indexNumSubVectors(config.get(INDEX_NUM_SUB_VECTORS));
-        }
-        builder.indexNumBits(config.get(INDEX_NUM_BITS));
-        builder.indexMaxLevel(config.get(INDEX_MAX_LEVEL));
-        builder.indexM(config.get(INDEX_M));
-        builder.indexEfConstruction(config.get(INDEX_EF_CONSTRUCTION));
-
-        // Vector search configuration
-        if (config.contains(VECTOR_COLUMN)) {
-            builder.vectorColumn(config.get(VECTOR_COLUMN));
-        }
-        builder.vectorMetric(MetricType.fromValue(config.get(VECTOR_METRIC)));
-        builder.vectorNprobes(config.get(VECTOR_NPROBES));
-        builder.vectorEf(config.get(VECTOR_EF));
-        if (config.contains(VECTOR_REFINE_FACTOR)) {
-            builder.vectorRefineFactor(config.get(VECTOR_REFINE_FACTOR));
-        }
-
-        // Catalog configuration
-        builder.defaultDatabase(config.get(DEFAULT_DATABASE));
-        if (config.contains(WAREHOUSE)) {
-            builder.warehouse(config.get(WAREHOUSE));
-        }
-
-        return builder.build();
+    public Builder vectorNprobes(int vectorNprobes) {
+      this.vectorNprobes = vectorNprobes;
+      return this;
     }
 
-    /**
-     * Configuration builder
-     */
-    public static class Builder {
-        private String path;
-        private int readBatchSize = 1024;
-        private Long readLimit;
-        private List<String> readColumns = Collections.emptyList();
-        private String readFilter;
-        private int writeBatchSize = 1024;
-        private WriteMode writeMode = WriteMode.APPEND;
-        private int writeMaxRowsPerFile = 1000000;
-        private IndexType indexType = IndexType.IVF_PQ;
-        private String indexColumn;
-        private int indexNumPartitions = 256;
-        private Integer indexNumSubVectors;
-        private int indexNumBits = 8;
-        private int indexMaxLevel = 7;
-        private int indexM = 16;
-        private int indexEfConstruction = 100;
-        private String vectorColumn;
-        private MetricType vectorMetric = MetricType.L2;
-        private int vectorNprobes = 20;
-        private int vectorEf = 100;
-        private Integer vectorRefineFactor;
-        private String defaultDatabase = "default";
-        private String warehouse;
-
-        public Builder path(String path) {
-            this.path = path;
-            return this;
-        }
-
-        public Builder readBatchSize(int readBatchSize) {
-            this.readBatchSize = readBatchSize;
-            return this;
-        }
-
-        public Builder readLimit(Long readLimit) {
-            this.readLimit = readLimit;
-            return this;
-        }
-
-        public Builder readColumns(List<String> readColumns) {
-            this.readColumns = readColumns != null ? readColumns : Collections.emptyList();
-            return this;
-        }
-
-        public Builder readFilter(String readFilter) {
-            this.readFilter = readFilter;
-            return this;
-        }
-
-        public Builder writeBatchSize(int writeBatchSize) {
-            this.writeBatchSize = writeBatchSize;
-            return this;
-        }
-
-        public Builder writeMode(WriteMode writeMode) {
-            this.writeMode = writeMode;
-            return this;
-        }
-
-        public Builder writeMaxRowsPerFile(int writeMaxRowsPerFile) {
-            this.writeMaxRowsPerFile = writeMaxRowsPerFile;
-            return this;
-        }
-
-        public Builder indexType(IndexType indexType) {
-            this.indexType = indexType;
-            return this;
-        }
-
-        public Builder indexColumn(String indexColumn) {
-            this.indexColumn = indexColumn;
-            return this;
-        }
-
-        public Builder indexNumPartitions(int indexNumPartitions) {
-            this.indexNumPartitions = indexNumPartitions;
-            return this;
-        }
-
-        public Builder indexNumSubVectors(Integer indexNumSubVectors) {
-            this.indexNumSubVectors = indexNumSubVectors;
-            return this;
-        }
-
-        public Builder indexNumBits(int indexNumBits) {
-            this.indexNumBits = indexNumBits;
-            return this;
-        }
-
-        public Builder indexMaxLevel(int indexMaxLevel) {
-            this.indexMaxLevel = indexMaxLevel;
-            return this;
-        }
-
-        public Builder indexM(int indexM) {
-            this.indexM = indexM;
-            return this;
-        }
-
-        public Builder indexEfConstruction(int indexEfConstruction) {
-            this.indexEfConstruction = indexEfConstruction;
-            return this;
-        }
-
-        public Builder vectorColumn(String vectorColumn) {
-            this.vectorColumn = vectorColumn;
-            return this;
-        }
-
-        public Builder vectorMetric(MetricType vectorMetric) {
-            this.vectorMetric = vectorMetric;
-            return this;
-        }
-
-        public Builder vectorNprobes(int vectorNprobes) {
-            this.vectorNprobes = vectorNprobes;
-            return this;
-        }
-
-        public Builder vectorEf(int vectorEf) {
-            this.vectorEf = vectorEf;
-            return this;
-        }
-
-        public Builder vectorRefineFactor(Integer vectorRefineFactor) {
-            this.vectorRefineFactor = vectorRefineFactor;
-            return this;
-        }
-
-        public Builder defaultDatabase(String defaultDatabase) {
-            this.defaultDatabase = defaultDatabase;
-            return this;
-        }
-
-        public Builder warehouse(String warehouse) {
-            this.warehouse = warehouse;
-            return this;
-        }
-
-        /**
-         * Build LanceOptions instance with validation
-         */
-        public LanceOptions build() {
-            validate();
-            return new LanceOptions(this);
-        }
-
-        /**
-         * Validate configuration
-         */
-        private void validate() {
-            // Validate read batch size
-            if (readBatchSize <= 0) {
-                throw new IllegalArgumentException(
-                        "read.batch-size must be greater than 0, current value: "
-                                + readBatchSize);
-            }
-
-            // Validate Limit (if set)
-            if (readLimit != null && readLimit < 0) {
-                throw new IllegalArgumentException(
-                        "read.limit must be >= 0, current value: "
-                                + readLimit);
-            }
-
-            // Validate write batch size
-            if (writeBatchSize <= 0) {
-                throw new IllegalArgumentException(
-                        "write.batch-size must be greater than 0, current value: "
-                                + writeBatchSize);
-            }
-
-            // Validate max rows per file
-            if (writeMaxRowsPerFile <= 0) {
-                throw new IllegalArgumentException(
-                        "write.max-rows-per-file must be > 0, current value: "
-                                + writeMaxRowsPerFile);
-            }
-
-            // Validate index partition count
-            if (indexNumPartitions <= 0) {
-                throw new IllegalArgumentException(
-                        "index.num-partitions must be > 0, current value: "
-                                + indexNumPartitions);
-            }
-
-            // Validate PQ sub-vector count
-            if (indexNumSubVectors != null && indexNumSubVectors <= 0) {
-                throw new IllegalArgumentException(
-                        "index.num-sub-vectors must be > 0, current value: "
-                                + indexNumSubVectors);
-            }
-
-            // Validate PQ quantization bits
-            if (indexNumBits <= 0 || indexNumBits > 16) {
-                throw new IllegalArgumentException(
-                        "index.num-bits must be between 1 and 16, current value: "
-                                + indexNumBits);
-            }
-
-            // Validate HNSW parameters
-            if (indexMaxLevel <= 0) {
-                throw new IllegalArgumentException(
-                        "index.max-level must be > 0, current value: "
-                                + indexMaxLevel);
-            }
-
-            if (indexM <= 0) {
-                throw new IllegalArgumentException("index.m must be greater than 0, current value: " + indexM);
-            }
-
-            if (indexEfConstruction <= 0) {
-                throw new IllegalArgumentException(
-                        "index.ef-construction must be > 0, current value: "
-                                + indexEfConstruction);
-            }
-
-            // Validate vector search parameters
-            if (vectorNprobes <= 0) {
-                throw new IllegalArgumentException(
-                        "vector.nprobes must be > 0, current value: "
-                                + vectorNprobes);
-            }
-
-            if (vectorEf <= 0) {
-                throw new IllegalArgumentException("vector.ef must be greater than 0, current value: " + vectorEf);
-            }
-
-            if (vectorRefineFactor != null && vectorRefineFactor <= 0) {
-                throw new IllegalArgumentException(
-                        "vector.refine-factor must be > 0, current value: "
-                                + vectorRefineFactor);
-            }
-        }
+    public Builder vectorEf(int vectorEf) {
+      this.vectorEf = vectorEf;
+      return this;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        LanceOptions that = (LanceOptions) o;
-        return readBatchSize == that.readBatchSize &&
-                Objects.equals(readLimit, that.readLimit) &&
-                writeBatchSize == that.writeBatchSize &&
-                writeMaxRowsPerFile == that.writeMaxRowsPerFile &&
-                indexNumPartitions == that.indexNumPartitions &&
-                indexNumBits == that.indexNumBits &&
-                indexMaxLevel == that.indexMaxLevel &&
-                indexM == that.indexM &&
-                indexEfConstruction == that.indexEfConstruction &&
-                vectorNprobes == that.vectorNprobes &&
-                vectorEf == that.vectorEf &&
-                Objects.equals(path, that.path) &&
-                Objects.equals(readColumns, that.readColumns) &&
-                Objects.equals(readFilter, that.readFilter) &&
-                writeMode == that.writeMode &&
-                indexType == that.indexType &&
-                Objects.equals(indexColumn, that.indexColumn) &&
-                Objects.equals(indexNumSubVectors, that.indexNumSubVectors) &&
-                Objects.equals(vectorColumn, that.vectorColumn) &&
-                vectorMetric == that.vectorMetric &&
-                Objects.equals(vectorRefineFactor, that.vectorRefineFactor) &&
-                Objects.equals(defaultDatabase, that.defaultDatabase) &&
-                Objects.equals(warehouse, that.warehouse);
+    public Builder vectorRefineFactor(Integer vectorRefineFactor) {
+      this.vectorRefineFactor = vectorRefineFactor;
+      return this;
     }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(path, readBatchSize, readLimit, readColumns, readFilter, writeBatchSize, writeMode,
-                writeMaxRowsPerFile, indexType, indexColumn, indexNumPartitions, indexNumSubVectors,
-                indexNumBits, indexMaxLevel, indexM, indexEfConstruction, vectorColumn, vectorMetric,
-                vectorNprobes, vectorEf, vectorRefineFactor, defaultDatabase, warehouse);
+    public Builder defaultDatabase(String defaultDatabase) {
+      this.defaultDatabase = defaultDatabase;
+      return this;
     }
 
-    @Override
-    public String toString() {
-        return "LanceOptions{" +
-                "path='" + path + '\'' +
-                ", readBatchSize=" + readBatchSize +
-                ", readLimit=" + readLimit +
-                ", readColumns=" + readColumns +
-                ", readFilter='" + readFilter + '\'' +
-                ", writeBatchSize=" + writeBatchSize +
-                ", writeMode=" + writeMode +
-                ", writeMaxRowsPerFile=" + writeMaxRowsPerFile +
-                ", indexType=" + indexType +
-                ", indexColumn='" + indexColumn + '\'' +
-                ", indexNumPartitions=" + indexNumPartitions +
-                ", indexNumSubVectors=" + indexNumSubVectors +
-                ", indexNumBits=" + indexNumBits +
-                ", indexMaxLevel=" + indexMaxLevel +
-                ", indexM=" + indexM +
-                ", indexEfConstruction=" + indexEfConstruction +
-                ", vectorColumn='" + vectorColumn + '\'' +
-                ", vectorMetric=" + vectorMetric +
-                ", vectorNprobes=" + vectorNprobes +
-                ", vectorEf=" + vectorEf +
-                ", vectorRefineFactor=" + vectorRefineFactor +
-                ", defaultDatabase='" + defaultDatabase + '\'' +
-                ", warehouse='" + warehouse + '\'' +
-                '}';
+    public Builder warehouse(String warehouse) {
+      this.warehouse = warehouse;
+      return this;
     }
+
+    /** Build LanceOptions instance with validation */
+    public LanceOptions build() {
+      validate();
+      return new LanceOptions(this);
+    }
+
+    /** Validate configuration */
+    private void validate() {
+      // Validate read batch size
+      if (readBatchSize <= 0) {
+        throw new IllegalArgumentException(
+            "read.batch-size must be greater than 0, current value: " + readBatchSize);
+      }
+
+      // Validate Limit (if set)
+      if (readLimit != null && readLimit < 0) {
+        throw new IllegalArgumentException("read.limit must be >= 0, current value: " + readLimit);
+      }
+
+      // Validate write batch size
+      if (writeBatchSize <= 0) {
+        throw new IllegalArgumentException(
+            "write.batch-size must be greater than 0, current value: " + writeBatchSize);
+      }
+
+      // Validate max rows per file
+      if (writeMaxRowsPerFile <= 0) {
+        throw new IllegalArgumentException(
+            "write.max-rows-per-file must be > 0, current value: " + writeMaxRowsPerFile);
+      }
+
+      // Validate index partition count
+      if (indexNumPartitions <= 0) {
+        throw new IllegalArgumentException(
+            "index.num-partitions must be > 0, current value: " + indexNumPartitions);
+      }
+
+      // Validate PQ sub-vector count
+      if (indexNumSubVectors != null && indexNumSubVectors <= 0) {
+        throw new IllegalArgumentException(
+            "index.num-sub-vectors must be > 0, current value: " + indexNumSubVectors);
+      }
+
+      // Validate PQ quantization bits
+      if (indexNumBits <= 0 || indexNumBits > 16) {
+        throw new IllegalArgumentException(
+            "index.num-bits must be between 1 and 16, current value: " + indexNumBits);
+      }
+
+      // Validate HNSW parameters
+      if (indexMaxLevel <= 0) {
+        throw new IllegalArgumentException(
+            "index.max-level must be > 0, current value: " + indexMaxLevel);
+      }
+
+      if (indexM <= 0) {
+        throw new IllegalArgumentException(
+            "index.m must be greater than 0, current value: " + indexM);
+      }
+
+      if (indexEfConstruction <= 0) {
+        throw new IllegalArgumentException(
+            "index.ef-construction must be > 0, current value: " + indexEfConstruction);
+      }
+
+      // Validate vector search parameters
+      if (vectorNprobes <= 0) {
+        throw new IllegalArgumentException(
+            "vector.nprobes must be > 0, current value: " + vectorNprobes);
+      }
+
+      if (vectorEf <= 0) {
+        throw new IllegalArgumentException(
+            "vector.ef must be greater than 0, current value: " + vectorEf);
+      }
+
+      if (vectorRefineFactor != null && vectorRefineFactor <= 0) {
+        throw new IllegalArgumentException(
+            "vector.refine-factor must be > 0, current value: " + vectorRefineFactor);
+      }
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    LanceOptions that = (LanceOptions) o;
+    return readBatchSize == that.readBatchSize
+        && Objects.equals(readLimit, that.readLimit)
+        && writeBatchSize == that.writeBatchSize
+        && writeMaxRowsPerFile == that.writeMaxRowsPerFile
+        && indexNumPartitions == that.indexNumPartitions
+        && indexNumBits == that.indexNumBits
+        && indexMaxLevel == that.indexMaxLevel
+        && indexM == that.indexM
+        && indexEfConstruction == that.indexEfConstruction
+        && vectorNprobes == that.vectorNprobes
+        && vectorEf == that.vectorEf
+        && Objects.equals(path, that.path)
+        && Objects.equals(readColumns, that.readColumns)
+        && Objects.equals(readFilter, that.readFilter)
+        && writeMode == that.writeMode
+        && indexType == that.indexType
+        && Objects.equals(indexColumn, that.indexColumn)
+        && Objects.equals(indexNumSubVectors, that.indexNumSubVectors)
+        && Objects.equals(vectorColumn, that.vectorColumn)
+        && vectorMetric == that.vectorMetric
+        && Objects.equals(vectorRefineFactor, that.vectorRefineFactor)
+        && Objects.equals(defaultDatabase, that.defaultDatabase)
+        && Objects.equals(warehouse, that.warehouse);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        path,
+        readBatchSize,
+        readLimit,
+        readColumns,
+        readFilter,
+        writeBatchSize,
+        writeMode,
+        writeMaxRowsPerFile,
+        indexType,
+        indexColumn,
+        indexNumPartitions,
+        indexNumSubVectors,
+        indexNumBits,
+        indexMaxLevel,
+        indexM,
+        indexEfConstruction,
+        vectorColumn,
+        vectorMetric,
+        vectorNprobes,
+        vectorEf,
+        vectorRefineFactor,
+        defaultDatabase,
+        warehouse);
+  }
+
+  @Override
+  public String toString() {
+    return "LanceOptions{"
+        + "path='"
+        + path
+        + '\''
+        + ", readBatchSize="
+        + readBatchSize
+        + ", readLimit="
+        + readLimit
+        + ", readColumns="
+        + readColumns
+        + ", readFilter='"
+        + readFilter
+        + '\''
+        + ", writeBatchSize="
+        + writeBatchSize
+        + ", writeMode="
+        + writeMode
+        + ", writeMaxRowsPerFile="
+        + writeMaxRowsPerFile
+        + ", indexType="
+        + indexType
+        + ", indexColumn='"
+        + indexColumn
+        + '\''
+        + ", indexNumPartitions="
+        + indexNumPartitions
+        + ", indexNumSubVectors="
+        + indexNumSubVectors
+        + ", indexNumBits="
+        + indexNumBits
+        + ", indexMaxLevel="
+        + indexMaxLevel
+        + ", indexM="
+        + indexM
+        + ", indexEfConstruction="
+        + indexEfConstruction
+        + ", vectorColumn='"
+        + vectorColumn
+        + '\''
+        + ", vectorMetric="
+        + vectorMetric
+        + ", vectorNprobes="
+        + vectorNprobes
+        + ", vectorEf="
+        + vectorEf
+        + ", vectorRefineFactor="
+        + vectorRefineFactor
+        + ", defaultDatabase='"
+        + defaultDatabase
+        + '\''
+        + ", warehouse='"
+        + warehouse
+        + '\''
+        + '}';
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/config/LanceOptions.java
+++ b/src/main/java/org/apache/flink/connector/lance/config/LanceOptions.java
@@ -437,6 +437,55 @@ public class LanceOptions implements Serializable {
     return warehouse;
   }
 
+  // ==================== Sub-Options Conversion ====================
+
+  /** Convert to {@link LanceSourceOptions} for source-only usage. */
+  public LanceSourceOptions toSourceOptions() {
+    return LanceSourceOptions.builder()
+        .path(path)
+        .batchSize(readBatchSize)
+        .limit(readLimit)
+        .columns(readColumns)
+        .filter(readFilter)
+        .build();
+  }
+
+  /** Convert to {@link LanceSinkOptions} for sink-only usage. */
+  public LanceSinkOptions toSinkOptions() {
+    return LanceSinkOptions.builder()
+        .path(path)
+        .batchSize(writeBatchSize)
+        .writeMode(writeMode)
+        .maxRowsPerFile(writeMaxRowsPerFile)
+        .build();
+  }
+
+  /** Convert to {@link LanceIndexOptions} for index-building usage. */
+  public LanceIndexOptions toIndexOptions() {
+    return LanceIndexOptions.builder()
+        .columnName(indexColumn)
+        .indexType(indexType)
+        .metricType(vectorMetric)
+        .numPartitions(indexNumPartitions)
+        .numSubVectors(indexNumSubVectors)
+        .numBits(indexNumBits)
+        .maxLevel(indexMaxLevel)
+        .maxEdges(indexM)
+        .efConstruction(indexEfConstruction)
+        .build();
+  }
+
+  /** Convert to {@link LanceVectorSearchOptions} for vector-search usage. */
+  public LanceVectorSearchOptions toVectorSearchOptions() {
+    return LanceVectorSearchOptions.builder()
+        .columnName(vectorColumn)
+        .metricType(vectorMetric)
+        .nprobes(vectorNprobes)
+        .ef(vectorEf)
+        .refineFactor(vectorRefineFactor)
+        .build();
+  }
+
   // ==================== Builder ====================
 
   public static Builder builder() {

--- a/src/main/java/org/apache/flink/connector/lance/config/LanceSinkOptions.java
+++ b/src/main/java/org/apache/flink/connector/lance/config/LanceSinkOptions.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.config;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Immutable configuration for Lance Sink (write side).
+ *
+ * <p>Contains all write-related options: dataset path, batch size, write mode, and max rows per
+ * file.
+ *
+ * <p>Use {@link Builder} to construct instances.
+ */
+public final class LanceSinkOptions implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String path;
+  private final int batchSize;
+  private final LanceOptions.WriteMode writeMode;
+  private final int maxRowsPerFile;
+
+  private LanceSinkOptions(Builder builder) {
+    this.path = builder.path;
+    this.batchSize = builder.batchSize;
+    this.writeMode = builder.writeMode;
+    this.maxRowsPerFile = builder.maxRowsPerFile;
+  }
+
+  /** Lance dataset path. */
+  public String getPath() {
+    return path;
+  }
+
+  /** Batch size for writing. */
+  public int getBatchSize() {
+    return batchSize;
+  }
+
+  /** Write mode: APPEND or OVERWRITE. */
+  public LanceOptions.WriteMode getWriteMode() {
+    return writeMode;
+  }
+
+  /** Maximum rows per data file. */
+  public int getMaxRowsPerFile() {
+    return maxRowsPerFile;
+  }
+
+  /** Create a new Builder. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Create a new Builder pre-populated with this instance's values, useful for creating a modified
+   * copy.
+   */
+  public Builder toBuilder() {
+    return new Builder()
+        .path(path)
+        .batchSize(batchSize)
+        .writeMode(writeMode)
+        .maxRowsPerFile(maxRowsPerFile);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    LanceSinkOptions that = (LanceSinkOptions) o;
+    return batchSize == that.batchSize
+        && maxRowsPerFile == that.maxRowsPerFile
+        && Objects.equals(path, that.path)
+        && writeMode == that.writeMode;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(path, batchSize, writeMode, maxRowsPerFile);
+  }
+
+  @Override
+  public String toString() {
+    return "LanceSinkOptions{"
+        + "path='"
+        + path
+        + '\''
+        + ", batchSize="
+        + batchSize
+        + ", writeMode="
+        + writeMode
+        + ", maxRowsPerFile="
+        + maxRowsPerFile
+        + '}';
+  }
+
+  /** Builder for {@link LanceSinkOptions}. */
+  public static class Builder {
+    private String path;
+    private int batchSize = 1024;
+    private LanceOptions.WriteMode writeMode = LanceOptions.WriteMode.APPEND;
+    private int maxRowsPerFile = 1000000;
+
+    public Builder path(String path) {
+      this.path = path;
+      return this;
+    }
+
+    public Builder batchSize(int batchSize) {
+      this.batchSize = batchSize;
+      return this;
+    }
+
+    public Builder writeMode(LanceOptions.WriteMode writeMode) {
+      this.writeMode = writeMode;
+      return this;
+    }
+
+    public Builder maxRowsPerFile(int maxRowsPerFile) {
+      this.maxRowsPerFile = maxRowsPerFile;
+      return this;
+    }
+
+    /** Build with validation. */
+    public LanceSinkOptions build() {
+      if (batchSize <= 0) {
+        throw new IllegalArgumentException(
+            "write.batch-size must be greater than 0, current value: " + batchSize);
+      }
+      if (maxRowsPerFile <= 0) {
+        throw new IllegalArgumentException(
+            "write.max-rows-per-file must be > 0, current value: " + maxRowsPerFile);
+      }
+      return new LanceSinkOptions(this);
+    }
+  }
+}

--- a/src/main/java/org/apache/flink/connector/lance/config/LanceSourceOptions.java
+++ b/src/main/java/org/apache/flink/connector/lance/config/LanceSourceOptions.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.config;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Immutable configuration for Lance Source (read side).
+ *
+ * <p>Contains all read-related options: dataset path, batch size, column projection, filter
+ * conditions, and read limit.
+ *
+ * <p>Use {@link Builder} to construct instances.
+ */
+public final class LanceSourceOptions implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String path;
+  private final int batchSize;
+  private final Long limit;
+  private final List<String> columns;
+  private final String filter;
+
+  private LanceSourceOptions(Builder builder) {
+    this.path = builder.path;
+    this.batchSize = builder.batchSize;
+    this.limit = builder.limit;
+    this.columns =
+        builder.columns != null
+            ? Collections.unmodifiableList(builder.columns)
+            : Collections.emptyList();
+    this.filter = builder.filter;
+  }
+
+  /** Lance dataset path. */
+  public String getPath() {
+    return path;
+  }
+
+  /** Batch size for reading. */
+  public int getBatchSize() {
+    return batchSize;
+  }
+
+  /** Maximum number of rows to read (for Limit push-down), null means no limit. */
+  public Long getLimit() {
+    return limit;
+  }
+
+  /** Columns to read; empty list means all columns. */
+  public List<String> getColumns() {
+    return columns;
+  }
+
+  /** Data filter condition (SQL WHERE clause syntax), null means no filter. */
+  public String getFilter() {
+    return filter;
+  }
+
+  /** Create a new Builder. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Create a new Builder pre-populated with this instance's values, useful for creating a modified
+   * copy.
+   */
+  public Builder toBuilder() {
+    return new Builder()
+        .path(path)
+        .batchSize(batchSize)
+        .limit(limit)
+        .columns(columns)
+        .filter(filter);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    LanceSourceOptions that = (LanceSourceOptions) o;
+    return batchSize == that.batchSize
+        && Objects.equals(path, that.path)
+        && Objects.equals(limit, that.limit)
+        && Objects.equals(columns, that.columns)
+        && Objects.equals(filter, that.filter);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(path, batchSize, limit, columns, filter);
+  }
+
+  @Override
+  public String toString() {
+    return "LanceSourceOptions{"
+        + "path='"
+        + path
+        + '\''
+        + ", batchSize="
+        + batchSize
+        + ", limit="
+        + limit
+        + ", columns="
+        + columns
+        + ", filter='"
+        + filter
+        + '\''
+        + '}';
+  }
+
+  /** Builder for {@link LanceSourceOptions}. */
+  public static class Builder {
+    private String path;
+    private int batchSize = 1024;
+    private Long limit;
+    private List<String> columns = Collections.emptyList();
+    private String filter;
+
+    public Builder path(String path) {
+      this.path = path;
+      return this;
+    }
+
+    public Builder batchSize(int batchSize) {
+      this.batchSize = batchSize;
+      return this;
+    }
+
+    public Builder limit(Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    public Builder columns(List<String> columns) {
+      this.columns = columns != null ? columns : Collections.emptyList();
+      return this;
+    }
+
+    public Builder filter(String filter) {
+      this.filter = filter;
+      return this;
+    }
+
+    /** Build with validation. */
+    public LanceSourceOptions build() {
+      if (batchSize <= 0) {
+        throw new IllegalArgumentException(
+            "read.batch-size must be greater than 0, current value: " + batchSize);
+      }
+      if (limit != null && limit < 0) {
+        throw new IllegalArgumentException("read.limit must be >= 0, current value: " + limit);
+      }
+      return new LanceSourceOptions(this);
+    }
+  }
+}

--- a/src/main/java/org/apache/flink/connector/lance/config/LanceVectorSearchOptions.java
+++ b/src/main/java/org/apache/flink/connector/lance/config/LanceVectorSearchOptions.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.config;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Immutable configuration for Lance vector search.
+ *
+ * <p>Contains all vector search options: column name, distance metric, nprobes, ef, refine factor.
+ *
+ * <p>Use {@link Builder} to construct instances.
+ */
+public final class LanceVectorSearchOptions implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private final String columnName;
+  private final LanceOptions.MetricType metricType;
+  private final int nprobes;
+  private final int ef;
+  private final Integer refineFactor;
+
+  private LanceVectorSearchOptions(Builder builder) {
+    this.columnName = builder.columnName;
+    this.metricType = builder.metricType;
+    this.nprobes = builder.nprobes;
+    this.ef = builder.ef;
+    this.refineFactor = builder.refineFactor;
+  }
+
+  /** Vector search column name. */
+  public String getColumnName() {
+    return columnName;
+  }
+
+  /** Distance metric type (L2, Cosine, Dot). */
+  public LanceOptions.MetricType getMetricType() {
+    return metricType;
+  }
+
+  /** IVF search probe count. */
+  public int getNprobes() {
+    return nprobes;
+  }
+
+  /** HNSW search width ef. */
+  public int getEf() {
+    return ef;
+  }
+
+  /** Refine factor for improving recall, null means not set. */
+  public Integer getRefineFactor() {
+    return refineFactor;
+  }
+
+  /** Create a new Builder. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    LanceVectorSearchOptions that = (LanceVectorSearchOptions) o;
+    return nprobes == that.nprobes
+        && ef == that.ef
+        && Objects.equals(columnName, that.columnName)
+        && metricType == that.metricType
+        && Objects.equals(refineFactor, that.refineFactor);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(columnName, metricType, nprobes, ef, refineFactor);
+  }
+
+  @Override
+  public String toString() {
+    return "LanceVectorSearchOptions{"
+        + "columnName='"
+        + columnName
+        + '\''
+        + ", metricType="
+        + metricType
+        + ", nprobes="
+        + nprobes
+        + ", ef="
+        + ef
+        + ", refineFactor="
+        + refineFactor
+        + '}';
+  }
+
+  /** Builder for {@link LanceVectorSearchOptions}. */
+  public static class Builder {
+    private String columnName;
+    private LanceOptions.MetricType metricType = LanceOptions.MetricType.L2;
+    private int nprobes = 20;
+    private int ef = 100;
+    private Integer refineFactor;
+
+    public Builder columnName(String columnName) {
+      this.columnName = columnName;
+      return this;
+    }
+
+    public Builder metricType(LanceOptions.MetricType metricType) {
+      this.metricType = metricType;
+      return this;
+    }
+
+    public Builder nprobes(int nprobes) {
+      this.nprobes = nprobes;
+      return this;
+    }
+
+    public Builder ef(int ef) {
+      this.ef = ef;
+      return this;
+    }
+
+    public Builder refineFactor(Integer refineFactor) {
+      this.refineFactor = refineFactor;
+      return this;
+    }
+
+    /** Build with validation. */
+    public LanceVectorSearchOptions build() {
+      if (nprobes <= 0) {
+        throw new IllegalArgumentException("vector.nprobes must be > 0, current value: " + nprobes);
+      }
+      if (ef <= 0) {
+        throw new IllegalArgumentException(
+            "vector.ef must be greater than 0, current value: " + ef);
+      }
+      if (refineFactor != null && refineFactor <= 0) {
+        throw new IllegalArgumentException(
+            "vector.refine-factor must be > 0, current value: " + refineFactor);
+      }
+      return new LanceVectorSearchOptions(this);
+    }
+  }
+}

--- a/src/main/java/org/apache/flink/connector/lance/converter/LanceTypeConverter.java
+++ b/src/main/java/org/apache/flink/connector/lance/converter/LanceTypeConverter.java
@@ -52,7 +52,7 @@ import java.util.List;
 
 /**
  * Type converter between Lance/Arrow and Flink types.
- * 
+ *
  * <p>Supported type mappings:
  * <ul>
  *   <li>Int8 <-> TINYINT</li>
@@ -267,11 +267,11 @@ public class LanceTypeConverter implements Serializable {
     public static Field createVectorField(String name, int dimension, boolean nullable) {
         ArrowType elementType = new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE);
         Field elementField = new Field("item", new FieldType(false, elementType, null), null);
-        
+
         ArrowType listType = new ArrowType.FixedSizeList(dimension);
         List<Field> children = new ArrayList<>();
         children.add(elementField);
-        
+
         return new Field(name, new FieldType(nullable, listType, null), children);
     }
 
@@ -286,11 +286,11 @@ public class LanceTypeConverter implements Serializable {
     public static Field createFloat64VectorField(String name, int dimension, boolean nullable) {
         ArrowType elementType = new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
         Field elementField = new Field("item", new FieldType(false, elementType, null), null);
-        
+
         ArrowType listType = new ArrowType.FixedSizeList(dimension);
         List<Field> children = new ArrayList<>();
         children.add(elementField);
-        
+
         return new Field(name, new FieldType(nullable, listType, null), children);
     }
 
@@ -305,18 +305,18 @@ public class LanceTypeConverter implements Serializable {
         if (!(arrowType instanceof ArrowType.FixedSizeList)) {
             return false;
         }
-        
+
         List<Field> children = field.getChildren();
         if (children == null || children.isEmpty()) {
             return false;
         }
-        
+
         ArrowType childType = children.get(0).getType();
         if (childType instanceof ArrowType.FloatingPoint) {
             FloatingPointPrecision precision = ((ArrowType.FloatingPoint) childType).getPrecision();
             return precision == FloatingPointPrecision.SINGLE || precision == FloatingPointPrecision.DOUBLE;
         }
-        
+
         return false;
     }
 
@@ -388,7 +388,7 @@ public class LanceTypeConverter implements Serializable {
                     .toArray(DataTypes.Field[]::new);
             return DataTypes.ROW(fields);
         }
-        
+
         throw new UnsupportedTypeException("Unsupported LogicalType: " + logicalType.getClass().getSimpleName());
     }
 

--- a/src/main/java/org/apache/flink/connector/lance/converter/LanceTypeConverter.java
+++ b/src/main/java/org/apache/flink/connector/lance/converter/LanceTypeConverter.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,9 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.converter;
 
+import org.apache.arrow.vector.types.DateUnit;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.ArrayType;
@@ -35,14 +37,6 @@ import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
-
-import org.apache.arrow.vector.types.DateUnit;
-import org.apache.arrow.vector.types.FloatingPointPrecision;
-import org.apache.arrow.vector.types.TimeUnit;
-import org.apache.arrow.vector.types.pojo.ArrowType;
-import org.apache.arrow.vector.types.pojo.Field;
-import org.apache.arrow.vector.types.pojo.FieldType;
-import org.apache.arrow.vector.types.pojo.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,387 +48,388 @@ import java.util.List;
  * Type converter between Lance/Arrow and Flink types.
  *
  * <p>Supported type mappings:
+ *
  * <ul>
- *   <li>Int8 <-> TINYINT</li>
- *   <li>Int16 <-> SMALLINT</li>
- *   <li>Int32 <-> INT</li>
- *   <li>Int64 <-> BIGINT</li>
- *   <li>Float32 <-> FLOAT</li>
- *   <li>Float64 <-> DOUBLE</li>
- *   <li>String/LargeString <-> STRING</li>
- *   <li>Boolean <-> BOOLEAN</li>
- *   <li>Binary/LargeBinary <-> BYTES</li>
- *   <li>Date32 <-> DATE</li>
- *   <li>Timestamp <-> TIMESTAMP</li>
- *   <li>FixedSizeList<Float32> <-> ARRAY<FLOAT></li>
- *   <li>FixedSizeList<Float64> <-> ARRAY<DOUBLE></li>
+ *   <li>Int8 <-> TINYINT
+ *   <li>Int16 <-> SMALLINT
+ *   <li>Int32 <-> INT
+ *   <li>Int64 <-> BIGINT
+ *   <li>Float32 <-> FLOAT
+ *   <li>Float64 <-> DOUBLE
+ *   <li>String/LargeString <-> STRING
+ *   <li>Boolean <-> BOOLEAN
+ *   <li>Binary/LargeBinary <-> BYTES
+ *   <li>Date32 <-> DATE
+ *   <li>Timestamp <-> TIMESTAMP
+ *   <li>FixedSizeList<Float32> <-> ARRAY<FLOAT>
+ *   <li>FixedSizeList<Float64> <-> ARRAY<DOUBLE>
  * </ul>
  */
 public class LanceTypeConverter implements Serializable {
 
-    private static final long serialVersionUID = 1L;
-    private static final Logger LOG = LoggerFactory.getLogger(LanceTypeConverter.class);
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(LanceTypeConverter.class);
 
-    /**
-     * Convert Arrow Schema to Flink RowType
-     *
-     * @param schema Arrow Schema
-     * @return Flink RowType
-     */
-    public static RowType toFlinkRowType(Schema schema) {
-        List<RowType.RowField> fields = new ArrayList<>();
-        for (Field field : schema.getFields()) {
-            LogicalType logicalType = arrowTypeToFlinkType(field);
-            fields.add(new RowType.RowField(field.getName(), logicalType));
-        }
-        return new RowType(fields);
+  /**
+   * Convert Arrow Schema to Flink RowType
+   *
+   * @param schema Arrow Schema
+   * @return Flink RowType
+   */
+  public static RowType toFlinkRowType(Schema schema) {
+    List<RowType.RowField> fields = new ArrayList<>();
+    for (Field field : schema.getFields()) {
+      LogicalType logicalType = arrowTypeToFlinkType(field);
+      fields.add(new RowType.RowField(field.getName(), logicalType));
+    }
+    return new RowType(fields);
+  }
+
+  /**
+   * Convert Flink RowType to Arrow Schema
+   *
+   * @param rowType Flink RowType
+   * @return Arrow Schema
+   */
+  public static Schema toArrowSchema(RowType rowType) {
+    List<Field> fields = new ArrayList<>();
+    for (RowType.RowField rowField : rowType.getFields()) {
+      Field arrowField = flinkTypeToArrowField(rowField.getName(), rowField.getType());
+      fields.add(arrowField);
+    }
+    return new Schema(fields);
+  }
+
+  /**
+   * Convert Arrow Field to Flink LogicalType
+   *
+   * @param field Arrow Field
+   * @return Flink LogicalType
+   */
+  public static LogicalType arrowTypeToFlinkType(Field field) {
+    ArrowType arrowType = field.getType();
+    boolean nullable = field.isNullable();
+
+    if (arrowType instanceof ArrowType.Int) {
+      ArrowType.Int intType = (ArrowType.Int) arrowType;
+      int bitWidth = intType.getBitWidth();
+      switch (bitWidth) {
+        case 8:
+          return new TinyIntType(nullable);
+        case 16:
+          return new SmallIntType(nullable);
+        case 32:
+          return new IntType(nullable);
+        case 64:
+          return new BigIntType(nullable);
+        default:
+          throw new UnsupportedTypeException("Unsupported Arrow Int bit width: " + bitWidth);
+      }
+    } else if (arrowType instanceof ArrowType.FloatingPoint) {
+      ArrowType.FloatingPoint fpType = (ArrowType.FloatingPoint) arrowType;
+      FloatingPointPrecision precision = fpType.getPrecision();
+      switch (precision) {
+        case SINGLE:
+          return new FloatType(nullable);
+        case DOUBLE:
+          return new DoubleType(nullable);
+        default:
+          throw new UnsupportedTypeException(
+              "Unsupported Arrow floating point precision: " + precision);
+      }
+    } else if (arrowType instanceof ArrowType.Utf8 || arrowType instanceof ArrowType.LargeUtf8) {
+      return new VarCharType(nullable, VarCharType.MAX_LENGTH);
+    } else if (arrowType instanceof ArrowType.Bool) {
+      return new BooleanType(nullable);
+    } else if (arrowType instanceof ArrowType.Binary) {
+      return new VarBinaryType(nullable, VarBinaryType.MAX_LENGTH);
+    } else if (arrowType instanceof ArrowType.LargeBinary) {
+      return new VarBinaryType(nullable, VarBinaryType.MAX_LENGTH);
+    } else if (arrowType instanceof ArrowType.FixedSizeBinary) {
+      ArrowType.FixedSizeBinary fixedBinary = (ArrowType.FixedSizeBinary) arrowType;
+      return new BinaryType(nullable, fixedBinary.getByteWidth());
+    } else if (arrowType instanceof ArrowType.Date) {
+      return new DateType(nullable);
+    } else if (arrowType instanceof ArrowType.Timestamp) {
+      ArrowType.Timestamp tsType = (ArrowType.Timestamp) arrowType;
+      // Determine precision based on time unit
+      int precision = getTimestampPrecision(tsType.getUnit());
+      return new TimestampType(nullable, precision);
+    } else if (arrowType instanceof ArrowType.FixedSizeList) {
+      // Vector type: FixedSizeList<Float32/Float64>
+      ArrowType.FixedSizeList listType = (ArrowType.FixedSizeList) arrowType;
+      List<Field> children = field.getChildren();
+      if (children != null && !children.isEmpty()) {
+        LogicalType elementType = arrowTypeToFlinkType(children.get(0));
+        return new ArrayType(nullable, elementType);
+      }
+      throw new UnsupportedTypeException("FixedSizeList must contain child type");
+    } else if (arrowType instanceof ArrowType.List || arrowType instanceof ArrowType.LargeList) {
+      // Regular list type
+      List<Field> children = field.getChildren();
+      if (children != null && !children.isEmpty()) {
+        LogicalType elementType = arrowTypeToFlinkType(children.get(0));
+        return new ArrayType(nullable, elementType);
+      }
+      throw new UnsupportedTypeException("List must contain child type");
+    } else if (arrowType instanceof ArrowType.Struct) {
+      // Struct type
+      List<RowType.RowField> structFields = new ArrayList<>();
+      for (Field child : field.getChildren()) {
+        LogicalType childType = arrowTypeToFlinkType(child);
+        structFields.add(new RowType.RowField(child.getName(), childType));
+      }
+      return new RowType(nullable, structFields);
+    } else if (arrowType instanceof ArrowType.Null) {
+      // Null type, map to nullable string
+      LOG.warn("Arrow Null type mapped to nullable STRING type");
+      return new VarCharType(true, VarCharType.MAX_LENGTH);
     }
 
-    /**
-     * Convert Flink RowType to Arrow Schema
-     *
-     * @param rowType Flink RowType
-     * @return Arrow Schema
-     */
-    public static Schema toArrowSchema(RowType rowType) {
-        List<Field> fields = new ArrayList<>();
-        for (RowType.RowField rowField : rowType.getFields()) {
-            Field arrowField = flinkTypeToArrowField(rowField.getName(), rowField.getType());
-            fields.add(arrowField);
-        }
-        return new Schema(fields);
+    throw new UnsupportedTypeException(
+        "Unsupported Arrow type: " + arrowType.getClass().getSimpleName());
+  }
+
+  /**
+   * Convert Flink LogicalType to Arrow Field
+   *
+   * @param name Field name
+   * @param logicalType Flink LogicalType
+   * @return Arrow Field
+   */
+  public static Field flinkTypeToArrowField(String name, LogicalType logicalType) {
+    boolean nullable = logicalType.isNullable();
+    ArrowType arrowType;
+    List<Field> children = null;
+
+    if (logicalType instanceof TinyIntType) {
+      arrowType = new ArrowType.Int(8, true);
+    } else if (logicalType instanceof SmallIntType) {
+      arrowType = new ArrowType.Int(16, true);
+    } else if (logicalType instanceof IntType) {
+      arrowType = new ArrowType.Int(32, true);
+    } else if (logicalType instanceof BigIntType) {
+      arrowType = new ArrowType.Int(64, true);
+    } else if (logicalType instanceof FloatType) {
+      arrowType = new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE);
+    } else if (logicalType instanceof DoubleType) {
+      arrowType = new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
+    } else if (logicalType instanceof VarCharType) {
+      arrowType = ArrowType.Utf8.INSTANCE;
+    } else if (logicalType instanceof BooleanType) {
+      arrowType = ArrowType.Bool.INSTANCE;
+    } else if (logicalType instanceof VarBinaryType) {
+      arrowType = ArrowType.Binary.INSTANCE;
+    } else if (logicalType instanceof BinaryType) {
+      BinaryType binaryType = (BinaryType) logicalType;
+      arrowType = new ArrowType.FixedSizeBinary(binaryType.getLength());
+    } else if (logicalType instanceof DateType) {
+      arrowType = new ArrowType.Date(DateUnit.DAY);
+    } else if (logicalType instanceof TimestampType) {
+      TimestampType tsType = (TimestampType) logicalType;
+      TimeUnit timeUnit = getArrowTimeUnit(tsType.getPrecision());
+      arrowType = new ArrowType.Timestamp(timeUnit, null);
+    } else if (logicalType instanceof ArrayType) {
+      ArrayType arrayType = (ArrayType) logicalType;
+      LogicalType elementType = arrayType.getElementType();
+      Field childField = flinkTypeToArrowField("item", elementType);
+      children = new ArrayList<>();
+      children.add(childField);
+      // For vector types, use List type
+      arrowType = ArrowType.List.INSTANCE;
+    } else if (logicalType instanceof RowType) {
+      RowType rowType = (RowType) logicalType;
+      children = new ArrayList<>();
+      for (RowType.RowField rowField : rowType.getFields()) {
+        Field childField = flinkTypeToArrowField(rowField.getName(), rowField.getType());
+        children.add(childField);
+      }
+      arrowType = ArrowType.Struct.INSTANCE;
+    } else {
+      throw new UnsupportedTypeException(
+          "Unsupported Flink type: " + logicalType.getClass().getSimpleName());
     }
 
-    /**
-     * Convert Arrow Field to Flink LogicalType
-     *
-     * @param field Arrow Field
-     * @return Flink LogicalType
-     */
-    public static LogicalType arrowTypeToFlinkType(Field field) {
-        ArrowType arrowType = field.getType();
-        boolean nullable = field.isNullable();
+    FieldType fieldType = new FieldType(nullable, arrowType, null);
+    return new Field(name, fieldType, children);
+  }
 
-        if (arrowType instanceof ArrowType.Int) {
-            ArrowType.Int intType = (ArrowType.Int) arrowType;
-            int bitWidth = intType.getBitWidth();
-            switch (bitWidth) {
-                case 8:
-                    return new TinyIntType(nullable);
-                case 16:
-                    return new SmallIntType(nullable);
-                case 32:
-                    return new IntType(nullable);
-                case 64:
-                    return new BigIntType(nullable);
-                default:
-                    throw new UnsupportedTypeException("Unsupported Arrow Int bit width: " + bitWidth);
-            }
-        } else if (arrowType instanceof ArrowType.FloatingPoint) {
-            ArrowType.FloatingPoint fpType = (ArrowType.FloatingPoint) arrowType;
-            FloatingPointPrecision precision = fpType.getPrecision();
-            switch (precision) {
-                case SINGLE:
-                    return new FloatType(nullable);
-                case DOUBLE:
-                    return new DoubleType(nullable);
-                default:
-                    throw new UnsupportedTypeException("Unsupported Arrow floating point precision: " + precision);
-            }
-        } else if (arrowType instanceof ArrowType.Utf8 || arrowType instanceof ArrowType.LargeUtf8) {
-            return new VarCharType(nullable, VarCharType.MAX_LENGTH);
-        } else if (arrowType instanceof ArrowType.Bool) {
-            return new BooleanType(nullable);
-        } else if (arrowType instanceof ArrowType.Binary) {
-            return new VarBinaryType(nullable, VarBinaryType.MAX_LENGTH);
-        } else if (arrowType instanceof ArrowType.LargeBinary) {
-            return new VarBinaryType(nullable, VarBinaryType.MAX_LENGTH);
-        } else if (arrowType instanceof ArrowType.FixedSizeBinary) {
-            ArrowType.FixedSizeBinary fixedBinary = (ArrowType.FixedSizeBinary) arrowType;
-            return new BinaryType(nullable, fixedBinary.getByteWidth());
-        } else if (arrowType instanceof ArrowType.Date) {
-            return new DateType(nullable);
-        } else if (arrowType instanceof ArrowType.Timestamp) {
-            ArrowType.Timestamp tsType = (ArrowType.Timestamp) arrowType;
-            // Determine precision based on time unit
-            int precision = getTimestampPrecision(tsType.getUnit());
-            return new TimestampType(nullable, precision);
-        } else if (arrowType instanceof ArrowType.FixedSizeList) {
-            // Vector type: FixedSizeList<Float32/Float64>
-            ArrowType.FixedSizeList listType = (ArrowType.FixedSizeList) arrowType;
-            List<Field> children = field.getChildren();
-            if (children != null && !children.isEmpty()) {
-                LogicalType elementType = arrowTypeToFlinkType(children.get(0));
-                return new ArrayType(nullable, elementType);
-            }
-            throw new UnsupportedTypeException("FixedSizeList must contain child type");
-        } else if (arrowType instanceof ArrowType.List || arrowType instanceof ArrowType.LargeList) {
-            // Regular list type
-            List<Field> children = field.getChildren();
-            if (children != null && !children.isEmpty()) {
-                LogicalType elementType = arrowTypeToFlinkType(children.get(0));
-                return new ArrayType(nullable, elementType);
-            }
-            throw new UnsupportedTypeException("List must contain child type");
-        } else if (arrowType instanceof ArrowType.Struct) {
-            // Struct type
-            List<RowType.RowField> structFields = new ArrayList<>();
-            for (Field child : field.getChildren()) {
-                LogicalType childType = arrowTypeToFlinkType(child);
-                structFields.add(new RowType.RowField(child.getName(), childType));
-            }
-            return new RowType(nullable, structFields);
-        } else if (arrowType instanceof ArrowType.Null) {
-            // Null type, map to nullable string
-            LOG.warn("Arrow Null type mapped to nullable STRING type");
-            return new VarCharType(true, VarCharType.MAX_LENGTH);
-        }
+  /**
+   * Create vector field (FixedSizeList<Float32>)
+   *
+   * @param name Field name
+   * @param dimension Vector dimension
+   * @param nullable Whether nullable
+   * @return Arrow Field
+   */
+  public static Field createVectorField(String name, int dimension, boolean nullable) {
+    ArrowType elementType = new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE);
+    Field elementField = new Field("item", new FieldType(false, elementType, null), null);
 
-        throw new UnsupportedTypeException("Unsupported Arrow type: " + arrowType.getClass().getSimpleName());
+    ArrowType listType = new ArrowType.FixedSizeList(dimension);
+    List<Field> children = new ArrayList<>();
+    children.add(elementField);
+
+    return new Field(name, new FieldType(nullable, listType, null), children);
+  }
+
+  /**
+   * Create Float64 vector field (FixedSizeList<Float64>)
+   *
+   * @param name Field name
+   * @param dimension Vector dimension
+   * @param nullable Whether nullable
+   * @return Arrow Field
+   */
+  public static Field createFloat64VectorField(String name, int dimension, boolean nullable) {
+    ArrowType elementType = new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
+    Field elementField = new Field("item", new FieldType(false, elementType, null), null);
+
+    ArrowType listType = new ArrowType.FixedSizeList(dimension);
+    List<Field> children = new ArrayList<>();
+    children.add(elementField);
+
+    return new Field(name, new FieldType(nullable, listType, null), children);
+  }
+
+  /**
+   * Check if field is vector type (FixedSizeList<Float32/Float64>)
+   *
+   * @param field Arrow Field
+   * @return Whether vector type
+   */
+  public static boolean isVectorField(Field field) {
+    ArrowType arrowType = field.getType();
+    if (!(arrowType instanceof ArrowType.FixedSizeList)) {
+      return false;
     }
 
-    /**
-     * Convert Flink LogicalType to Arrow Field
-     *
-     * @param name Field name
-     * @param logicalType Flink LogicalType
-     * @return Arrow Field
-     */
-    public static Field flinkTypeToArrowField(String name, LogicalType logicalType) {
-        boolean nullable = logicalType.isNullable();
-        ArrowType arrowType;
-        List<Field> children = null;
-
-        if (logicalType instanceof TinyIntType) {
-            arrowType = new ArrowType.Int(8, true);
-        } else if (logicalType instanceof SmallIntType) {
-            arrowType = new ArrowType.Int(16, true);
-        } else if (logicalType instanceof IntType) {
-            arrowType = new ArrowType.Int(32, true);
-        } else if (logicalType instanceof BigIntType) {
-            arrowType = new ArrowType.Int(64, true);
-        } else if (logicalType instanceof FloatType) {
-            arrowType = new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE);
-        } else if (logicalType instanceof DoubleType) {
-            arrowType = new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
-        } else if (logicalType instanceof VarCharType) {
-            arrowType = ArrowType.Utf8.INSTANCE;
-        } else if (logicalType instanceof BooleanType) {
-            arrowType = ArrowType.Bool.INSTANCE;
-        } else if (logicalType instanceof VarBinaryType) {
-            arrowType = ArrowType.Binary.INSTANCE;
-        } else if (logicalType instanceof BinaryType) {
-            BinaryType binaryType = (BinaryType) logicalType;
-            arrowType = new ArrowType.FixedSizeBinary(binaryType.getLength());
-        } else if (logicalType instanceof DateType) {
-            arrowType = new ArrowType.Date(DateUnit.DAY);
-        } else if (logicalType instanceof TimestampType) {
-            TimestampType tsType = (TimestampType) logicalType;
-            TimeUnit timeUnit = getArrowTimeUnit(tsType.getPrecision());
-            arrowType = new ArrowType.Timestamp(timeUnit, null);
-        } else if (logicalType instanceof ArrayType) {
-            ArrayType arrayType = (ArrayType) logicalType;
-            LogicalType elementType = arrayType.getElementType();
-            Field childField = flinkTypeToArrowField("item", elementType);
-            children = new ArrayList<>();
-            children.add(childField);
-            // For vector types, use List type
-            arrowType = ArrowType.List.INSTANCE;
-        } else if (logicalType instanceof RowType) {
-            RowType rowType = (RowType) logicalType;
-            children = new ArrayList<>();
-            for (RowType.RowField rowField : rowType.getFields()) {
-                Field childField = flinkTypeToArrowField(rowField.getName(), rowField.getType());
-                children.add(childField);
-            }
-            arrowType = ArrowType.Struct.INSTANCE;
-        } else {
-            throw new UnsupportedTypeException("Unsupported Flink type: " + logicalType.getClass().getSimpleName());
-        }
-
-        FieldType fieldType = new FieldType(nullable, arrowType, null);
-        return new Field(name, fieldType, children);
+    List<Field> children = field.getChildren();
+    if (children == null || children.isEmpty()) {
+      return false;
     }
 
-    /**
-     * Create vector field (FixedSizeList<Float32>)
-     *
-     * @param name Field name
-     * @param dimension Vector dimension
-     * @param nullable Whether nullable
-     * @return Arrow Field
-     */
-    public static Field createVectorField(String name, int dimension, boolean nullable) {
-        ArrowType elementType = new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE);
-        Field elementField = new Field("item", new FieldType(false, elementType, null), null);
-
-        ArrowType listType = new ArrowType.FixedSizeList(dimension);
-        List<Field> children = new ArrayList<>();
-        children.add(elementField);
-
-        return new Field(name, new FieldType(nullable, listType, null), children);
+    ArrowType childType = children.get(0).getType();
+    if (childType instanceof ArrowType.FloatingPoint) {
+      FloatingPointPrecision precision = ((ArrowType.FloatingPoint) childType).getPrecision();
+      return precision == FloatingPointPrecision.SINGLE
+          || precision == FloatingPointPrecision.DOUBLE;
     }
 
-    /**
-     * Create Float64 vector field (FixedSizeList<Float64>)
-     *
-     * @param name Field name
-     * @param dimension Vector dimension
-     * @param nullable Whether nullable
-     * @return Arrow Field
-     */
-    public static Field createFloat64VectorField(String name, int dimension, boolean nullable) {
-        ArrowType elementType = new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
-        Field elementField = new Field("item", new FieldType(false, elementType, null), null);
+    return false;
+  }
 
-        ArrowType listType = new ArrowType.FixedSizeList(dimension);
-        List<Field> children = new ArrayList<>();
-        children.add(elementField);
+  /**
+   * Get vector field dimension
+   *
+   * @param field Arrow Field
+   * @return Vector dimension, returns -1 if not vector field
+   */
+  public static int getVectorDimension(Field field) {
+    ArrowType arrowType = field.getType();
+    if (arrowType instanceof ArrowType.FixedSizeList) {
+      return ((ArrowType.FixedSizeList) arrowType).getListSize();
+    }
+    return -1;
+  }
 
-        return new Field(name, new FieldType(nullable, listType, null), children);
+  /**
+   * Convert Flink DataType to LogicalType
+   *
+   * @param dataType Flink DataType
+   * @return LogicalType
+   */
+  public static LogicalType toLogicalType(DataType dataType) {
+    return dataType.getLogicalType();
+  }
+
+  /**
+   * Convert LogicalType to Flink DataType
+   *
+   * @param logicalType Flink LogicalType
+   * @return Flink DataType
+   */
+  public static DataType toDataType(LogicalType logicalType) {
+    if (logicalType instanceof TinyIntType) {
+      return DataTypes.TINYINT();
+    } else if (logicalType instanceof SmallIntType) {
+      return DataTypes.SMALLINT();
+    } else if (logicalType instanceof IntType) {
+      return DataTypes.INT();
+    } else if (logicalType instanceof BigIntType) {
+      return DataTypes.BIGINT();
+    } else if (logicalType instanceof FloatType) {
+      return DataTypes.FLOAT();
+    } else if (logicalType instanceof DoubleType) {
+      return DataTypes.DOUBLE();
+    } else if (logicalType instanceof VarCharType) {
+      return DataTypes.STRING();
+    } else if (logicalType instanceof BooleanType) {
+      return DataTypes.BOOLEAN();
+    } else if (logicalType instanceof VarBinaryType) {
+      return DataTypes.BYTES();
+    } else if (logicalType instanceof BinaryType) {
+      BinaryType binaryType = (BinaryType) logicalType;
+      return DataTypes.BINARY(binaryType.getLength());
+    } else if (logicalType instanceof DateType) {
+      return DataTypes.DATE();
+    } else if (logicalType instanceof TimestampType) {
+      TimestampType tsType = (TimestampType) logicalType;
+      return DataTypes.TIMESTAMP(tsType.getPrecision());
+    } else if (logicalType instanceof ArrayType) {
+      ArrayType arrayType = (ArrayType) logicalType;
+      DataType elementDataType = toDataType(arrayType.getElementType());
+      return DataTypes.ARRAY(elementDataType);
+    } else if (logicalType instanceof RowType) {
+      RowType rowType = (RowType) logicalType;
+      DataTypes.Field[] fields =
+          rowType.getFields().stream()
+              .map(f -> DataTypes.FIELD(f.getName(), toDataType(f.getType())))
+              .toArray(DataTypes.Field[]::new);
+      return DataTypes.ROW(fields);
     }
 
-    /**
-     * Check if field is vector type (FixedSizeList<Float32/Float64>)
-     *
-     * @param field Arrow Field
-     * @return Whether vector type
-     */
-    public static boolean isVectorField(Field field) {
-        ArrowType arrowType = field.getType();
-        if (!(arrowType instanceof ArrowType.FixedSizeList)) {
-            return false;
-        }
+    throw new UnsupportedTypeException(
+        "Unsupported LogicalType: " + logicalType.getClass().getSimpleName());
+  }
 
-        List<Field> children = field.getChildren();
-        if (children == null || children.isEmpty()) {
-            return false;
-        }
+  /** Get Flink Timestamp precision based on Arrow TimeUnit */
+  private static int getTimestampPrecision(TimeUnit timeUnit) {
+    switch (timeUnit) {
+      case SECOND:
+        return 0;
+      case MILLISECOND:
+        return 3;
+      case MICROSECOND:
+        return 6;
+      case NANOSECOND:
+        return 9;
+      default:
+        return 6; // Default microsecond precision
+    }
+  }
 
-        ArrowType childType = children.get(0).getType();
-        if (childType instanceof ArrowType.FloatingPoint) {
-            FloatingPointPrecision precision = ((ArrowType.FloatingPoint) childType).getPrecision();
-            return precision == FloatingPointPrecision.SINGLE || precision == FloatingPointPrecision.DOUBLE;
-        }
+  /** Get Arrow TimeUnit based on Flink Timestamp precision */
+  private static TimeUnit getArrowTimeUnit(int precision) {
+    if (precision <= 0) {
+      return TimeUnit.SECOND;
+    } else if (precision <= 3) {
+      return TimeUnit.MILLISECOND;
+    } else if (precision <= 6) {
+      return TimeUnit.MICROSECOND;
+    } else {
+      return TimeUnit.NANOSECOND;
+    }
+  }
 
-        return false;
+  /** Unsupported type exception */
+  public static class UnsupportedTypeException extends RuntimeException {
+    public UnsupportedTypeException(String message) {
+      super(message);
     }
 
-    /**
-     * Get vector field dimension
-     *
-     * @param field Arrow Field
-     * @return Vector dimension, returns -1 if not vector field
-     */
-    public static int getVectorDimension(Field field) {
-        ArrowType arrowType = field.getType();
-        if (arrowType instanceof ArrowType.FixedSizeList) {
-            return ((ArrowType.FixedSizeList) arrowType).getListSize();
-        }
-        return -1;
+    public UnsupportedTypeException(String message, Throwable cause) {
+      super(message, cause);
     }
-
-    /**
-     * Convert Flink DataType to LogicalType
-     *
-     * @param dataType Flink DataType
-     * @return LogicalType
-     */
-    public static LogicalType toLogicalType(DataType dataType) {
-        return dataType.getLogicalType();
-    }
-
-    /**
-     * Convert LogicalType to Flink DataType
-     *
-     * @param logicalType Flink LogicalType
-     * @return Flink DataType
-     */
-    public static DataType toDataType(LogicalType logicalType) {
-        if (logicalType instanceof TinyIntType) {
-            return DataTypes.TINYINT();
-        } else if (logicalType instanceof SmallIntType) {
-            return DataTypes.SMALLINT();
-        } else if (logicalType instanceof IntType) {
-            return DataTypes.INT();
-        } else if (logicalType instanceof BigIntType) {
-            return DataTypes.BIGINT();
-        } else if (logicalType instanceof FloatType) {
-            return DataTypes.FLOAT();
-        } else if (logicalType instanceof DoubleType) {
-            return DataTypes.DOUBLE();
-        } else if (logicalType instanceof VarCharType) {
-            return DataTypes.STRING();
-        } else if (logicalType instanceof BooleanType) {
-            return DataTypes.BOOLEAN();
-        } else if (logicalType instanceof VarBinaryType) {
-            return DataTypes.BYTES();
-        } else if (logicalType instanceof BinaryType) {
-            BinaryType binaryType = (BinaryType) logicalType;
-            return DataTypes.BINARY(binaryType.getLength());
-        } else if (logicalType instanceof DateType) {
-            return DataTypes.DATE();
-        } else if (logicalType instanceof TimestampType) {
-            TimestampType tsType = (TimestampType) logicalType;
-            return DataTypes.TIMESTAMP(tsType.getPrecision());
-        } else if (logicalType instanceof ArrayType) {
-            ArrayType arrayType = (ArrayType) logicalType;
-            DataType elementDataType = toDataType(arrayType.getElementType());
-            return DataTypes.ARRAY(elementDataType);
-        } else if (logicalType instanceof RowType) {
-            RowType rowType = (RowType) logicalType;
-            DataTypes.Field[] fields = rowType.getFields().stream()
-                    .map(f -> DataTypes.FIELD(f.getName(), toDataType(f.getType())))
-                    .toArray(DataTypes.Field[]::new);
-            return DataTypes.ROW(fields);
-        }
-
-        throw new UnsupportedTypeException("Unsupported LogicalType: " + logicalType.getClass().getSimpleName());
-    }
-
-    /**
-     * Get Flink Timestamp precision based on Arrow TimeUnit
-     */
-    private static int getTimestampPrecision(TimeUnit timeUnit) {
-        switch (timeUnit) {
-            case SECOND:
-                return 0;
-            case MILLISECOND:
-                return 3;
-            case MICROSECOND:
-                return 6;
-            case NANOSECOND:
-                return 9;
-            default:
-                return 6; // Default microsecond precision
-        }
-    }
-
-    /**
-     * Get Arrow TimeUnit based on Flink Timestamp precision
-     */
-    private static TimeUnit getArrowTimeUnit(int precision) {
-        if (precision <= 0) {
-            return TimeUnit.SECOND;
-        } else if (precision <= 3) {
-            return TimeUnit.MILLISECOND;
-        } else if (precision <= 6) {
-            return TimeUnit.MICROSECOND;
-        } else {
-            return TimeUnit.NANOSECOND;
-        }
-    }
-
-    /**
-     * Unsupported type exception
-     */
-    public static class UnsupportedTypeException extends RuntimeException {
-        public UnsupportedTypeException(String message) {
-            super(message);
-        }
-
-        public UnsupportedTypeException(String message, Throwable cause) {
-            super(message, cause);
-        }
-    }
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/converter/RowDataConverter.java
+++ b/src/main/java/org/apache/flink/connector/lance/converter/RowDataConverter.java
@@ -66,15 +66,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Converter between RowData and Arrow data.
- * 
+ *
  * <p>Responsible for bidirectional conversion between Arrow VectorSchemaRoot and Flink RowData.
  */
 public class RowDataConverter implements Serializable {
@@ -103,26 +100,26 @@ public class RowDataConverter implements Serializable {
     public List<RowData> toRowDataList(VectorSchemaRoot root) {
         List<RowData> rows = new ArrayList<>();
         int rowCount = root.getRowCount();
-        
+
         for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
             GenericRowData rowData = new GenericRowData(fieldTypes.length);
-            
+
             for (int fieldIndex = 0; fieldIndex < fieldTypes.length; fieldIndex++) {
                 String fieldName = fieldNames[fieldIndex];
                 FieldVector vector = root.getVector(fieldName);
-                
+
                 if (vector == null) {
                     rowData.setField(fieldIndex, null);
                     continue;
                 }
-                
+
                 Object value = readValue(vector, rowIndex, fieldTypes[fieldIndex]);
                 rowData.setField(fieldIndex, value);
             }
-            
+
             rows.add(rowData);
         }
-        
+
         return rows;
     }
 
@@ -134,23 +131,23 @@ public class RowDataConverter implements Serializable {
      */
     public void toVectorSchemaRoot(List<RowData> rows, VectorSchemaRoot root) {
         root.allocateNew();
-        
+
         for (int rowIndex = 0; rowIndex < rows.size(); rowIndex++) {
             RowData rowData = rows.get(rowIndex);
-            
+
             for (int fieldIndex = 0; fieldIndex < fieldTypes.length; fieldIndex++) {
                 String fieldName = fieldNames[fieldIndex];
                 FieldVector vector = root.getVector(fieldName);
-                
+
                 if (vector == null) {
                     continue;
                 }
-                
+
                 Object value = getFieldValue(rowData, fieldIndex, fieldTypes[fieldIndex]);
                 writeValue(vector, rowIndex, value, fieldTypes[fieldIndex]);
             }
         }
-        
+
         root.setRowCount(rows.size());
     }
 
@@ -239,13 +236,13 @@ public class RowDataConverter implements Serializable {
      */
     private ArrayData readArray(FieldVector vector, int index, ArrayType arrayType) {
         LogicalType elementType = arrayType.getElementType();
-        
+
         if (vector instanceof FixedSizeListVector) {
             FixedSizeListVector listVector = (FixedSizeListVector) vector;
             int listSize = listVector.getListSize();
             FieldVector dataVector = listVector.getDataVector();
             int startIndex = index * listSize;
-            
+
             return readArrayData(dataVector, startIndex, listSize, elementType);
         } else if (vector instanceof ListVector) {
             ListVector listVector = (ListVector) vector;
@@ -253,7 +250,7 @@ public class RowDataConverter implements Serializable {
             int endIndex = listVector.getElementEndIndex(index);
             int listSize = endIndex - startIndex;
             FieldVector dataVector = listVector.getDataVector();
-            
+
             return readArrayData(dataVector, startIndex, listSize, elementType);
         }
 
@@ -529,24 +526,24 @@ public class RowDataConverter implements Serializable {
         if (vector instanceof FixedSizeListVector) {
             FixedSizeListVector listVector = (FixedSizeListVector) vector;
             int listSize = listVector.getListSize();
-            
+
             if (size != listSize) {
                 throw new IllegalArgumentException(
                         "Array size " + size + " does not match FixedSizeList size " + listSize);
             }
-            
+
             FieldVector dataVector = listVector.getDataVector();
             int startIndex = index * listSize;
-            
+
             writeArrayData(dataVector, startIndex, arrayData, elementType);
             listVector.setNotNull(index);
         } else if (vector instanceof ListVector) {
             ListVector listVector = (ListVector) vector;
             listVector.startNewValue(index);
-            
+
             FieldVector dataVector = listVector.getDataVector();
             int startIndex = listVector.getElementStartIndex(index);
-            
+
             writeArrayData(dataVector, startIndex, arrayData, elementType);
             listVector.endValue(index, size);
         } else {

--- a/src/main/java/org/apache/flink/connector/lance/converter/RowDataConverter.java
+++ b/src/main/java/org/apache/flink/connector/lance/converter/RowDataConverter.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,30 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.converter;
-
-import org.apache.flink.table.data.ArrayData;
-import org.apache.flink.table.data.GenericArrayData;
-import org.apache.flink.table.data.GenericRowData;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.StringData;
-import org.apache.flink.table.data.TimestampData;
-import org.apache.flink.table.types.logical.ArrayType;
-import org.apache.flink.table.types.logical.BigIntType;
-import org.apache.flink.table.types.logical.BinaryType;
-import org.apache.flink.table.types.logical.BooleanType;
-import org.apache.flink.table.types.logical.DateType;
-import org.apache.flink.table.types.logical.DoubleType;
-import org.apache.flink.table.types.logical.FloatType;
-import org.apache.flink.table.types.logical.IntType;
-import org.apache.flink.table.types.logical.LogicalType;
-import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.SmallIntType;
-import org.apache.flink.table.types.logical.TimestampType;
-import org.apache.flink.table.types.logical.TinyIntType;
-import org.apache.flink.table.types.logical.VarBinaryType;
-import org.apache.flink.table.types.logical.VarCharType;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.BigIntVector;
@@ -62,6 +35,27 @@ import org.apache.arrow.vector.complex.FixedSizeListVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.BinaryType;
+import org.apache.flink.table.types.logical.BooleanType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,647 +70,617 @@ import java.util.List;
  */
 public class RowDataConverter implements Serializable {
 
-    private static final long serialVersionUID = 1L;
-    private static final Logger LOG = LoggerFactory.getLogger(RowDataConverter.class);
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(RowDataConverter.class);
 
-    private final RowType rowType;
-    private final String[] fieldNames;
-    private final LogicalType[] fieldTypes;
+  private final RowType rowType;
+  private final String[] fieldNames;
+  private final LogicalType[] fieldTypes;
 
-    public RowDataConverter(RowType rowType) {
-        this.rowType = rowType;
-        this.fieldNames = rowType.getFieldNames().toArray(new String[0]);
-        this.fieldTypes = rowType.getFields().stream()
-                .map(RowType.RowField::getType)
-                .toArray(LogicalType[]::new);
-    }
+  public RowDataConverter(RowType rowType) {
+    this.rowType = rowType;
+    this.fieldNames = rowType.getFieldNames().toArray(new String[0]);
+    this.fieldTypes =
+        rowType.getFields().stream().map(RowType.RowField::getType).toArray(LogicalType[]::new);
+  }
 
-    /**
-     * Convert Arrow VectorSchemaRoot to RowData list
-     *
-     * @param root Arrow VectorSchemaRoot
-     * @return RowData list
-     */
-    public List<RowData> toRowDataList(VectorSchemaRoot root) {
-        List<RowData> rows = new ArrayList<>();
-        int rowCount = root.getRowCount();
+  /**
+   * Convert Arrow VectorSchemaRoot to RowData list
+   *
+   * @param root Arrow VectorSchemaRoot
+   * @return RowData list
+   */
+  public List<RowData> toRowDataList(VectorSchemaRoot root) {
+    List<RowData> rows = new ArrayList<>();
+    int rowCount = root.getRowCount();
 
-        for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
-            GenericRowData rowData = new GenericRowData(fieldTypes.length);
+    for (int rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      GenericRowData rowData = new GenericRowData(fieldTypes.length);
 
-            for (int fieldIndex = 0; fieldIndex < fieldTypes.length; fieldIndex++) {
-                String fieldName = fieldNames[fieldIndex];
-                FieldVector vector = root.getVector(fieldName);
+      for (int fieldIndex = 0; fieldIndex < fieldTypes.length; fieldIndex++) {
+        String fieldName = fieldNames[fieldIndex];
+        FieldVector vector = root.getVector(fieldName);
 
-                if (vector == null) {
-                    rowData.setField(fieldIndex, null);
-                    continue;
-                }
-
-                Object value = readValue(vector, rowIndex, fieldTypes[fieldIndex]);
-                rowData.setField(fieldIndex, value);
-            }
-
-            rows.add(rowData);
-        }
-
-        return rows;
-    }
-
-    /**
-     * Write RowData list to Arrow VectorSchemaRoot
-     *
-     * @param rows RowData list
-     * @param root Arrow VectorSchemaRoot
-     */
-    public void toVectorSchemaRoot(List<RowData> rows, VectorSchemaRoot root) {
-        root.allocateNew();
-
-        for (int rowIndex = 0; rowIndex < rows.size(); rowIndex++) {
-            RowData rowData = rows.get(rowIndex);
-
-            for (int fieldIndex = 0; fieldIndex < fieldTypes.length; fieldIndex++) {
-                String fieldName = fieldNames[fieldIndex];
-                FieldVector vector = root.getVector(fieldName);
-
-                if (vector == null) {
-                    continue;
-                }
-
-                Object value = getFieldValue(rowData, fieldIndex, fieldTypes[fieldIndex]);
-                writeValue(vector, rowIndex, value, fieldTypes[fieldIndex]);
-            }
-        }
-
-        root.setRowCount(rows.size());
-    }
-
-    /**
-     * Create VectorSchemaRoot
-     *
-     * @param allocator Memory allocator
-     * @return VectorSchemaRoot
-     */
-    public VectorSchemaRoot createVectorSchemaRoot(BufferAllocator allocator) {
-        Schema arrowSchema = LanceTypeConverter.toArrowSchema(rowType);
-        return VectorSchemaRoot.create(arrowSchema, allocator);
-    }
-
-    /**
-     * Read value from Arrow Vector
-     */
-    private Object readValue(FieldVector vector, int index, LogicalType logicalType) {
-        if (vector.isNull(index)) {
-            return null;
-        }
-
-        if (logicalType instanceof TinyIntType) {
-            return ((TinyIntVector) vector).get(index);
-        } else if (logicalType instanceof SmallIntType) {
-            return ((SmallIntVector) vector).get(index);
-        } else if (logicalType instanceof IntType) {
-            return ((IntVector) vector).get(index);
-        } else if (logicalType instanceof BigIntType) {
-            return ((BigIntVector) vector).get(index);
-        } else if (logicalType instanceof FloatType) {
-            return ((Float4Vector) vector).get(index);
-        } else if (logicalType instanceof DoubleType) {
-            return ((Float8Vector) vector).get(index);
-        } else if (logicalType instanceof VarCharType) {
-            byte[] bytes = ((VarCharVector) vector).get(index);
-            return StringData.fromBytes(bytes);
-        } else if (logicalType instanceof BooleanType) {
-            return ((BitVector) vector).get(index) == 1;
-        } else if (logicalType instanceof VarBinaryType) {
-            return ((VarBinaryVector) vector).get(index);
-        } else if (logicalType instanceof BinaryType) {
-            return ((FixedSizeBinaryVector) vector).get(index);
-        } else if (logicalType instanceof DateType) {
-            int daysSinceEpoch = ((DateDayVector) vector).get(index);
-            return daysSinceEpoch;
-        } else if (logicalType instanceof TimestampType) {
-            return readTimestamp(vector, index, (TimestampType) logicalType);
-        } else if (logicalType instanceof ArrayType) {
-            return readArray(vector, index, (ArrayType) logicalType);
-        } else if (logicalType instanceof RowType) {
-            return readStruct(vector, index, (RowType) logicalType);
-        }
-
-        throw new LanceTypeConverter.UnsupportedTypeException(
-                "Unsupported read type: " + logicalType.getClass().getSimpleName());
-    }
-
-    /**
-     * Read timestamp value
-     */
-    private TimestampData readTimestamp(FieldVector vector, int index, TimestampType tsType) {
-        long value;
-        int precision = tsType.getPrecision();
-
-        if (vector instanceof TimeStampSecVector) {
-            value = ((TimeStampSecVector) vector).get(index);
-            return TimestampData.fromEpochMillis(value * 1000);
-        } else if (vector instanceof TimeStampMilliVector) {
-            value = ((TimeStampMilliVector) vector).get(index);
-            return TimestampData.fromEpochMillis(value);
-        } else if (vector instanceof TimeStampMicroVector) {
-            value = ((TimeStampMicroVector) vector).get(index);
-            return TimestampData.fromEpochMillis(value / 1000, (int) ((value % 1000) * 1000));
-        } else if (vector instanceof TimeStampNanoVector) {
-            value = ((TimeStampNanoVector) vector).get(index);
-            return TimestampData.fromEpochMillis(value / 1000000, (int) (value % 1000000));
-        }
-
-        throw new LanceTypeConverter.UnsupportedTypeException(
-                "Unsupported timestamp Vector type: " + vector.getClass().getSimpleName());
-    }
-
-    /**
-     * Read array value
-     */
-    private ArrayData readArray(FieldVector vector, int index, ArrayType arrayType) {
-        LogicalType elementType = arrayType.getElementType();
-
-        if (vector instanceof FixedSizeListVector) {
-            FixedSizeListVector listVector = (FixedSizeListVector) vector;
-            int listSize = listVector.getListSize();
-            FieldVector dataVector = listVector.getDataVector();
-            int startIndex = index * listSize;
-
-            return readArrayData(dataVector, startIndex, listSize, elementType);
-        } else if (vector instanceof ListVector) {
-            ListVector listVector = (ListVector) vector;
-            int startIndex = listVector.getElementStartIndex(index);
-            int endIndex = listVector.getElementEndIndex(index);
-            int listSize = endIndex - startIndex;
-            FieldVector dataVector = listVector.getDataVector();
-
-            return readArrayData(dataVector, startIndex, listSize, elementType);
-        }
-
-        throw new LanceTypeConverter.UnsupportedTypeException(
-                "Unsupported array Vector type: " + vector.getClass().getSimpleName());
-    }
-
-    /**
-     * Read array data
-     */
-    private ArrayData readArrayData(FieldVector dataVector, int startIndex, int size, LogicalType elementType) {
-        if (elementType instanceof FloatType) {
-            Float4Vector float4Vector = (Float4Vector) dataVector;
-            Float[] values = new Float[size];
-            for (int i = 0; i < size; i++) {
-                if (float4Vector.isNull(startIndex + i)) {
-                    values[i] = null;
-                } else {
-                    values[i] = float4Vector.get(startIndex + i);
-                }
-            }
-            return new GenericArrayData(values);
-        } else if (elementType instanceof DoubleType) {
-            Double8Vector double8Vector = (Double8Vector) dataVector;
-            Double[] values = new Double[size];
-            for (int i = 0; i < size; i++) {
-                if (double8Vector.isNull(startIndex + i)) {
-                    values[i] = null;
-                } else {
-                    values[i] = double8Vector.get(startIndex + i);
-                }
-            }
-            return new GenericArrayData(values);
-        } else if (elementType instanceof IntType) {
-            IntVector intVector = (IntVector) dataVector;
-            Integer[] values = new Integer[size];
-            for (int i = 0; i < size; i++) {
-                if (intVector.isNull(startIndex + i)) {
-                    values[i] = null;
-                } else {
-                    values[i] = intVector.get(startIndex + i);
-                }
-            }
-            return new GenericArrayData(values);
-        } else if (elementType instanceof BigIntType) {
-            BigIntVector bigIntVector = (BigIntVector) dataVector;
-            Long[] values = new Long[size];
-            for (int i = 0; i < size; i++) {
-                if (bigIntVector.isNull(startIndex + i)) {
-                    values[i] = null;
-                } else {
-                    values[i] = bigIntVector.get(startIndex + i);
-                }
-            }
-            return new GenericArrayData(values);
-        } else if (elementType instanceof VarCharType) {
-            VarCharVector varCharVector = (VarCharVector) dataVector;
-            StringData[] values = new StringData[size];
-            for (int i = 0; i < size; i++) {
-                if (varCharVector.isNull(startIndex + i)) {
-                    values[i] = null;
-                } else {
-                    values[i] = StringData.fromBytes(varCharVector.get(startIndex + i));
-                }
-            }
-            return new GenericArrayData(values);
-        }
-
-        throw new LanceTypeConverter.UnsupportedTypeException(
-                "Unsupported array element type: " + elementType.getClass().getSimpleName());
-    }
-
-    /**
-     * Internal class for handling Double type Vector (alias for Float8Vector)
-     */
-    private static class Double8Vector {
-        private final Float8Vector vector;
-
-        Double8Vector(FieldVector vector) {
-            this.vector = (Float8Vector) vector;
-        }
-
-        boolean isNull(int index) {
-            return vector.isNull(index);
-        }
-
-        double get(int index) {
-            return vector.get(index);
-        }
-    }
-
-    /**
-     * Read struct value
-     */
-    private RowData readStruct(FieldVector vector, int index, RowType rowType) {
-        StructVector structVector = (StructVector) vector;
-        List<RowType.RowField> fields = rowType.getFields();
-        GenericRowData rowData = new GenericRowData(fields.size());
-
-        for (int i = 0; i < fields.size(); i++) {
-            RowType.RowField field = fields.get(i);
-            FieldVector childVector = structVector.getChild(field.getName());
-            if (childVector == null) {
-                rowData.setField(i, null);
-            } else {
-                Object value = readValue(childVector, index, field.getType());
-                rowData.setField(i, value);
-            }
-        }
-
-        return rowData;
-    }
-
-    /**
-     * Get field value from RowData
-     */
-    private Object getFieldValue(RowData rowData, int index, LogicalType logicalType) {
-        if (rowData.isNullAt(index)) {
-            return null;
-        }
-
-        if (logicalType instanceof TinyIntType) {
-            return rowData.getByte(index);
-        } else if (logicalType instanceof SmallIntType) {
-            return rowData.getShort(index);
-        } else if (logicalType instanceof IntType) {
-            return rowData.getInt(index);
-        } else if (logicalType instanceof BigIntType) {
-            return rowData.getLong(index);
-        } else if (logicalType instanceof FloatType) {
-            return rowData.getFloat(index);
-        } else if (logicalType instanceof DoubleType) {
-            return rowData.getDouble(index);
-        } else if (logicalType instanceof VarCharType) {
-            return rowData.getString(index);
-        } else if (logicalType instanceof BooleanType) {
-            return rowData.getBoolean(index);
-        } else if (logicalType instanceof VarBinaryType || logicalType instanceof BinaryType) {
-            return rowData.getBinary(index);
-        } else if (logicalType instanceof DateType) {
-            return rowData.getInt(index);
-        } else if (logicalType instanceof TimestampType) {
-            TimestampType tsType = (TimestampType) logicalType;
-            return rowData.getTimestamp(index, tsType.getPrecision());
-        } else if (logicalType instanceof ArrayType) {
-            return rowData.getArray(index);
-        } else if (logicalType instanceof RowType) {
-            RowType nestedRowType = (RowType) logicalType;
-            return rowData.getRow(index, nestedRowType.getFieldCount());
-        }
-
-        throw new LanceTypeConverter.UnsupportedTypeException(
-                "Unsupported get type: " + logicalType.getClass().getSimpleName());
-    }
-
-    /**
-     * Write value to Arrow Vector
-     */
-    private void writeValue(FieldVector vector, int index, Object value, LogicalType logicalType) {
-        if (value == null) {
-            setNull(vector, index);
-            return;
-        }
-
-        if (logicalType instanceof TinyIntType) {
-            ((TinyIntVector) vector).setSafe(index, (byte) value);
-        } else if (logicalType instanceof SmallIntType) {
-            ((SmallIntVector) vector).setSafe(index, (short) value);
-        } else if (logicalType instanceof IntType) {
-            ((IntVector) vector).setSafe(index, (int) value);
-        } else if (logicalType instanceof BigIntType) {
-            ((BigIntVector) vector).setSafe(index, (long) value);
-        } else if (logicalType instanceof FloatType) {
-            ((Float4Vector) vector).setSafe(index, (float) value);
-        } else if (logicalType instanceof DoubleType) {
-            ((Float8Vector) vector).setSafe(index, (double) value);
-        } else if (logicalType instanceof VarCharType) {
-            StringData stringData = (StringData) value;
-            ((VarCharVector) vector).setSafe(index, stringData.toBytes());
-        } else if (logicalType instanceof BooleanType) {
-            ((BitVector) vector).setSafe(index, (boolean) value ? 1 : 0);
-        } else if (logicalType instanceof VarBinaryType) {
-            ((VarBinaryVector) vector).setSafe(index, (byte[]) value);
-        } else if (logicalType instanceof BinaryType) {
-            ((FixedSizeBinaryVector) vector).setSafe(index, (byte[]) value);
-        } else if (logicalType instanceof DateType) {
-            ((DateDayVector) vector).setSafe(index, (int) value);
-        } else if (logicalType instanceof TimestampType) {
-            writeTimestamp(vector, index, (TimestampData) value, (TimestampType) logicalType);
-        } else if (logicalType instanceof ArrayType) {
-            writeArray(vector, index, (ArrayData) value, (ArrayType) logicalType);
-        } else if (logicalType instanceof RowType) {
-            writeStruct(vector, index, (RowData) value, (RowType) logicalType);
-        } else {
-            throw new LanceTypeConverter.UnsupportedTypeException(
-                    "Unsupported write type: " + logicalType.getClass().getSimpleName());
-        }
-    }
-
-    /**
-     * Set null value
-     */
-    private void setNull(FieldVector vector, int index) {
-        if (vector instanceof TinyIntVector) {
-            ((TinyIntVector) vector).setNull(index);
-        } else if (vector instanceof SmallIntVector) {
-            ((SmallIntVector) vector).setNull(index);
-        } else if (vector instanceof IntVector) {
-            ((IntVector) vector).setNull(index);
-        } else if (vector instanceof BigIntVector) {
-            ((BigIntVector) vector).setNull(index);
-        } else if (vector instanceof Float4Vector) {
-            ((Float4Vector) vector).setNull(index);
-        } else if (vector instanceof Float8Vector) {
-            ((Float8Vector) vector).setNull(index);
-        } else if (vector instanceof VarCharVector) {
-            ((VarCharVector) vector).setNull(index);
-        } else if (vector instanceof BitVector) {
-            ((BitVector) vector).setNull(index);
-        } else if (vector instanceof VarBinaryVector) {
-            ((VarBinaryVector) vector).setNull(index);
-        } else if (vector instanceof FixedSizeBinaryVector) {
-            ((FixedSizeBinaryVector) vector).setNull(index);
-        } else if (vector instanceof DateDayVector) {
-            ((DateDayVector) vector).setNull(index);
-        } else if (vector instanceof TimeStampSecVector) {
-            ((TimeStampSecVector) vector).setNull(index);
-        } else if (vector instanceof TimeStampMilliVector) {
-            ((TimeStampMilliVector) vector).setNull(index);
-        } else if (vector instanceof TimeStampMicroVector) {
-            ((TimeStampMicroVector) vector).setNull(index);
-        } else if (vector instanceof TimeStampNanoVector) {
-            ((TimeStampNanoVector) vector).setNull(index);
-        } else if (vector instanceof FixedSizeListVector) {
-            ((FixedSizeListVector) vector).setNull(index);
-        } else if (vector instanceof ListVector) {
-            ((ListVector) vector).setNull(index);
-        } else if (vector instanceof StructVector) {
-            ((StructVector) vector).setNull(index);
-        }
-    }
-
-    /**
-     * Write timestamp value
-     */
-    private void writeTimestamp(FieldVector vector, int index, TimestampData tsData, TimestampType tsType) {
-        long millis = tsData.getMillisecond();
-        int nanos = tsData.getNanoOfMillisecond();
-
-        if (vector instanceof TimeStampSecVector) {
-            ((TimeStampSecVector) vector).setSafe(index, millis / 1000);
-        } else if (vector instanceof TimeStampMilliVector) {
-            ((TimeStampMilliVector) vector).setSafe(index, millis);
-        } else if (vector instanceof TimeStampMicroVector) {
-            long micros = millis * 1000 + nanos / 1000;
-            ((TimeStampMicroVector) vector).setSafe(index, micros);
-        } else if (vector instanceof TimeStampNanoVector) {
-            long totalNanos = millis * 1000000 + nanos;
-            ((TimeStampNanoVector) vector).setSafe(index, totalNanos);
-        } else {
-            throw new LanceTypeConverter.UnsupportedTypeException(
-                    "Unsupported timestamp Vector type: " + vector.getClass().getSimpleName());
-        }
-    }
-
-    /**
-     * Write array value
-     */
-    private void writeArray(FieldVector vector, int index, ArrayData arrayData, ArrayType arrayType) {
-        LogicalType elementType = arrayType.getElementType();
-        int size = arrayData.size();
-
-        if (vector instanceof FixedSizeListVector) {
-            FixedSizeListVector listVector = (FixedSizeListVector) vector;
-            int listSize = listVector.getListSize();
-
-            if (size != listSize) {
-                throw new IllegalArgumentException(
-                        "Array size " + size + " does not match FixedSizeList size " + listSize);
-            }
-
-            FieldVector dataVector = listVector.getDataVector();
-            int startIndex = index * listSize;
-
-            writeArrayData(dataVector, startIndex, arrayData, elementType);
-            listVector.setNotNull(index);
-        } else if (vector instanceof ListVector) {
-            ListVector listVector = (ListVector) vector;
-            listVector.startNewValue(index);
-
-            FieldVector dataVector = listVector.getDataVector();
-            int startIndex = listVector.getElementStartIndex(index);
-
-            writeArrayData(dataVector, startIndex, arrayData, elementType);
-            listVector.endValue(index, size);
-        } else {
-            throw new LanceTypeConverter.UnsupportedTypeException(
-                    "Unsupported array Vector type: " + vector.getClass().getSimpleName());
-        }
-    }
-
-    /**
-     * Write array data
-     */
-    private void writeArrayData(FieldVector dataVector, int startIndex, ArrayData arrayData, LogicalType elementType) {
-        int size = arrayData.size();
-
-        if (elementType instanceof FloatType) {
-            Float4Vector float4Vector = (Float4Vector) dataVector;
-            for (int i = 0; i < size; i++) {
-                if (arrayData.isNullAt(i)) {
-                    float4Vector.setNull(startIndex + i);
-                } else {
-                    float4Vector.setSafe(startIndex + i, arrayData.getFloat(i));
-                }
-            }
-        } else if (elementType instanceof DoubleType) {
-            Float8Vector float8Vector = (Float8Vector) dataVector;
-            for (int i = 0; i < size; i++) {
-                if (arrayData.isNullAt(i)) {
-                    float8Vector.setNull(startIndex + i);
-                } else {
-                    float8Vector.setSafe(startIndex + i, arrayData.getDouble(i));
-                }
-            }
-        } else if (elementType instanceof IntType) {
-            IntVector intVector = (IntVector) dataVector;
-            for (int i = 0; i < size; i++) {
-                if (arrayData.isNullAt(i)) {
-                    intVector.setNull(startIndex + i);
-                } else {
-                    intVector.setSafe(startIndex + i, arrayData.getInt(i));
-                }
-            }
-        } else if (elementType instanceof BigIntType) {
-            BigIntVector bigIntVector = (BigIntVector) dataVector;
-            for (int i = 0; i < size; i++) {
-                if (arrayData.isNullAt(i)) {
-                    bigIntVector.setNull(startIndex + i);
-                } else {
-                    bigIntVector.setSafe(startIndex + i, arrayData.getLong(i));
-                }
-            }
-        } else if (elementType instanceof VarCharType) {
-            VarCharVector varCharVector = (VarCharVector) dataVector;
-            for (int i = 0; i < size; i++) {
-                if (arrayData.isNullAt(i)) {
-                    varCharVector.setNull(startIndex + i);
-                } else {
-                    StringData stringData = arrayData.getString(i);
-                    varCharVector.setSafe(startIndex + i, stringData.toBytes());
-                }
-            }
-        } else {
-            throw new LanceTypeConverter.UnsupportedTypeException(
-                    "Unsupported array element type: " + elementType.getClass().getSimpleName());
-        }
-    }
-
-    /**
-     * Write struct value
-     */
-    private void writeStruct(FieldVector vector, int index, RowData rowData, RowType rowType) {
-        StructVector structVector = (StructVector) vector;
-        List<RowType.RowField> fields = rowType.getFields();
-
-        for (int i = 0; i < fields.size(); i++) {
-            RowType.RowField field = fields.get(i);
-            FieldVector childVector = structVector.getChild(field.getName());
-            if (childVector != null) {
-                Object value = getFieldValue(rowData, i, field.getType());
-                writeValue(childVector, index, value, field.getType());
-            }
-        }
-
-        structVector.setIndexDefined(index);
-    }
-
-    /**
-     * Convert float array to ArrayData
-     *
-     * @param vector float array
-     * @return ArrayData
-     */
-    public static ArrayData toArrayData(float[] vector) {
         if (vector == null) {
-            return null;
+          rowData.setField(fieldIndex, null);
+          continue;
         }
-        Float[] boxed = new Float[vector.length];
-        for (int i = 0; i < vector.length; i++) {
-            boxed[i] = vector[i];
-        }
-        return new GenericArrayData(boxed);
+
+        Object value = readValue(vector, rowIndex, fieldTypes[fieldIndex]);
+        rowData.setField(fieldIndex, value);
+      }
+
+      rows.add(rowData);
     }
 
-    /**
-     * Convert double array to ArrayData
-     *
-     * @param vector double array
-     * @return ArrayData
-     */
-    public static ArrayData toArrayData(double[] vector) {
+    return rows;
+  }
+
+  /**
+   * Write RowData list to Arrow VectorSchemaRoot
+   *
+   * @param rows RowData list
+   * @param root Arrow VectorSchemaRoot
+   */
+  public void toVectorSchemaRoot(List<RowData> rows, VectorSchemaRoot root) {
+    root.allocateNew();
+
+    for (int rowIndex = 0; rowIndex < rows.size(); rowIndex++) {
+      RowData rowData = rows.get(rowIndex);
+
+      for (int fieldIndex = 0; fieldIndex < fieldTypes.length; fieldIndex++) {
+        String fieldName = fieldNames[fieldIndex];
+        FieldVector vector = root.getVector(fieldName);
+
         if (vector == null) {
-            return null;
+          continue;
         }
-        Double[] boxed = new Double[vector.length];
-        for (int i = 0; i < vector.length; i++) {
-            boxed[i] = vector[i];
-        }
-        return new GenericArrayData(boxed);
+
+        Object value = getFieldValue(rowData, fieldIndex, fieldTypes[fieldIndex]);
+        writeValue(vector, rowIndex, value, fieldTypes[fieldIndex]);
+      }
     }
 
-    /**
-     * Convert ArrayData to float array
-     *
-     * @param arrayData ArrayData
-     * @return float array
-     */
-    public static float[] toFloatArray(ArrayData arrayData) {
-        if (arrayData == null) {
-            return null;
-        }
-        int size = arrayData.size();
-        float[] result = new float[size];
-        for (int i = 0; i < size; i++) {
-            result[i] = arrayData.getFloat(i);
-        }
-        return result;
+    root.setRowCount(rows.size());
+  }
+
+  /**
+   * Create VectorSchemaRoot
+   *
+   * @param allocator Memory allocator
+   * @return VectorSchemaRoot
+   */
+  public VectorSchemaRoot createVectorSchemaRoot(BufferAllocator allocator) {
+    Schema arrowSchema = LanceTypeConverter.toArrowSchema(rowType);
+    return VectorSchemaRoot.create(arrowSchema, allocator);
+  }
+
+  /** Read value from Arrow Vector */
+  private Object readValue(FieldVector vector, int index, LogicalType logicalType) {
+    if (vector.isNull(index)) {
+      return null;
     }
 
-    /**
-     * Convert ArrayData to double array
-     *
-     * @param arrayData ArrayData
-     * @return double array
-     */
-    public static double[] toDoubleArray(ArrayData arrayData) {
-        if (arrayData == null) {
-            return null;
+    if (logicalType instanceof TinyIntType) {
+      return ((TinyIntVector) vector).get(index);
+    } else if (logicalType instanceof SmallIntType) {
+      return ((SmallIntVector) vector).get(index);
+    } else if (logicalType instanceof IntType) {
+      return ((IntVector) vector).get(index);
+    } else if (logicalType instanceof BigIntType) {
+      return ((BigIntVector) vector).get(index);
+    } else if (logicalType instanceof FloatType) {
+      return ((Float4Vector) vector).get(index);
+    } else if (logicalType instanceof DoubleType) {
+      return ((Float8Vector) vector).get(index);
+    } else if (logicalType instanceof VarCharType) {
+      byte[] bytes = ((VarCharVector) vector).get(index);
+      return StringData.fromBytes(bytes);
+    } else if (logicalType instanceof BooleanType) {
+      return ((BitVector) vector).get(index) == 1;
+    } else if (logicalType instanceof VarBinaryType) {
+      return ((VarBinaryVector) vector).get(index);
+    } else if (logicalType instanceof BinaryType) {
+      return ((FixedSizeBinaryVector) vector).get(index);
+    } else if (logicalType instanceof DateType) {
+      int daysSinceEpoch = ((DateDayVector) vector).get(index);
+      return daysSinceEpoch;
+    } else if (logicalType instanceof TimestampType) {
+      return readTimestamp(vector, index, (TimestampType) logicalType);
+    } else if (logicalType instanceof ArrayType) {
+      return readArray(vector, index, (ArrayType) logicalType);
+    } else if (logicalType instanceof RowType) {
+      return readStruct(vector, index, (RowType) logicalType);
+    }
+
+    throw new LanceTypeConverter.UnsupportedTypeException(
+        "Unsupported read type: " + logicalType.getClass().getSimpleName());
+  }
+
+  /** Read timestamp value */
+  private TimestampData readTimestamp(FieldVector vector, int index, TimestampType tsType) {
+    long value;
+    int precision = tsType.getPrecision();
+
+    if (vector instanceof TimeStampSecVector) {
+      value = ((TimeStampSecVector) vector).get(index);
+      return TimestampData.fromEpochMillis(value * 1000);
+    } else if (vector instanceof TimeStampMilliVector) {
+      value = ((TimeStampMilliVector) vector).get(index);
+      return TimestampData.fromEpochMillis(value);
+    } else if (vector instanceof TimeStampMicroVector) {
+      value = ((TimeStampMicroVector) vector).get(index);
+      return TimestampData.fromEpochMillis(value / 1000, (int) ((value % 1000) * 1000));
+    } else if (vector instanceof TimeStampNanoVector) {
+      value = ((TimeStampNanoVector) vector).get(index);
+      return TimestampData.fromEpochMillis(value / 1000000, (int) (value % 1000000));
+    }
+
+    throw new LanceTypeConverter.UnsupportedTypeException(
+        "Unsupported timestamp Vector type: " + vector.getClass().getSimpleName());
+  }
+
+  /** Read array value */
+  private ArrayData readArray(FieldVector vector, int index, ArrayType arrayType) {
+    LogicalType elementType = arrayType.getElementType();
+
+    if (vector instanceof FixedSizeListVector) {
+      FixedSizeListVector listVector = (FixedSizeListVector) vector;
+      int listSize = listVector.getListSize();
+      FieldVector dataVector = listVector.getDataVector();
+      int startIndex = index * listSize;
+
+      return readArrayData(dataVector, startIndex, listSize, elementType);
+    } else if (vector instanceof ListVector) {
+      ListVector listVector = (ListVector) vector;
+      int startIndex = listVector.getElementStartIndex(index);
+      int endIndex = listVector.getElementEndIndex(index);
+      int listSize = endIndex - startIndex;
+      FieldVector dataVector = listVector.getDataVector();
+
+      return readArrayData(dataVector, startIndex, listSize, elementType);
+    }
+
+    throw new LanceTypeConverter.UnsupportedTypeException(
+        "Unsupported array Vector type: " + vector.getClass().getSimpleName());
+  }
+
+  /** Read array data */
+  private ArrayData readArrayData(
+      FieldVector dataVector, int startIndex, int size, LogicalType elementType) {
+    if (elementType instanceof FloatType) {
+      Float4Vector float4Vector = (Float4Vector) dataVector;
+      Float[] values = new Float[size];
+      for (int i = 0; i < size; i++) {
+        if (float4Vector.isNull(startIndex + i)) {
+          values[i] = null;
+        } else {
+          values[i] = float4Vector.get(startIndex + i);
         }
-        int size = arrayData.size();
-        double[] result = new double[size];
-        for (int i = 0; i < size; i++) {
-            result[i] = arrayData.getDouble(i);
+      }
+      return new GenericArrayData(values);
+    } else if (elementType instanceof DoubleType) {
+      Double8Vector double8Vector = (Double8Vector) dataVector;
+      Double[] values = new Double[size];
+      for (int i = 0; i < size; i++) {
+        if (double8Vector.isNull(startIndex + i)) {
+          values[i] = null;
+        } else {
+          values[i] = double8Vector.get(startIndex + i);
         }
-        return result;
+      }
+      return new GenericArrayData(values);
+    } else if (elementType instanceof IntType) {
+      IntVector intVector = (IntVector) dataVector;
+      Integer[] values = new Integer[size];
+      for (int i = 0; i < size; i++) {
+        if (intVector.isNull(startIndex + i)) {
+          values[i] = null;
+        } else {
+          values[i] = intVector.get(startIndex + i);
+        }
+      }
+      return new GenericArrayData(values);
+    } else if (elementType instanceof BigIntType) {
+      BigIntVector bigIntVector = (BigIntVector) dataVector;
+      Long[] values = new Long[size];
+      for (int i = 0; i < size; i++) {
+        if (bigIntVector.isNull(startIndex + i)) {
+          values[i] = null;
+        } else {
+          values[i] = bigIntVector.get(startIndex + i);
+        }
+      }
+      return new GenericArrayData(values);
+    } else if (elementType instanceof VarCharType) {
+      VarCharVector varCharVector = (VarCharVector) dataVector;
+      StringData[] values = new StringData[size];
+      for (int i = 0; i < size; i++) {
+        if (varCharVector.isNull(startIndex + i)) {
+          values[i] = null;
+        } else {
+          values[i] = StringData.fromBytes(varCharVector.get(startIndex + i));
+        }
+      }
+      return new GenericArrayData(values);
     }
 
-    /**
-     * Get RowType
-     */
-    public RowType getRowType() {
-        return rowType;
+    throw new LanceTypeConverter.UnsupportedTypeException(
+        "Unsupported array element type: " + elementType.getClass().getSimpleName());
+  }
+
+  /** Internal class for handling Double type Vector (alias for Float8Vector) */
+  private static class Double8Vector {
+    private final Float8Vector vector;
+
+    Double8Vector(FieldVector vector) {
+      this.vector = (Float8Vector) vector;
     }
 
-    /**
-     * Get field name array
-     */
-    public String[] getFieldNames() {
-        return fieldNames;
+    boolean isNull(int index) {
+      return vector.isNull(index);
     }
 
-    /**
-     * Get field type array
-     */
-    public LogicalType[] getFieldTypes() {
-        return fieldTypes;
+    double get(int index) {
+      return vector.get(index);
     }
+  }
+
+  /** Read struct value */
+  private RowData readStruct(FieldVector vector, int index, RowType rowType) {
+    StructVector structVector = (StructVector) vector;
+    List<RowType.RowField> fields = rowType.getFields();
+    GenericRowData rowData = new GenericRowData(fields.size());
+
+    for (int i = 0; i < fields.size(); i++) {
+      RowType.RowField field = fields.get(i);
+      FieldVector childVector = structVector.getChild(field.getName());
+      if (childVector == null) {
+        rowData.setField(i, null);
+      } else {
+        Object value = readValue(childVector, index, field.getType());
+        rowData.setField(i, value);
+      }
+    }
+
+    return rowData;
+  }
+
+  /** Get field value from RowData */
+  private Object getFieldValue(RowData rowData, int index, LogicalType logicalType) {
+    if (rowData.isNullAt(index)) {
+      return null;
+    }
+
+    if (logicalType instanceof TinyIntType) {
+      return rowData.getByte(index);
+    } else if (logicalType instanceof SmallIntType) {
+      return rowData.getShort(index);
+    } else if (logicalType instanceof IntType) {
+      return rowData.getInt(index);
+    } else if (logicalType instanceof BigIntType) {
+      return rowData.getLong(index);
+    } else if (logicalType instanceof FloatType) {
+      return rowData.getFloat(index);
+    } else if (logicalType instanceof DoubleType) {
+      return rowData.getDouble(index);
+    } else if (logicalType instanceof VarCharType) {
+      return rowData.getString(index);
+    } else if (logicalType instanceof BooleanType) {
+      return rowData.getBoolean(index);
+    } else if (logicalType instanceof VarBinaryType || logicalType instanceof BinaryType) {
+      return rowData.getBinary(index);
+    } else if (logicalType instanceof DateType) {
+      return rowData.getInt(index);
+    } else if (logicalType instanceof TimestampType) {
+      TimestampType tsType = (TimestampType) logicalType;
+      return rowData.getTimestamp(index, tsType.getPrecision());
+    } else if (logicalType instanceof ArrayType) {
+      return rowData.getArray(index);
+    } else if (logicalType instanceof RowType) {
+      RowType nestedRowType = (RowType) logicalType;
+      return rowData.getRow(index, nestedRowType.getFieldCount());
+    }
+
+    throw new LanceTypeConverter.UnsupportedTypeException(
+        "Unsupported get type: " + logicalType.getClass().getSimpleName());
+  }
+
+  /** Write value to Arrow Vector */
+  private void writeValue(FieldVector vector, int index, Object value, LogicalType logicalType) {
+    if (value == null) {
+      setNull(vector, index);
+      return;
+    }
+
+    if (logicalType instanceof TinyIntType) {
+      ((TinyIntVector) vector).setSafe(index, (byte) value);
+    } else if (logicalType instanceof SmallIntType) {
+      ((SmallIntVector) vector).setSafe(index, (short) value);
+    } else if (logicalType instanceof IntType) {
+      ((IntVector) vector).setSafe(index, (int) value);
+    } else if (logicalType instanceof BigIntType) {
+      ((BigIntVector) vector).setSafe(index, (long) value);
+    } else if (logicalType instanceof FloatType) {
+      ((Float4Vector) vector).setSafe(index, (float) value);
+    } else if (logicalType instanceof DoubleType) {
+      ((Float8Vector) vector).setSafe(index, (double) value);
+    } else if (logicalType instanceof VarCharType) {
+      StringData stringData = (StringData) value;
+      ((VarCharVector) vector).setSafe(index, stringData.toBytes());
+    } else if (logicalType instanceof BooleanType) {
+      ((BitVector) vector).setSafe(index, (boolean) value ? 1 : 0);
+    } else if (logicalType instanceof VarBinaryType) {
+      ((VarBinaryVector) vector).setSafe(index, (byte[]) value);
+    } else if (logicalType instanceof BinaryType) {
+      ((FixedSizeBinaryVector) vector).setSafe(index, (byte[]) value);
+    } else if (logicalType instanceof DateType) {
+      ((DateDayVector) vector).setSafe(index, (int) value);
+    } else if (logicalType instanceof TimestampType) {
+      writeTimestamp(vector, index, (TimestampData) value, (TimestampType) logicalType);
+    } else if (logicalType instanceof ArrayType) {
+      writeArray(vector, index, (ArrayData) value, (ArrayType) logicalType);
+    } else if (logicalType instanceof RowType) {
+      writeStruct(vector, index, (RowData) value, (RowType) logicalType);
+    } else {
+      throw new LanceTypeConverter.UnsupportedTypeException(
+          "Unsupported write type: " + logicalType.getClass().getSimpleName());
+    }
+  }
+
+  /** Set null value */
+  private void setNull(FieldVector vector, int index) {
+    if (vector instanceof TinyIntVector) {
+      ((TinyIntVector) vector).setNull(index);
+    } else if (vector instanceof SmallIntVector) {
+      ((SmallIntVector) vector).setNull(index);
+    } else if (vector instanceof IntVector) {
+      ((IntVector) vector).setNull(index);
+    } else if (vector instanceof BigIntVector) {
+      ((BigIntVector) vector).setNull(index);
+    } else if (vector instanceof Float4Vector) {
+      ((Float4Vector) vector).setNull(index);
+    } else if (vector instanceof Float8Vector) {
+      ((Float8Vector) vector).setNull(index);
+    } else if (vector instanceof VarCharVector) {
+      ((VarCharVector) vector).setNull(index);
+    } else if (vector instanceof BitVector) {
+      ((BitVector) vector).setNull(index);
+    } else if (vector instanceof VarBinaryVector) {
+      ((VarBinaryVector) vector).setNull(index);
+    } else if (vector instanceof FixedSizeBinaryVector) {
+      ((FixedSizeBinaryVector) vector).setNull(index);
+    } else if (vector instanceof DateDayVector) {
+      ((DateDayVector) vector).setNull(index);
+    } else if (vector instanceof TimeStampSecVector) {
+      ((TimeStampSecVector) vector).setNull(index);
+    } else if (vector instanceof TimeStampMilliVector) {
+      ((TimeStampMilliVector) vector).setNull(index);
+    } else if (vector instanceof TimeStampMicroVector) {
+      ((TimeStampMicroVector) vector).setNull(index);
+    } else if (vector instanceof TimeStampNanoVector) {
+      ((TimeStampNanoVector) vector).setNull(index);
+    } else if (vector instanceof FixedSizeListVector) {
+      ((FixedSizeListVector) vector).setNull(index);
+    } else if (vector instanceof ListVector) {
+      ((ListVector) vector).setNull(index);
+    } else if (vector instanceof StructVector) {
+      ((StructVector) vector).setNull(index);
+    }
+  }
+
+  /** Write timestamp value */
+  private void writeTimestamp(
+      FieldVector vector, int index, TimestampData tsData, TimestampType tsType) {
+    long millis = tsData.getMillisecond();
+    int nanos = tsData.getNanoOfMillisecond();
+
+    if (vector instanceof TimeStampSecVector) {
+      ((TimeStampSecVector) vector).setSafe(index, millis / 1000);
+    } else if (vector instanceof TimeStampMilliVector) {
+      ((TimeStampMilliVector) vector).setSafe(index, millis);
+    } else if (vector instanceof TimeStampMicroVector) {
+      long micros = millis * 1000 + nanos / 1000;
+      ((TimeStampMicroVector) vector).setSafe(index, micros);
+    } else if (vector instanceof TimeStampNanoVector) {
+      long totalNanos = millis * 1000000 + nanos;
+      ((TimeStampNanoVector) vector).setSafe(index, totalNanos);
+    } else {
+      throw new LanceTypeConverter.UnsupportedTypeException(
+          "Unsupported timestamp Vector type: " + vector.getClass().getSimpleName());
+    }
+  }
+
+  /** Write array value */
+  private void writeArray(FieldVector vector, int index, ArrayData arrayData, ArrayType arrayType) {
+    LogicalType elementType = arrayType.getElementType();
+    int size = arrayData.size();
+
+    if (vector instanceof FixedSizeListVector) {
+      FixedSizeListVector listVector = (FixedSizeListVector) vector;
+      int listSize = listVector.getListSize();
+
+      if (size != listSize) {
+        throw new IllegalArgumentException(
+            "Array size " + size + " does not match FixedSizeList size " + listSize);
+      }
+
+      FieldVector dataVector = listVector.getDataVector();
+      int startIndex = index * listSize;
+
+      writeArrayData(dataVector, startIndex, arrayData, elementType);
+      listVector.setNotNull(index);
+    } else if (vector instanceof ListVector) {
+      ListVector listVector = (ListVector) vector;
+      listVector.startNewValue(index);
+
+      FieldVector dataVector = listVector.getDataVector();
+      int startIndex = listVector.getElementStartIndex(index);
+
+      writeArrayData(dataVector, startIndex, arrayData, elementType);
+      listVector.endValue(index, size);
+    } else {
+      throw new LanceTypeConverter.UnsupportedTypeException(
+          "Unsupported array Vector type: " + vector.getClass().getSimpleName());
+    }
+  }
+
+  /** Write array data */
+  private void writeArrayData(
+      FieldVector dataVector, int startIndex, ArrayData arrayData, LogicalType elementType) {
+    int size = arrayData.size();
+
+    if (elementType instanceof FloatType) {
+      Float4Vector float4Vector = (Float4Vector) dataVector;
+      for (int i = 0; i < size; i++) {
+        if (arrayData.isNullAt(i)) {
+          float4Vector.setNull(startIndex + i);
+        } else {
+          float4Vector.setSafe(startIndex + i, arrayData.getFloat(i));
+        }
+      }
+    } else if (elementType instanceof DoubleType) {
+      Float8Vector float8Vector = (Float8Vector) dataVector;
+      for (int i = 0; i < size; i++) {
+        if (arrayData.isNullAt(i)) {
+          float8Vector.setNull(startIndex + i);
+        } else {
+          float8Vector.setSafe(startIndex + i, arrayData.getDouble(i));
+        }
+      }
+    } else if (elementType instanceof IntType) {
+      IntVector intVector = (IntVector) dataVector;
+      for (int i = 0; i < size; i++) {
+        if (arrayData.isNullAt(i)) {
+          intVector.setNull(startIndex + i);
+        } else {
+          intVector.setSafe(startIndex + i, arrayData.getInt(i));
+        }
+      }
+    } else if (elementType instanceof BigIntType) {
+      BigIntVector bigIntVector = (BigIntVector) dataVector;
+      for (int i = 0; i < size; i++) {
+        if (arrayData.isNullAt(i)) {
+          bigIntVector.setNull(startIndex + i);
+        } else {
+          bigIntVector.setSafe(startIndex + i, arrayData.getLong(i));
+        }
+      }
+    } else if (elementType instanceof VarCharType) {
+      VarCharVector varCharVector = (VarCharVector) dataVector;
+      for (int i = 0; i < size; i++) {
+        if (arrayData.isNullAt(i)) {
+          varCharVector.setNull(startIndex + i);
+        } else {
+          StringData stringData = arrayData.getString(i);
+          varCharVector.setSafe(startIndex + i, stringData.toBytes());
+        }
+      }
+    } else {
+      throw new LanceTypeConverter.UnsupportedTypeException(
+          "Unsupported array element type: " + elementType.getClass().getSimpleName());
+    }
+  }
+
+  /** Write struct value */
+  private void writeStruct(FieldVector vector, int index, RowData rowData, RowType rowType) {
+    StructVector structVector = (StructVector) vector;
+    List<RowType.RowField> fields = rowType.getFields();
+
+    for (int i = 0; i < fields.size(); i++) {
+      RowType.RowField field = fields.get(i);
+      FieldVector childVector = structVector.getChild(field.getName());
+      if (childVector != null) {
+        Object value = getFieldValue(rowData, i, field.getType());
+        writeValue(childVector, index, value, field.getType());
+      }
+    }
+
+    structVector.setIndexDefined(index);
+  }
+
+  /**
+   * Convert float array to ArrayData
+   *
+   * @param vector float array
+   * @return ArrayData
+   */
+  public static ArrayData toArrayData(float[] vector) {
+    if (vector == null) {
+      return null;
+    }
+    Float[] boxed = new Float[vector.length];
+    for (int i = 0; i < vector.length; i++) {
+      boxed[i] = vector[i];
+    }
+    return new GenericArrayData(boxed);
+  }
+
+  /**
+   * Convert double array to ArrayData
+   *
+   * @param vector double array
+   * @return ArrayData
+   */
+  public static ArrayData toArrayData(double[] vector) {
+    if (vector == null) {
+      return null;
+    }
+    Double[] boxed = new Double[vector.length];
+    for (int i = 0; i < vector.length; i++) {
+      boxed[i] = vector[i];
+    }
+    return new GenericArrayData(boxed);
+  }
+
+  /**
+   * Convert ArrayData to float array
+   *
+   * @param arrayData ArrayData
+   * @return float array
+   */
+  public static float[] toFloatArray(ArrayData arrayData) {
+    if (arrayData == null) {
+      return null;
+    }
+    int size = arrayData.size();
+    float[] result = new float[size];
+    for (int i = 0; i < size; i++) {
+      result[i] = arrayData.getFloat(i);
+    }
+    return result;
+  }
+
+  /**
+   * Convert ArrayData to double array
+   *
+   * @param arrayData ArrayData
+   * @return double array
+   */
+  public static double[] toDoubleArray(ArrayData arrayData) {
+    if (arrayData == null) {
+      return null;
+    }
+    int size = arrayData.size();
+    double[] result = new double[size];
+    for (int i = 0; i < size; i++) {
+      result[i] = arrayData.getDouble(i);
+    }
+    return result;
+  }
+
+  /** Get RowType */
+  public RowType getRowType() {
+    return rowType;
+  }
+
+  /** Get field name array */
+  public String[] getFieldNames() {
+    return fieldNames;
+  }
+
+  /** Get field type array */
+  public LogicalType[] getFieldTypes() {
+    return fieldTypes;
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/sink/LanceSink.java
+++ b/src/main/java/org/apache/flink/connector/lance/sink/LanceSink.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.sink;
 
 import org.apache.flink.api.connector.sink2.Sink;
@@ -32,6 +27,7 @@ import java.io.IOException;
  * <p>Top-level entry point for Flink Sink V2 API, responsible for creating {@link LanceSinkWriter}.
  *
  * <p>Usage example:
+ *
  * <pre>{@code
  * LanceOptions options = LanceOptions.builder()
  *     .path("/path/to/lance/dataset")
@@ -45,100 +41,93 @@ import java.io.IOException;
  */
 public class LanceSink implements Sink<RowData> {
 
-    private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-    private final LanceOptions options;
-    private final RowType rowType;
+  private final LanceOptions options;
+  private final RowType rowType;
 
-    /**
-     * Create a LanceSink.
-     *
-     * @param options Lance configuration options
-     * @param rowType Flink RowType
-     */
-    public LanceSink(LanceOptions options, RowType rowType) {
-        this.options = options;
-        this.rowType = rowType;
+  /**
+   * Create a LanceSink.
+   *
+   * @param options Lance configuration options
+   * @param rowType Flink RowType
+   */
+  public LanceSink(LanceOptions options, RowType rowType) {
+    this.options = options;
+    this.rowType = rowType;
+  }
+
+  @Override
+  public SinkWriter<RowData> createWriter(InitContext context) throws IOException {
+    return new LanceSinkWriter(options, rowType);
+  }
+
+  /** Get RowType. */
+  public RowType getRowType() {
+    return rowType;
+  }
+
+  /** Get configuration options. */
+  public LanceOptions getOptions() {
+    return options;
+  }
+
+  /** Builder pattern constructor. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** LanceSink Builder */
+  public static class Builder {
+    private String path;
+    private int batchSize = 1024;
+    private LanceOptions.WriteMode writeMode = LanceOptions.WriteMode.APPEND;
+    private int maxRowsPerFile = 1000000;
+    private RowType rowType;
+
+    public Builder path(String path) {
+      this.path = path;
+      return this;
     }
 
-    @Override
-    public SinkWriter<RowData> createWriter(InitContext context) throws IOException {
-        return new LanceSinkWriter(options, rowType);
+    public Builder batchSize(int batchSize) {
+      this.batchSize = batchSize;
+      return this;
     }
 
-    /**
-     * Get RowType.
-     */
-    public RowType getRowType() {
-        return rowType;
+    public Builder writeMode(LanceOptions.WriteMode writeMode) {
+      this.writeMode = writeMode;
+      return this;
     }
 
-    /**
-     * Get configuration options.
-     */
-    public LanceOptions getOptions() {
-        return options;
+    public Builder maxRowsPerFile(int maxRowsPerFile) {
+      this.maxRowsPerFile = maxRowsPerFile;
+      return this;
     }
 
-    /**
-     * Builder pattern constructor.
-     */
-    public static Builder builder() {
-        return new Builder();
+    public Builder rowType(RowType rowType) {
+      this.rowType = rowType;
+      return this;
     }
 
-    /**
-     * LanceSink Builder
-     */
-    public static class Builder {
-        private String path;
-        private int batchSize = 1024;
-        private LanceOptions.WriteMode writeMode = LanceOptions.WriteMode.APPEND;
-        private int maxRowsPerFile = 1000000;
-        private RowType rowType;
+    public LanceSink build() {
+      if (path == null || path.isEmpty()) {
+        throw new IllegalArgumentException("Dataset path must not be empty");
+      }
 
-        public Builder path(String path) {
-            this.path = path;
-            return this;
-        }
+      if (rowType == null) {
+        throw new IllegalArgumentException("RowType must not be null");
+      }
 
-        public Builder batchSize(int batchSize) {
-            this.batchSize = batchSize;
-            return this;
-        }
+      LanceOptions options =
+          LanceOptions.builder()
+              .path(path)
+              .writeBatchSize(batchSize)
+              .writeMode(writeMode)
+              .writeMaxRowsPerFile(maxRowsPerFile)
+              .build();
 
-        public Builder writeMode(LanceOptions.WriteMode writeMode) {
-            this.writeMode = writeMode;
-            return this;
-        }
-
-        public Builder maxRowsPerFile(int maxRowsPerFile) {
-            this.maxRowsPerFile = maxRowsPerFile;
-            return this;
-        }
-
-        public Builder rowType(RowType rowType) {
-            this.rowType = rowType;
-            return this;
-        }
-
-        public LanceSink build() {
-            if (path == null || path.isEmpty()) {
-                throw new IllegalArgumentException("Dataset path must not be empty");
-            }
-
-            if (rowType == null) {
-                throw new IllegalArgumentException("RowType must not be null");
-            }
-
-            LanceOptions options = LanceOptions.builder()
-                    .path(path)
-                    .writeBatchSize(batchSize)
-                    .writeMode(writeMode)
-                    .writeMaxRowsPerFile(maxRowsPerFile)
-                    .build();
-
-            return new LanceSink(options, rowType);
-        }
+      return new LanceSink(options, rowType);
     }
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/sink/LanceSink.java
+++ b/src/main/java/org/apache/flink/connector/lance/sink/LanceSink.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.lance.sink;
+
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.connector.lance.config.LanceOptions;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.io.IOException;
+
+/**
+ * Lance Sink V2 implementation (based on FLIP-143).
+ *
+ * <p>Top-level entry point for Flink Sink V2 API, responsible for creating {@link LanceSinkWriter}.
+ *
+ * <p>Usage example:
+ * <pre>{@code
+ * LanceOptions options = LanceOptions.builder()
+ *     .path("/path/to/lance/dataset")
+ *     .writeBatchSize(1024)
+ *     .writeMode(WriteMode.APPEND)
+ *     .build();
+ *
+ * LanceSink sink = new LanceSink(options, rowType);
+ * dataStream.sinkTo(sink);
+ * }</pre>
+ */
+public class LanceSink implements Sink<RowData> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final LanceOptions options;
+    private final RowType rowType;
+
+    /**
+     * Create a LanceSink.
+     *
+     * @param options Lance configuration options
+     * @param rowType Flink RowType
+     */
+    public LanceSink(LanceOptions options, RowType rowType) {
+        this.options = options;
+        this.rowType = rowType;
+    }
+
+    @Override
+    public SinkWriter<RowData> createWriter(InitContext context) throws IOException {
+        return new LanceSinkWriter(options, rowType);
+    }
+
+    /**
+     * Get RowType.
+     */
+    public RowType getRowType() {
+        return rowType;
+    }
+
+    /**
+     * Get configuration options.
+     */
+    public LanceOptions getOptions() {
+        return options;
+    }
+
+    /**
+     * Builder pattern constructor.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * LanceSink Builder
+     */
+    public static class Builder {
+        private String path;
+        private int batchSize = 1024;
+        private LanceOptions.WriteMode writeMode = LanceOptions.WriteMode.APPEND;
+        private int maxRowsPerFile = 1000000;
+        private RowType rowType;
+
+        public Builder path(String path) {
+            this.path = path;
+            return this;
+        }
+
+        public Builder batchSize(int batchSize) {
+            this.batchSize = batchSize;
+            return this;
+        }
+
+        public Builder writeMode(LanceOptions.WriteMode writeMode) {
+            this.writeMode = writeMode;
+            return this;
+        }
+
+        public Builder maxRowsPerFile(int maxRowsPerFile) {
+            this.maxRowsPerFile = maxRowsPerFile;
+            return this;
+        }
+
+        public Builder rowType(RowType rowType) {
+            this.rowType = rowType;
+            return this;
+        }
+
+        public LanceSink build() {
+            if (path == null || path.isEmpty()) {
+                throw new IllegalArgumentException("Dataset path must not be empty");
+            }
+
+            if (rowType == null) {
+                throw new IllegalArgumentException("RowType must not be null");
+            }
+
+            LanceOptions options = LanceOptions.builder()
+                    .path(path)
+                    .writeBatchSize(batchSize)
+                    .writeMode(writeMode)
+                    .writeMaxRowsPerFile(maxRowsPerFile)
+                    .build();
+
+            return new LanceSink(options, rowType);
+        }
+    }
+}

--- a/src/main/java/org/apache/flink/connector/lance/sink/LanceSinkWriter.java
+++ b/src/main/java/org/apache/flink/connector/lance/sink/LanceSinkWriter.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,15 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.sink;
-
-import org.apache.flink.api.connector.sink2.SinkWriter;
-import org.apache.flink.connector.lance.config.LanceOptions;
-import org.apache.flink.connector.lance.converter.LanceTypeConverter;
-import org.apache.flink.connector.lance.converter.RowDataConverter;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.logical.RowType;
 
 import com.lancedb.lance.Dataset;
 import com.lancedb.lance.Fragment;
@@ -34,6 +22,12 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.connector.lance.config.LanceOptions;
+import org.apache.flink.connector.lance.converter.LanceTypeConverter;
+import org.apache.flink.connector.lance.converter.RowDataConverter;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,227 +43,219 @@ import java.util.Optional;
 /**
  * Data writer for Lance Sink V2.
  *
- * <p>Receives Flink {@link RowData}, buffers them and writes to Lance Dataset when the batch size is reached.
+ * <p>Receives Flink {@link RowData}, buffers them and writes to Lance Dataset when the batch size
+ * is reached.
  *
  * <p>Main responsibilities:
+ *
  * <ul>
- *   <li>Receive data and buffer</li>
- *   <li>Auto flush when batch size is reached</li>
- *   <li>Convert RowData to Arrow VectorSchemaRoot</li>
- *   <li>Write to Lance Dataset via Fragment.create + FragmentOperation</li>
- *   <li>Support APPEND and OVERWRITE write modes</li>
+ *   <li>Receive data and buffer
+ *   <li>Auto flush when batch size is reached
+ *   <li>Convert RowData to Arrow VectorSchemaRoot
+ *   <li>Write to Lance Dataset via Fragment.create + FragmentOperation
+ *   <li>Support APPEND and OVERWRITE write modes
  * </ul>
  */
 public class LanceSinkWriter implements SinkWriter<RowData> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(LanceSinkWriter.class);
+  private static final Logger LOG = LoggerFactory.getLogger(LanceSinkWriter.class);
 
-    private final LanceOptions options;
-    private final RowType rowType;
+  private final LanceOptions options;
+  private final RowType rowType;
 
-    private transient BufferAllocator allocator;
-    private transient RowDataConverter converter;
-    private transient Schema arrowSchema;
-    private transient List<RowData> buffer;
-    private transient long totalWrittenRows;
-    private transient boolean datasetExists;
-    private transient boolean isFirstWrite;
+  private transient BufferAllocator allocator;
+  private transient RowDataConverter converter;
+  private transient Schema arrowSchema;
+  private transient List<RowData> buffer;
+  private transient long totalWrittenRows;
+  private transient boolean datasetExists;
+  private transient boolean isFirstWrite;
 
-    /**
-     * Create a LanceSinkWriter.
-     *
-     * @param options Lance configuration options
-     * @param rowType Flink RowType
-     */
-    public LanceSinkWriter(LanceOptions options, RowType rowType) {
-        this.options = options;
-        this.rowType = rowType;
+  /**
+   * Create a LanceSinkWriter.
+   *
+   * @param options Lance configuration options
+   * @param rowType Flink RowType
+   */
+  public LanceSinkWriter(LanceOptions options, RowType rowType) {
+    this.options = options;
+    this.rowType = rowType;
 
-        initialize();
+    initialize();
+  }
+
+  /** Initialize writer resources. */
+  private void initialize() {
+    LOG.info("Initializing LanceSinkWriter: {}", options.getPath());
+
+    this.allocator = new RootAllocator(Long.MAX_VALUE);
+    this.buffer = new ArrayList<>(options.getWriteBatchSize());
+    this.totalWrittenRows = 0;
+    this.isFirstWrite = true;
+
+    // Initialize converter and schema
+    this.converter = new RowDataConverter(rowType);
+    this.arrowSchema = LanceTypeConverter.toArrowSchema(rowType);
+
+    // Check dataset path
+    String datasetPath = options.getPath();
+    if (datasetPath == null || datasetPath.isEmpty()) {
+      throw new IllegalArgumentException("Lance dataset path must not be empty");
     }
 
-    /**
-     * Initialize writer resources.
-     */
-    private void initialize() {
-        LOG.info("Initializing LanceSinkWriter: {}", options.getPath());
+    Path path = Paths.get(datasetPath);
+    this.datasetExists = Files.exists(path);
 
-        this.allocator = new RootAllocator(Long.MAX_VALUE);
-        this.buffer = new ArrayList<>(options.getWriteBatchSize());
-        this.totalWrittenRows = 0;
-        this.isFirstWrite = true;
+    // If overwrite mode and dataset already exists, delete it first
+    if (datasetExists && options.getWriteMode() == LanceOptions.WriteMode.OVERWRITE) {
+      LOG.info("Overwrite mode, deleting existing dataset: {}", datasetPath);
+      try {
+        deleteDirectory(path);
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to delete existing dataset: " + datasetPath, e);
+      }
+      this.datasetExists = false;
+    }
 
-        // Initialize converter and schema
-        this.converter = new RowDataConverter(rowType);
-        this.arrowSchema = LanceTypeConverter.toArrowSchema(rowType);
+    LOG.info("LanceSinkWriter initialized, schema: {}", rowType);
+  }
 
-        // Check dataset path
-        String datasetPath = options.getPath();
-        if (datasetPath == null || datasetPath.isEmpty()) {
-            throw new IllegalArgumentException("Lance dataset path must not be empty");
-        }
+  @Override
+  public void write(RowData element, Context context) throws IOException, InterruptedException {
+    buffer.add(element);
 
-        Path path = Paths.get(datasetPath);
-        this.datasetExists = Files.exists(path);
+    // Flush when buffer reaches batch size
+    if (buffer.size() >= options.getWriteBatchSize()) {
+      doFlush();
+    }
+  }
 
-        // If overwrite mode and dataset already exists, delete it first
-        if (datasetExists && options.getWriteMode() == LanceOptions.WriteMode.OVERWRITE) {
-            LOG.info("Overwrite mode, deleting existing dataset: {}", datasetPath);
+  @Override
+  public void flush(boolean endOfInput) throws IOException, InterruptedException {
+    // Flush all buffered data on checkpoint or end of input
+    doFlush();
+
+    if (endOfInput) {
+      LOG.info("End of input, total rows written: {}", totalWrittenRows);
+    }
+  }
+
+  /** Perform the actual flush operation, writing buffered data to Lance Dataset. */
+  private void doFlush() throws IOException {
+    if (buffer.isEmpty()) {
+      return;
+    }
+
+    LOG.debug("Flushing buffer, row count: {}", buffer.size());
+
+    try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
+      // Convert RowData to VectorSchemaRoot
+      converter.toVectorSchemaRoot(buffer, root);
+
+      String datasetPath = options.getPath();
+
+      // Build write params
+      WriteParams writeParams =
+          new WriteParams.Builder().withMaxRowsPerFile(options.getWriteMaxRowsPerFile()).build();
+
+      // Create fragments
+      List<FragmentMetadata> fragments = Fragment.create(datasetPath, allocator, root, writeParams);
+
+      Dataset dataset = null;
+      try {
+        if (!datasetExists) {
+          // Create new dataset
+          FragmentOperation.Overwrite overwrite =
+              new FragmentOperation.Overwrite(fragments, arrowSchema);
+          dataset =
+              overwrite.commit(allocator, datasetPath, Optional.empty(), Collections.emptyMap());
+          datasetExists = true;
+          isFirstWrite = false;
+          LOG.info("Created new dataset: {}", datasetPath);
+        } else {
+          if (isFirstWrite && options.getWriteMode() == LanceOptions.WriteMode.OVERWRITE) {
+            // First write in overwrite mode
+            FragmentOperation.Overwrite overwrite =
+                new FragmentOperation.Overwrite(fragments, arrowSchema);
+            dataset =
+                overwrite.commit(allocator, datasetPath, Optional.empty(), Collections.emptyMap());
+            isFirstWrite = false;
+          } else {
+            // Append mode: need to get the current dataset version
+            Dataset existingDataset = Dataset.open(datasetPath, allocator);
+            long readVersion;
             try {
-                deleteDirectory(path);
-            } catch (IOException e) {
-                throw new RuntimeException("Failed to delete existing dataset: " + datasetPath, e);
-            }
-            this.datasetExists = false;
-        }
-
-        LOG.info("LanceSinkWriter initialized, schema: {}", rowType);
-    }
-
-    @Override
-    public void write(RowData element, Context context) throws IOException, InterruptedException {
-        buffer.add(element);
-
-        // Flush when buffer reaches batch size
-        if (buffer.size() >= options.getWriteBatchSize()) {
-            doFlush();
-        }
-    }
-
-    @Override
-    public void flush(boolean endOfInput) throws IOException, InterruptedException {
-        // Flush all buffered data on checkpoint or end of input
-        doFlush();
-
-        if (endOfInput) {
-            LOG.info("End of input, total rows written: {}", totalWrittenRows);
-        }
-    }
-
-    /**
-     * Perform the actual flush operation, writing buffered data to Lance Dataset.
-     */
-    private void doFlush() throws IOException {
-        if (buffer.isEmpty()) {
-            return;
-        }
-
-        LOG.debug("Flushing buffer, row count: {}", buffer.size());
-
-        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
-            // Convert RowData to VectorSchemaRoot
-            converter.toVectorSchemaRoot(buffer, root);
-
-            String datasetPath = options.getPath();
-
-            // Build write params
-            WriteParams writeParams = new WriteParams.Builder()
-                    .withMaxRowsPerFile(options.getWriteMaxRowsPerFile())
-                    .build();
-
-            // Create fragments
-            List<FragmentMetadata> fragments = Fragment.create(
-                    datasetPath,
-                    allocator,
-                    root,
-                    writeParams
-            );
-
-            Dataset dataset = null;
-            try {
-                if (!datasetExists) {
-                    // Create new dataset
-                    FragmentOperation.Overwrite overwrite = new FragmentOperation.Overwrite(fragments, arrowSchema);
-                    dataset = overwrite.commit(allocator, datasetPath, Optional.empty(), Collections.emptyMap());
-                    datasetExists = true;
-                    isFirstWrite = false;
-                    LOG.info("Created new dataset: {}", datasetPath);
-                } else {
-                    if (isFirstWrite && options.getWriteMode() == LanceOptions.WriteMode.OVERWRITE) {
-                        // First write in overwrite mode
-                        FragmentOperation.Overwrite overwrite = new FragmentOperation.Overwrite(fragments, arrowSchema);
-                        dataset = overwrite.commit(allocator, datasetPath, Optional.empty(), Collections.emptyMap());
-                        isFirstWrite = false;
-                    } else {
-                        // Append mode: need to get the current dataset version
-                        Dataset existingDataset = Dataset.open(datasetPath, allocator);
-                        long readVersion;
-                        try {
-                            readVersion = existingDataset.version();
-                        } finally {
-                            existingDataset.close();
-                        }
-
-                        FragmentOperation.Append append =
-                                new FragmentOperation.Append(fragments);
-                        dataset = append.commit(
-                                allocator, datasetPath,
-                                Optional.of(readVersion),
-                                Collections.emptyMap());
-                    }
-                }
-
-                totalWrittenRows += buffer.size();
-                LOG.debug("Wrote {} rows, total: {} rows", buffer.size(), totalWrittenRows);
-
-                buffer.clear();
+              readVersion = existingDataset.version();
             } finally {
-                if (dataset != null) {
-                    try {
-                        dataset.close();
-                    } catch (Exception e) {
-                    LOG.warn("Failed to close dataset", e);
-                    }
-                }
+              existingDataset.close();
             }
-        } catch (Exception e) {
-            throw new IOException("Failed to write to Lance dataset", e);
-        }
-    }
 
-    @Override
-    public void close() throws Exception {
-        LOG.info("Closing LanceSinkWriter");
-
-        // Flush remaining data
-        try {
-            doFlush();
-        } catch (Exception e) {
-            LOG.warn("Failed to flush data on close", e);
+            FragmentOperation.Append append = new FragmentOperation.Append(fragments);
+            dataset =
+                append.commit(
+                    allocator, datasetPath, Optional.of(readVersion), Collections.emptyMap());
+          }
         }
 
-        if (allocator != null) {
-            try {
-                allocator.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close allocator", e);
-            }
-            allocator = null;
+        totalWrittenRows += buffer.size();
+        LOG.debug("Wrote {} rows, total: {} rows", buffer.size(), totalWrittenRows);
+
+        buffer.clear();
+      } finally {
+        if (dataset != null) {
+          try {
+            dataset.close();
+          } catch (Exception e) {
+            LOG.warn("Failed to close dataset", e);
+          }
         }
+      }
+    } catch (Exception e) {
+      throw new IOException("Failed to write to Lance dataset", e);
+    }
+  }
 
-        LOG.info("LanceSinkWriter closed, total rows written: {}", totalWrittenRows);
+  @Override
+  public void close() throws Exception {
+    LOG.info("Closing LanceSinkWriter");
+
+    // Flush remaining data
+    try {
+      doFlush();
+    } catch (Exception e) {
+      LOG.warn("Failed to flush data on close", e);
     }
 
-    /**
-     * Get total written row count.
-     */
-    public long getTotalWrittenRows() {
-        return totalWrittenRows;
+    if (allocator != null) {
+      try {
+        allocator.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close allocator", e);
+      }
+      allocator = null;
     }
 
-    /**
-     * Recursively delete a directory.
-     */
-    private void deleteDirectory(Path path) throws IOException {
-        if (Files.isDirectory(path)) {
-            Files.list(path).forEach(child -> {
+    LOG.info("LanceSinkWriter closed, total rows written: {}", totalWrittenRows);
+  }
+
+  /** Get total written row count. */
+  public long getTotalWrittenRows() {
+    return totalWrittenRows;
+  }
+
+  /** Recursively delete a directory. */
+  private void deleteDirectory(Path path) throws IOException {
+    if (Files.isDirectory(path)) {
+      Files.list(path)
+          .forEach(
+              child -> {
                 try {
-                    deleteDirectory(child);
+                  deleteDirectory(child);
                 } catch (IOException e) {
-                    LOG.warn("Failed to delete file: {}", child, e);
+                  LOG.warn("Failed to delete file: {}", child, e);
                 }
-            });
-        }
-        Files.deleteIfExists(path);
+              });
     }
+    Files.deleteIfExists(path);
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/sink/LanceSinkWriter.java
+++ b/src/main/java/org/apache/flink/connector/lance/sink/LanceSinkWriter.java
@@ -200,8 +200,12 @@ public class LanceSinkWriter implements SinkWriter<RowData> {
                             existingDataset.close();
                         }
 
-                        FragmentOperation.Append append = new FragmentOperation.Append(fragments);
-                        dataset = append.commit(allocator, datasetPath, Optional.of(readVersion), Collections.emptyMap());
+                        FragmentOperation.Append append =
+                                new FragmentOperation.Append(fragments);
+                        dataset = append.commit(
+                                allocator, datasetPath,
+                                Optional.of(readVersion),
+                                Collections.emptyMap());
                     }
                 }
 

--- a/src/main/java/org/apache/flink/connector/lance/sink/LanceSinkWriter.java
+++ b/src/main/java/org/apache/flink/connector/lance/sink/LanceSinkWriter.java
@@ -104,16 +104,21 @@ public class LanceSinkWriter implements SinkWriter<RowData> {
       throw new IllegalArgumentException("Lance dataset path must not be empty");
     }
 
-    Path path = Paths.get(datasetPath);
-    this.datasetExists = Files.exists(path);
+    // Determine if dataset already exists (supports both local and remote paths)
+    this.datasetExists = checkDatasetExists(datasetPath);
 
-    // If overwrite mode and dataset already exists, delete it first
+    // If overwrite mode and dataset already exists, handle accordingly
     if (datasetExists && options.getWriteMode() == LanceOptions.WriteMode.OVERWRITE) {
-      LOG.info("Overwrite mode, deleting existing dataset: {}", datasetPath);
-      try {
-        deleteDirectory(path);
-      } catch (IOException e) {
-        throw new RuntimeException("Failed to delete existing dataset: " + datasetPath, e);
+      if (!isRemotePath(datasetPath)) {
+        LOG.info("Overwrite mode, deleting existing local dataset: {}", datasetPath);
+        try {
+          deleteDirectory(Paths.get(datasetPath));
+        } catch (IOException e) {
+          throw new RuntimeException("Failed to delete existing dataset: " + datasetPath, e);
+        }
+      } else {
+        LOG.info(
+            "Overwrite mode for remote dataset: {} (will overwrite on first write)", datasetPath);
       }
       this.datasetExists = false;
     }
@@ -242,6 +247,42 @@ public class LanceSinkWriter implements SinkWriter<RowData> {
   /** Get total written row count. */
   public long getTotalWrittenRows() {
     return totalWrittenRows;
+  }
+
+  /**
+   * Check whether a dataset exists at the given path. Supports both local filesystem paths and
+   * remote storage URIs (S3, GCS, etc.).
+   */
+  private boolean checkDatasetExists(String datasetPath) {
+    if (isRemotePath(datasetPath)) {
+      // For remote storage, try to open the dataset to check existence
+      try {
+        Dataset dataset = LanceDatasetFactory.open(datasetPath, allocator);
+        dataset.close();
+        return true;
+      } catch (Exception e) {
+        LOG.debug("Dataset does not exist at remote path: {}", datasetPath);
+        return false;
+      }
+    } else {
+      // Local filesystem check
+      Path path = Paths.get(datasetPath);
+      return Files.exists(path);
+    }
+  }
+
+  /** Detect whether a path is a remote storage URI. */
+  private static boolean isRemotePath(String path) {
+    if (path == null) {
+      return false;
+    }
+    String lower = path.toLowerCase();
+    return lower.startsWith("s3://")
+        || lower.startsWith("s3a://")
+        || lower.startsWith("gs://")
+        || lower.startsWith("az://")
+        || lower.startsWith("https://")
+        || lower.startsWith("http://");
   }
 
   /** Recursively delete a directory. */

--- a/src/main/java/org/apache/flink/connector/lance/sink/LanceSinkWriter.java
+++ b/src/main/java/org/apache/flink/connector/lance/sink/LanceSinkWriter.java
@@ -23,6 +23,7 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.connector.lance.config.LanceDatasetFactory;
 import org.apache.flink.connector.lance.config.LanceOptions;
 import org.apache.flink.connector.lance.converter.LanceTypeConverter;
 import org.apache.flink.connector.lance.converter.RowDataConverter;
@@ -182,7 +183,7 @@ public class LanceSinkWriter implements SinkWriter<RowData> {
             isFirstWrite = false;
           } else {
             // Append mode: need to get the current dataset version
-            Dataset existingDataset = Dataset.open(datasetPath, allocator);
+            Dataset existingDataset = LanceDatasetFactory.open(datasetPath, allocator);
             long readVersion;
             try {
               readVersion = existingDataset.version();

--- a/src/main/java/org/apache/flink/connector/lance/sink/LanceSinkWriter.java
+++ b/src/main/java/org/apache/flink/connector/lance/sink/LanceSinkWriter.java
@@ -16,16 +16,12 @@
  * limitations under the License.
  */
 
-package org.apache.flink.connector.lance;
+package org.apache.flink.connector.lance.sink;
 
-import org.apache.flink.configuration.Configuration;
+import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.connector.lance.config.LanceOptions;
 import org.apache.flink.connector.lance.converter.LanceTypeConverter;
 import org.apache.flink.connector.lance.converter.RowDataConverter;
-import org.apache.flink.runtime.state.FunctionInitializationContext;
-import org.apache.flink.runtime.state.FunctionSnapshotContext;
-import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
-import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 
@@ -51,32 +47,27 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Lance Sink implementation.
- * 
- * <p>Writes Flink RowData to Lance dataset, supports batch writing and Checkpoint.
- * 
- * <p>Usage example:
- * <pre>{@code
- * LanceOptions options = LanceOptions.builder()
- *     .path("/path/to/lance/dataset")
- *     .writeBatchSize(1024)
- *     .writeMode(WriteMode.APPEND)
- *     .build();
- * 
- * LanceSink sink = new LanceSink(options, rowType);
- * dataStream.addSink(sink);
- * }</pre>
+ * Data writer for Lance Sink V2.
+ *
+ * <p>Receives Flink {@link RowData}, buffers them and writes to Lance Dataset when the batch size is reached.
+ *
+ * <p>Main responsibilities:
+ * <ul>
+ *   <li>Receive data and buffer</li>
+ *   <li>Auto flush when batch size is reached</li>
+ *   <li>Convert RowData to Arrow VectorSchemaRoot</li>
+ *   <li>Write to Lance Dataset via Fragment.create + FragmentOperation</li>
+ *   <li>Support APPEND and OVERWRITE write modes</li>
+ * </ul>
  */
-public class LanceSink extends RichSinkFunction<RowData> implements CheckpointedFunction {
+public class LanceSinkWriter implements SinkWriter<RowData> {
 
-    private static final long serialVersionUID = 1L;
-    private static final Logger LOG = LoggerFactory.getLogger(LanceSink.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LanceSinkWriter.class);
 
     private final LanceOptions options;
     private final RowType rowType;
 
     private transient BufferAllocator allocator;
-    private transient Dataset dataset;
     private transient RowDataConverter converter;
     private transient Schema arrowSchema;
     private transient List<RowData> buffer;
@@ -85,105 +76,122 @@ public class LanceSink extends RichSinkFunction<RowData> implements Checkpointed
     private transient boolean isFirstWrite;
 
     /**
-     * Create LanceSink
+     * Create a LanceSinkWriter.
      *
      * @param options Lance configuration options
      * @param rowType Flink RowType
      */
-    public LanceSink(LanceOptions options, RowType rowType) {
+    public LanceSinkWriter(LanceOptions options, RowType rowType) {
         this.options = options;
         this.rowType = rowType;
+
+        initialize();
     }
 
-    @Override
-    public void open(Configuration parameters) throws Exception {
-        super.open(parameters);
-        
-        LOG.info("Opening Lance Sink: {}", options.getPath());
-        
+    /**
+     * Initialize writer resources.
+     */
+    private void initialize() {
+        LOG.info("Initializing LanceSinkWriter: {}", options.getPath());
+
         this.allocator = new RootAllocator(Long.MAX_VALUE);
         this.buffer = new ArrayList<>(options.getWriteBatchSize());
         this.totalWrittenRows = 0;
         this.isFirstWrite = true;
-        
-        // Initialize converter and Schema
+
+        // Initialize converter and schema
         this.converter = new RowDataConverter(rowType);
         this.arrowSchema = LanceTypeConverter.toArrowSchema(rowType);
-        
-        // Check if dataset exists
+
+        // Check dataset path
         String datasetPath = options.getPath();
         if (datasetPath == null || datasetPath.isEmpty()) {
-            throw new IllegalArgumentException("Lance dataset path cannot be empty");
+            throw new IllegalArgumentException("Lance dataset path must not be empty");
         }
-        
+
         Path path = Paths.get(datasetPath);
         this.datasetExists = Files.exists(path);
-        
-        // If overwrite mode and dataset exists, delete first
+
+        // If overwrite mode and dataset already exists, delete it first
         if (datasetExists && options.getWriteMode() == LanceOptions.WriteMode.OVERWRITE) {
             LOG.info("Overwrite mode, deleting existing dataset: {}", datasetPath);
-            deleteDirectory(path);
+            try {
+                deleteDirectory(path);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to delete existing dataset: " + datasetPath, e);
+            }
             this.datasetExists = false;
         }
-        
-        LOG.info("Lance Sink opened, Schema: {}", rowType);
+
+        LOG.info("LanceSinkWriter initialized, schema: {}", rowType);
     }
 
     @Override
-    public void invoke(RowData value, Context context) throws Exception {
-        buffer.add(value);
-        
-        // When buffer reaches batch size, execute write
+    public void write(RowData element, Context context) throws IOException, InterruptedException {
+        buffer.add(element);
+
+        // Flush when buffer reaches batch size
         if (buffer.size() >= options.getWriteBatchSize()) {
-            flush();
+            doFlush();
+        }
+    }
+
+    @Override
+    public void flush(boolean endOfInput) throws IOException, InterruptedException {
+        // Flush all buffered data on checkpoint or end of input
+        doFlush();
+
+        if (endOfInput) {
+            LOG.info("End of input, total rows written: {}", totalWrittenRows);
         }
     }
 
     /**
-     * Flush buffer, write data to Lance dataset
+     * Perform the actual flush operation, writing buffered data to Lance Dataset.
      */
-    public void flush() throws IOException {
+    private void doFlush() throws IOException {
         if (buffer.isEmpty()) {
             return;
         }
-        
+
         LOG.debug("Flushing buffer, row count: {}", buffer.size());
-        
+
         try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator)) {
             // Convert RowData to VectorSchemaRoot
             converter.toVectorSchemaRoot(buffer, root);
-            
+
             String datasetPath = options.getPath();
-            
-            // Build write parameters
+
+            // Build write params
             WriteParams writeParams = new WriteParams.Builder()
                     .withMaxRowsPerFile(options.getWriteMaxRowsPerFile())
                     .build();
-            
-            // Create Fragment
+
+            // Create fragments
             List<FragmentMetadata> fragments = Fragment.create(
                     datasetPath,
                     allocator,
                     root,
                     writeParams
             );
-            
-            if (!datasetExists) {
-                // Create new dataset (using Overwrite operation)
-                FragmentOperation.Overwrite overwrite = new FragmentOperation.Overwrite(fragments, arrowSchema);
-                dataset = overwrite.commit(allocator, datasetPath, Optional.empty(), Collections.emptyMap());
-                datasetExists = true;
-                isFirstWrite = false;
-                LOG.info("Created new dataset: {}", datasetPath);
+
+            Dataset dataset = null;
+            try {
+                if (!datasetExists) {
+                    // Create new dataset
+                    FragmentOperation.Overwrite overwrite = new FragmentOperation.Overwrite(fragments, arrowSchema);
+                    dataset = overwrite.commit(allocator, datasetPath, Optional.empty(), Collections.emptyMap());
+                    datasetExists = true;
+                    isFirstWrite = false;
+                    LOG.info("Created new dataset: {}", datasetPath);
                 } else {
-                    // Append data
                     if (isFirstWrite && options.getWriteMode() == LanceOptions.WriteMode.OVERWRITE) {
-                        // First write and overwrite mode
+                        // First write in overwrite mode
                         FragmentOperation.Overwrite overwrite = new FragmentOperation.Overwrite(fragments, arrowSchema);
                         dataset = overwrite.commit(allocator, datasetPath, Optional.empty(), Collections.emptyMap());
                         isFirstWrite = false;
                     } else {
-                        // Append mode: need to get current dataset version
+                        // Append mode: need to get the current dataset version
                         Dataset existingDataset = Dataset.open(datasetPath, allocator);
                         long readVersion;
                         try {
@@ -196,34 +204,36 @@ public class LanceSink extends RichSinkFunction<RowData> implements Checkpointed
                         dataset = append.commit(allocator, datasetPath, Optional.of(readVersion), Collections.emptyMap());
                     }
                 }
-            
-            totalWrittenRows += buffer.size();
-            LOG.debug("Written {} rows, total: {} rows", buffer.size(), totalWrittenRows);
-            
-            buffer.clear();
+
+                totalWrittenRows += buffer.size();
+                LOG.debug("Wrote {} rows, total: {} rows", buffer.size(), totalWrittenRows);
+
+                buffer.clear();
+            } finally {
+                if (dataset != null) {
+                    try {
+                        dataset.close();
+                    } catch (Exception e) {
+                    LOG.warn("Failed to close dataset", e);
+                    }
+                }
+            }
         } catch (Exception e) {
-            throw new IOException("Failed to write Lance dataset", e);
+            throw new IOException("Failed to write to Lance dataset", e);
         }
     }
 
     @Override
     public void close() throws Exception {
-        LOG.info("Closing Lance Sink");
+        LOG.info("Closing LanceSinkWriter");
+
         // Flush remaining data
         try {
-            flush();
+            doFlush();
         } catch (Exception e) {
             LOG.warn("Failed to flush data on close", e);
         }
-        if (dataset != null) {
-            try {
-                dataset.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close dataset", e);
-            }
-            dataset = null;
-        }
-        
+
         if (allocator != null) {
             try {
                 allocator.close();
@@ -232,49 +242,19 @@ public class LanceSink extends RichSinkFunction<RowData> implements Checkpointed
             }
             allocator = null;
         }
-        
-        LOG.info("Lance Sink closed, total written {} rows", totalWrittenRows);
-        
-        super.close();
-    }
 
-    @Override
-    public void snapshotState(FunctionSnapshotContext context) throws Exception {
-        LOG.debug("Snapshot state, checkpointId: {}", context.getCheckpointId());
-        
-        // Flush all buffered data at Checkpoint
-        flush();
-    }
-
-    @Override
-    public void initializeState(FunctionInitializationContext context) throws Exception {
-        LOG.debug("Initialize state, isRestored: {}", context.isRestored());
-        // State initialization (if recovery needed)
+        LOG.info("LanceSinkWriter closed, total rows written: {}", totalWrittenRows);
     }
 
     /**
-     * Get RowType
-     */
-    public RowType getRowType() {
-        return rowType;
-    }
-
-    /**
-     * Get configuration options
-     */
-    public LanceOptions getOptions() {
-        return options;
-    }
-
-    /**
-     * Get total written row count
+     * Get total written row count.
      */
     public long getTotalWrittenRows() {
         return totalWrittenRows;
     }
 
     /**
-     * Recursively delete directory
+     * Recursively delete a directory.
      */
     private void deleteDirectory(Path path) throws IOException {
         if (Files.isDirectory(path)) {
@@ -287,67 +267,5 @@ public class LanceSink extends RichSinkFunction<RowData> implements Checkpointed
             });
         }
         Files.deleteIfExists(path);
-    }
-
-    /**
-     * Builder pattern constructor
-     */
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    /**
-     * LanceSink Builder
-     */
-    public static class Builder {
-        private String path;
-        private int batchSize = 1024;
-        private LanceOptions.WriteMode writeMode = LanceOptions.WriteMode.APPEND;
-        private int maxRowsPerFile = 1000000;
-        private RowType rowType;
-
-        public Builder path(String path) {
-            this.path = path;
-            return this;
-        }
-
-        public Builder batchSize(int batchSize) {
-            this.batchSize = batchSize;
-            return this;
-        }
-
-        public Builder writeMode(LanceOptions.WriteMode writeMode) {
-            this.writeMode = writeMode;
-            return this;
-        }
-
-        public Builder maxRowsPerFile(int maxRowsPerFile) {
-            this.maxRowsPerFile = maxRowsPerFile;
-            return this;
-        }
-
-        public Builder rowType(RowType rowType) {
-            this.rowType = rowType;
-            return this;
-        }
-
-        public LanceSink build() {
-            if (path == null || path.isEmpty()) {
-                throw new IllegalArgumentException("Dataset path cannot be empty");
-            }
-            
-            if (rowType == null) {
-                throw new IllegalArgumentException("RowType cannot be null");
-            }
-
-            LanceOptions options = LanceOptions.builder()
-                    .path(path)
-                    .writeBatchSize(batchSize)
-                    .writeMode(writeMode)
-                    .writeMaxRowsPerFile(maxRowsPerFile)
-                    .build();
-
-            return new LanceSink(options, rowType);
-        }
     }
 }

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceEnumeratorState.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceEnumeratorState.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.source;
 
 import java.io.Serializable;
@@ -31,33 +26,31 @@ import java.util.List;
  */
 public class LanceEnumeratorState implements Serializable {
 
-    private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-    /** List of unassigned Splits */
-    private final List<LanceSourceSplit> pendingSplits;
+  /** List of unassigned Splits */
+  private final List<LanceSourceSplit> pendingSplits;
 
-    /**
-     * Create a LanceEnumeratorState.
-     *
-     * @param pendingSplits List of unassigned Splits
-     */
-    public LanceEnumeratorState(Collection<LanceSourceSplit> pendingSplits) {
-        this.pendingSplits = Collections.unmodifiableList(new ArrayList<>(pendingSplits));
-    }
+  /**
+   * Create a LanceEnumeratorState.
+   *
+   * @param pendingSplits List of unassigned Splits
+   */
+  public LanceEnumeratorState(Collection<LanceSourceSplit> pendingSplits) {
+    this.pendingSplits = Collections.unmodifiableList(new ArrayList<>(pendingSplits));
+  }
 
-    /**
-     * Get the list of unassigned Splits.
-     *
-     * @return Immutable list of Splits
-     */
-    public List<LanceSourceSplit> getPendingSplits() {
-        return pendingSplits;
-    }
+  /**
+   * Get the list of unassigned Splits.
+   *
+   * @return Immutable list of Splits
+   */
+  public List<LanceSourceSplit> getPendingSplits() {
+    return pendingSplits;
+  }
 
-    @Override
-    public String toString() {
-        return "LanceEnumeratorState{"
-                + "pendingSplits=" + pendingSplits.size()
-                + '}';
-    }
+  @Override
+  public String toString() {
+    return "LanceEnumeratorState{" + "pendingSplits=" + pendingSplits.size() + '}';
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceEnumeratorState.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceEnumeratorState.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.lance.source;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Checkpoint state for {@link LanceSplitEnumerator}.
+ *
+ * <p>Stores unassigned Splits, used for reassignment when recovering from a checkpoint.
+ */
+public class LanceEnumeratorState implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** List of unassigned Splits */
+    private final List<LanceSourceSplit> pendingSplits;
+
+    /**
+     * Create a LanceEnumeratorState.
+     *
+     * @param pendingSplits List of unassigned Splits
+     */
+    public LanceEnumeratorState(Collection<LanceSourceSplit> pendingSplits) {
+        this.pendingSplits = Collections.unmodifiableList(new ArrayList<>(pendingSplits));
+    }
+
+    /**
+     * Get the list of unassigned Splits.
+     *
+     * @return Immutable list of Splits
+     */
+    public List<LanceSourceSplit> getPendingSplits() {
+        return pendingSplits;
+    }
+
+    @Override
+    public String toString() {
+        return "LanceEnumeratorState{"
+                + "pendingSplits=" + pendingSplits.size()
+                + '}';
+    }
+}

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceEnumeratorStateSerializer.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceEnumeratorStateSerializer.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.lance.source;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Serializer for {@link LanceEnumeratorState}.
+ *
+ * <p>Used for serializing/deserializing Enumerator state during checkpoint and recovery.
+ */
+public class LanceEnumeratorStateSerializer implements SimpleVersionedSerializer<LanceEnumeratorState> {
+
+    public static final LanceEnumeratorStateSerializer INSTANCE = new LanceEnumeratorStateSerializer();
+
+    private static final int CURRENT_VERSION = 1;
+
+    private LanceEnumeratorStateSerializer() {
+    }
+
+    @Override
+    public int getVersion() {
+        return CURRENT_VERSION;
+    }
+
+    @Override
+    public byte[] serialize(LanceEnumeratorState state) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(baos);
+
+        List<LanceSourceSplit> pendingSplits = state.getPendingSplits();
+        out.writeInt(pendingSplits.size());
+
+        for (LanceSourceSplit split : pendingSplits) {
+            byte[] splitBytes = LanceSourceSplitSerializer.INSTANCE.serialize(split);
+            out.writeInt(splitBytes.length);
+            out.write(splitBytes);
+        }
+
+        out.flush();
+        return baos.toByteArray();
+    }
+
+    @Override
+    public LanceEnumeratorState deserialize(int version, byte[] serialized) throws IOException {
+        if (version != CURRENT_VERSION) {
+            throw new IOException("Unsupported serialization version: " + version + ", current version: " + CURRENT_VERSION);
+        }
+
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(serialized));
+
+        int splitCount = in.readInt();
+        List<LanceSourceSplit> pendingSplits = new ArrayList<>(splitCount);
+
+        for (int i = 0; i < splitCount; i++) {
+            int splitBytesLen = in.readInt();
+            byte[] splitBytes = new byte[splitBytesLen];
+            in.readFully(splitBytes);
+            LanceSourceSplit split = LanceSourceSplitSerializer.INSTANCE.deserialize(
+                    LanceSourceSplitSerializer.INSTANCE.getVersion(), splitBytes);
+            pendingSplits.add(split);
+        }
+
+        return new LanceEnumeratorState(pendingSplits);
+    }
+}

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceEnumeratorStateSerializer.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceEnumeratorStateSerializer.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.source;
 
 import org.apache.flink.core.io.SimpleVersionedSerializer;
@@ -33,60 +28,64 @@ import java.util.List;
  *
  * <p>Used for serializing/deserializing Enumerator state during checkpoint and recovery.
  */
-public class LanceEnumeratorStateSerializer implements SimpleVersionedSerializer<LanceEnumeratorState> {
+public class LanceEnumeratorStateSerializer
+    implements SimpleVersionedSerializer<LanceEnumeratorState> {
 
-    public static final LanceEnumeratorStateSerializer INSTANCE = new LanceEnumeratorStateSerializer();
+  public static final LanceEnumeratorStateSerializer INSTANCE =
+      new LanceEnumeratorStateSerializer();
 
-    private static final int CURRENT_VERSION = 1;
+  private static final int CURRENT_VERSION = 1;
 
-    private LanceEnumeratorStateSerializer() {
+  private LanceEnumeratorStateSerializer() {}
+
+  @Override
+  public int getVersion() {
+    return CURRENT_VERSION;
+  }
+
+  @Override
+  public byte[] serialize(LanceEnumeratorState state) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream out = new DataOutputStream(baos);
+
+    List<LanceSourceSplit> pendingSplits = state.getPendingSplits();
+    out.writeInt(pendingSplits.size());
+
+    for (LanceSourceSplit split : pendingSplits) {
+      byte[] splitBytes = LanceSourceSplitSerializer.INSTANCE.serialize(split);
+      out.writeInt(splitBytes.length);
+      out.write(splitBytes);
     }
 
-    @Override
-    public int getVersion() {
-        return CURRENT_VERSION;
+    out.flush();
+    return baos.toByteArray();
+  }
+
+  @Override
+  public LanceEnumeratorState deserialize(int version, byte[] serialized) throws IOException {
+    if (version != CURRENT_VERSION) {
+      throw new IOException(
+          "Unsupported serialization version: "
+              + version
+              + ", current version: "
+              + CURRENT_VERSION);
     }
 
-    @Override
-    public byte[] serialize(LanceEnumeratorState state) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        DataOutputStream out = new DataOutputStream(baos);
+    DataInputStream in = new DataInputStream(new ByteArrayInputStream(serialized));
 
-        List<LanceSourceSplit> pendingSplits = state.getPendingSplits();
-        out.writeInt(pendingSplits.size());
+    int splitCount = in.readInt();
+    List<LanceSourceSplit> pendingSplits = new ArrayList<>(splitCount);
 
-        for (LanceSourceSplit split : pendingSplits) {
-            byte[] splitBytes = LanceSourceSplitSerializer.INSTANCE.serialize(split);
-            out.writeInt(splitBytes.length);
-            out.write(splitBytes);
-        }
-
-        out.flush();
-        return baos.toByteArray();
+    for (int i = 0; i < splitCount; i++) {
+      int splitBytesLen = in.readInt();
+      byte[] splitBytes = new byte[splitBytesLen];
+      in.readFully(splitBytes);
+      LanceSourceSplit split =
+          LanceSourceSplitSerializer.INSTANCE.deserialize(
+              LanceSourceSplitSerializer.INSTANCE.getVersion(), splitBytes);
+      pendingSplits.add(split);
     }
 
-    @Override
-    public LanceEnumeratorState deserialize(int version, byte[] serialized) throws IOException {
-        if (version != CURRENT_VERSION) {
-            throw new IOException(
-                    "Unsupported serialization version: " + version
-                            + ", current version: " + CURRENT_VERSION);
-        }
-
-        DataInputStream in = new DataInputStream(new ByteArrayInputStream(serialized));
-
-        int splitCount = in.readInt();
-        List<LanceSourceSplit> pendingSplits = new ArrayList<>(splitCount);
-
-        for (int i = 0; i < splitCount; i++) {
-            int splitBytesLen = in.readInt();
-            byte[] splitBytes = new byte[splitBytesLen];
-            in.readFully(splitBytes);
-            LanceSourceSplit split = LanceSourceSplitSerializer.INSTANCE.deserialize(
-                    LanceSourceSplitSerializer.INSTANCE.getVersion(), splitBytes);
-            pendingSplits.add(split);
-        }
-
-        return new LanceEnumeratorState(pendingSplits);
-    }
+    return new LanceEnumeratorState(pendingSplits);
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceEnumeratorStateSerializer.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceEnumeratorStateSerializer.java
@@ -68,7 +68,9 @@ public class LanceEnumeratorStateSerializer implements SimpleVersionedSerializer
     @Override
     public LanceEnumeratorState deserialize(int version, byte[] serialized) throws IOException {
         if (version != CURRENT_VERSION) {
-            throw new IOException("Unsupported serialization version: " + version + ", current version: " + CURRENT_VERSION);
+            throw new IOException(
+                    "Unsupported serialization version: " + version
+                            + ", current version: " + CURRENT_VERSION);
         }
 
         DataInputStream in = new DataInputStream(new ByteArrayInputStream(serialized));

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceSource.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceSource.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.source;
 
 import org.apache.flink.api.connector.source.Boundedness;
@@ -36,12 +31,13 @@ import java.util.List;
 /**
  * Lance Source V2 implementation (based on FLIP-27).
  *
- * <p>Top-level entry point for Flink Source V2 API, coordinates the creation of
- * {@link LanceSplitEnumerator} (split coordinator) and {@link LanceSourceReader} (data reader).
+ * <p>Top-level entry point for Flink Source V2 API, coordinates the creation of {@link
+ * LanceSplitEnumerator} (split coordinator) and {@link LanceSourceReader} (data reader).
  *
  * <p>Lance Dataset is a bounded data source, so it only supports batch mode.
  *
  * <p>Usage example:
+ *
  * <pre>{@code
  * LanceOptions options = LanceOptions.builder()
  *     .path("/path/to/lance/dataset")
@@ -55,142 +51,135 @@ import java.util.List;
  */
 public class LanceSource implements Source<RowData, LanceSourceSplit, LanceEnumeratorState> {
 
-    private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-    private final LanceOptions options;
-    private final RowType rowType;
+  private final LanceOptions options;
+  private final RowType rowType;
 
-    /**
-     * Create a LanceSource.
-     *
-     * @param options Lance configuration options
-     * @param rowType Flink RowType (nullable, auto-inferred from Dataset Schema)
-     */
-    public LanceSource(LanceOptions options, @Nullable RowType rowType) {
-        this.options = options;
-        this.rowType = rowType;
+  /**
+   * Create a LanceSource.
+   *
+   * @param options Lance configuration options
+   * @param rowType Flink RowType (nullable, auto-inferred from Dataset Schema)
+   */
+  public LanceSource(LanceOptions options, @Nullable RowType rowType) {
+    this.options = options;
+    this.rowType = rowType;
+  }
+
+  /**
+   * Create a LanceSource (auto-infer schema).
+   *
+   * @param options Lance configuration options
+   */
+  public LanceSource(LanceOptions options) {
+    this(options, null);
+  }
+
+  @Override
+  public Boundedness getBoundedness() {
+    // Lance Dataset is a bounded data source
+    return Boundedness.BOUNDED;
+  }
+
+  @Override
+  public SplitEnumerator<LanceSourceSplit, LanceEnumeratorState> createEnumerator(
+      SplitEnumeratorContext<LanceSourceSplit> enumContext) throws Exception {
+    return new LanceSplitEnumerator(enumContext, options);
+  }
+
+  @Override
+  public SplitEnumerator<LanceSourceSplit, LanceEnumeratorState> restoreEnumerator(
+      SplitEnumeratorContext<LanceSourceSplit> enumContext, LanceEnumeratorState checkpoint)
+      throws Exception {
+    return new LanceSplitEnumerator(enumContext, options, checkpoint.getPendingSplits());
+  }
+
+  @Override
+  public SimpleVersionedSerializer<LanceSourceSplit> getSplitSerializer() {
+    return LanceSourceSplitSerializer.INSTANCE;
+  }
+
+  @Override
+  public SimpleVersionedSerializer<LanceEnumeratorState> getEnumeratorCheckpointSerializer() {
+    return LanceEnumeratorStateSerializer.INSTANCE;
+  }
+
+  @Override
+  public SourceReader<RowData, LanceSourceSplit> createReader(SourceReaderContext readerContext)
+      throws Exception {
+    return new LanceSourceReader(readerContext, options, rowType);
+  }
+
+  /** Get RowType. */
+  public RowType getRowType() {
+    return rowType;
+  }
+
+  /** Get configuration options. */
+  public LanceOptions getOptions() {
+    return options;
+  }
+
+  /** Builder pattern constructor. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** LanceSource Builder */
+  public static class Builder {
+    private String path;
+    private int batchSize = 1024;
+    private List<String> columns;
+    private String filter;
+    private Long limit;
+    private RowType rowType;
+
+    public Builder path(String path) {
+      this.path = path;
+      return this;
     }
 
-    /**
-     * Create a LanceSource (auto-infer schema).
-     *
-     * @param options Lance configuration options
-     */
-    public LanceSource(LanceOptions options) {
-        this(options, null);
+    public Builder batchSize(int batchSize) {
+      this.batchSize = batchSize;
+      return this;
     }
 
-    @Override
-    public Boundedness getBoundedness() {
-        // Lance Dataset is a bounded data source
-        return Boundedness.BOUNDED;
+    public Builder columns(List<String> columns) {
+      this.columns = columns;
+      return this;
     }
 
-    @Override
-    public SplitEnumerator<LanceSourceSplit, LanceEnumeratorState> createEnumerator(
-            SplitEnumeratorContext<LanceSourceSplit> enumContext) throws Exception {
-        return new LanceSplitEnumerator(enumContext, options);
+    public Builder filter(String filter) {
+      this.filter = filter;
+      return this;
     }
 
-    @Override
-    public SplitEnumerator<LanceSourceSplit, LanceEnumeratorState> restoreEnumerator(
-            SplitEnumeratorContext<LanceSourceSplit> enumContext,
-            LanceEnumeratorState checkpoint) throws Exception {
-        return new LanceSplitEnumerator(enumContext, options, checkpoint.getPendingSplits());
+    public Builder limit(Long limit) {
+      this.limit = limit;
+      return this;
     }
 
-    @Override
-    public SimpleVersionedSerializer<LanceSourceSplit> getSplitSerializer() {
-        return LanceSourceSplitSerializer.INSTANCE;
+    public Builder rowType(RowType rowType) {
+      this.rowType = rowType;
+      return this;
     }
 
-    @Override
-    public SimpleVersionedSerializer<LanceEnumeratorState> getEnumeratorCheckpointSerializer() {
-        return LanceEnumeratorStateSerializer.INSTANCE;
+    public LanceSource build() {
+      if (path == null || path.isEmpty()) {
+        throw new IllegalArgumentException("Dataset path must not be empty");
+      }
+
+      LanceOptions options =
+          LanceOptions.builder()
+              .path(path)
+              .readBatchSize(batchSize)
+              .readColumns(columns)
+              .readFilter(filter)
+              .readLimit(limit)
+              .build();
+
+      return new LanceSource(options, rowType);
     }
-
-    @Override
-    public SourceReader<RowData, LanceSourceSplit> createReader(
-            SourceReaderContext readerContext) throws Exception {
-        return new LanceSourceReader(readerContext, options, rowType);
-    }
-
-    /**
-     * Get RowType.
-     */
-    public RowType getRowType() {
-        return rowType;
-    }
-
-    /**
-     * Get configuration options.
-     */
-    public LanceOptions getOptions() {
-        return options;
-    }
-
-    /**
-     * Builder pattern constructor.
-     */
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    /**
-     * LanceSource Builder
-     */
-    public static class Builder {
-        private String path;
-        private int batchSize = 1024;
-        private List<String> columns;
-        private String filter;
-        private Long limit;
-        private RowType rowType;
-
-        public Builder path(String path) {
-            this.path = path;
-            return this;
-        }
-
-        public Builder batchSize(int batchSize) {
-            this.batchSize = batchSize;
-            return this;
-        }
-
-        public Builder columns(List<String> columns) {
-            this.columns = columns;
-            return this;
-        }
-
-        public Builder filter(String filter) {
-            this.filter = filter;
-            return this;
-        }
-
-        public Builder limit(Long limit) {
-            this.limit = limit;
-            return this;
-        }
-
-        public Builder rowType(RowType rowType) {
-            this.rowType = rowType;
-            return this;
-        }
-
-        public LanceSource build() {
-            if (path == null || path.isEmpty()) {
-                throw new IllegalArgumentException("Dataset path must not be empty");
-            }
-
-            LanceOptions options = LanceOptions.builder()
-                    .path(path)
-                    .readBatchSize(batchSize)
-                    .readColumns(columns)
-                    .readFilter(filter)
-                    .readLimit(limit)
-                    .build();
-
-            return new LanceSource(options, rowType);
-        }
-    }
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceSource.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceSource.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.connector.lance.source;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.connector.source.SourceReader;

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceSource.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceSource.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.lance.source;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.connector.lance.config.LanceOptions;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+
+/**
+ * Lance Source V2 implementation (based on FLIP-27).
+ *
+ * <p>Top-level entry point for Flink Source V2 API, coordinates the creation of
+ * {@link LanceSplitEnumerator} (split coordinator) and {@link LanceSourceReader} (data reader).
+ *
+ * <p>Lance Dataset is a bounded data source, so it only supports batch mode.
+ *
+ * <p>Usage example:
+ * <pre>{@code
+ * LanceOptions options = LanceOptions.builder()
+ *     .path("/path/to/lance/dataset")
+ *     .readBatchSize(1024)
+ *     .readLimit(100L)
+ *     .build();
+ *
+ * LanceSource source = new LanceSource(options, rowType);
+ * DataStream<RowData> stream = env.fromSource(source, WatermarkStrategy.noWatermarks(), "lance-source");
+ * }</pre>
+ */
+public class LanceSource implements Source<RowData, LanceSourceSplit, LanceEnumeratorState> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final LanceOptions options;
+    private final RowType rowType;
+
+    /**
+     * Create a LanceSource.
+     *
+     * @param options Lance configuration options
+     * @param rowType Flink RowType (nullable, auto-inferred from Dataset Schema)
+     */
+    public LanceSource(LanceOptions options, @Nullable RowType rowType) {
+        this.options = options;
+        this.rowType = rowType;
+    }
+
+    /**
+     * Create a LanceSource (auto-infer schema).
+     *
+     * @param options Lance configuration options
+     */
+    public LanceSource(LanceOptions options) {
+        this(options, null);
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        // Lance Dataset is a bounded data source
+        return Boundedness.BOUNDED;
+    }
+
+    @Override
+    public SplitEnumerator<LanceSourceSplit, LanceEnumeratorState> createEnumerator(
+            SplitEnumeratorContext<LanceSourceSplit> enumContext) throws Exception {
+        return new LanceSplitEnumerator(enumContext, options);
+    }
+
+    @Override
+    public SplitEnumerator<LanceSourceSplit, LanceEnumeratorState> restoreEnumerator(
+            SplitEnumeratorContext<LanceSourceSplit> enumContext,
+            LanceEnumeratorState checkpoint) throws Exception {
+        return new LanceSplitEnumerator(enumContext, options, checkpoint.getPendingSplits());
+    }
+
+    @Override
+    public SimpleVersionedSerializer<LanceSourceSplit> getSplitSerializer() {
+        return LanceSourceSplitSerializer.INSTANCE;
+    }
+
+    @Override
+    public SimpleVersionedSerializer<LanceEnumeratorState> getEnumeratorCheckpointSerializer() {
+        return LanceEnumeratorStateSerializer.INSTANCE;
+    }
+
+    @Override
+    public SourceReader<RowData, LanceSourceSplit> createReader(
+            SourceReaderContext readerContext) throws Exception {
+        return new LanceSourceReader(readerContext, options, rowType);
+    }
+
+    /**
+     * Get RowType.
+     */
+    public RowType getRowType() {
+        return rowType;
+    }
+
+    /**
+     * Get configuration options.
+     */
+    public LanceOptions getOptions() {
+        return options;
+    }
+
+    /**
+     * Builder pattern constructor.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * LanceSource Builder
+     */
+    public static class Builder {
+        private String path;
+        private int batchSize = 1024;
+        private List<String> columns;
+        private String filter;
+        private Long limit;
+        private RowType rowType;
+
+        public Builder path(String path) {
+            this.path = path;
+            return this;
+        }
+
+        public Builder batchSize(int batchSize) {
+            this.batchSize = batchSize;
+            return this;
+        }
+
+        public Builder columns(List<String> columns) {
+            this.columns = columns;
+            return this;
+        }
+
+        public Builder filter(String filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        public Builder limit(Long limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        public Builder rowType(RowType rowType) {
+            this.rowType = rowType;
+            return this;
+        }
+
+        public LanceSource build() {
+            if (path == null || path.isEmpty()) {
+                throw new IllegalArgumentException("Dataset path must not be empty");
+            }
+
+            LanceOptions options = LanceOptions.builder()
+                    .path(path)
+                    .readBatchSize(batchSize)
+                    .readColumns(columns)
+                    .readFilter(filter)
+                    .readLimit(limit)
+                    .build();
+
+            return new LanceSource(options, rowType);
+        }
+    }
+}

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceSourceReader.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceSourceReader.java
@@ -1,0 +1,357 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.lance.source;
+
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.connector.lance.config.LanceOptions;
+import org.apache.flink.connector.lance.converter.LanceTypeConverter;
+import org.apache.flink.connector.lance.converter.RowDataConverter;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+import com.lancedb.lance.Dataset;
+import com.lancedb.lance.Fragment;
+import com.lancedb.lance.ipc.LanceScanner;
+import com.lancedb.lance.ipc.ScanOptions;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Data reader for Lance Source.
+ *
+ * <p>Reads data from assigned {@link LanceSourceSplit}s and converts Arrow data to Flink {@link RowData}.
+ * Similar to the PageSource role in Trino.
+ *
+ * <p>Main responsibilities:
+ * <ul>
+ *   <li>Receive Splits assigned by SplitEnumerator</li>
+ *   <li>Open Fragment Scanner to read data</li>
+ *   <li>Convert Arrow data to RowData</li>
+ *   <li>Support column pruning, filter push-down and limit push-down</li>
+ * </ul>
+ */
+public class LanceSourceReader implements SourceReader<RowData, LanceSourceSplit> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LanceSourceReader.class);
+
+    private final SourceReaderContext readerContext;
+    private final LanceOptions options;
+    private final RowType rowType;
+    private final String[] selectedColumns;
+    private final Long readLimit;
+
+    /** Queue of pending Splits to process */
+    private final Queue<LanceSourceSplit> pendingSplits;
+
+    /** Current reading resources */
+    private transient BufferAllocator allocator;
+    private transient Dataset currentDataset;
+    private transient LanceScanner currentScanner;
+    private transient ArrowReader currentReader;
+    private transient Iterator<RowData> currentBatchIterator;
+    private transient RowDataConverter converter;
+    private transient LanceSourceSplit currentSplit;
+
+    /** Whether there are no more Splits */
+    private boolean noMoreSplits;
+
+    /** Number of emitted rows (for Limit) */
+    private long emittedCount;
+
+    /** Future for available data notification */
+    private CompletableFuture<Void> availableFuture;
+
+    /**
+     * Create a LanceSourceReader.
+     *
+     * @param readerContext Reader context
+     * @param options       Lance configuration
+     * @param rowType       Row type (nullable, auto-inferred)
+     */
+    public LanceSourceReader(
+            SourceReaderContext readerContext,
+            LanceOptions options,
+            @Nullable RowType rowType) {
+        this.readerContext = readerContext;
+        this.options = options;
+        this.rowType = rowType;
+        this.pendingSplits = new ArrayDeque<>();
+        this.noMoreSplits = false;
+        this.emittedCount = 0;
+
+        List<String> columns = options.getReadColumns();
+        this.selectedColumns = columns != null && !columns.isEmpty()
+                ? columns.toArray(new String[0])
+                : null;
+        this.readLimit = options.getReadLimit();
+    }
+
+    @Override
+    public void start() {
+        LOG.info("Starting LanceSourceReader, subtask: {}", readerContext.getIndexOfSubtask());
+        // Request the first Split
+        readerContext.sendSplitRequest();
+    }
+
+    @Override
+    public InputStatus pollNext(ReaderOutput<RowData> output) throws Exception {
+        // Check if Limit has been reached
+        if (isLimitReached()) {
+            return InputStatus.END_OF_INPUT;
+        }
+
+        // Try to read data from current batch
+        if (currentBatchIterator != null && currentBatchIterator.hasNext()) {
+            RowData row = currentBatchIterator.next();
+            output.collect(row);
+            emittedCount++;
+            if (isLimitReached()) {
+                closeCurrentSplit();
+                return InputStatus.END_OF_INPUT;
+            }
+            return InputStatus.MORE_AVAILABLE;
+        }
+
+        // Current batch exhausted, try to load next batch
+        if (currentReader != null) {
+            try {
+                if (currentReader.loadNextBatch()) {
+                    VectorSchemaRoot root = currentReader.getVectorSchemaRoot();
+                    List<RowData> rows = converter.toRowDataList(root);
+                    currentBatchIterator = rows.iterator();
+                    return InputStatus.MORE_AVAILABLE;
+                }
+            } catch (Exception e) {
+                throw new IOException("Failed to load data batch", e);
+            }
+
+            // Current Split reading completed
+            closeCurrentSplit();
+            LOG.info("Split {} 读取完成", currentSplit != null ? currentSplit.splitId() : "unknown");
+            currentSplit = null;
+        }
+
+        // Try to open the next Split
+        if (!pendingSplits.isEmpty()) {
+            LanceSourceSplit split = pendingSplits.poll();
+            openSplit(split);
+            return InputStatus.MORE_AVAILABLE;
+        }
+
+        // No more pending Splits
+        if (noMoreSplits) {
+            LOG.info("All Splits read, total rows emitted: {}", emittedCount);
+            return InputStatus.END_OF_INPUT;
+        }
+
+        // More Splits may be coming, wait
+        return InputStatus.NOTHING_AVAILABLE;
+    }
+
+    /**
+     * Open a Split and start reading.
+     */
+    private void openSplit(LanceSourceSplit split) throws IOException {
+        LOG.info("Opening Split: {}", split);
+        this.currentSplit = split;
+
+        try {
+            // Initialize allocator (if not already initialized)
+            if (allocator == null) {
+                allocator = new RootAllocator(Long.MAX_VALUE);
+            }
+
+            // Open Dataset
+            String datasetPath = split.getDatasetPath();
+            currentDataset = Dataset.open(datasetPath, allocator);
+
+            // Initialize converter (if not already initialized)
+            if (converter == null) {
+                RowType actualRowType = this.rowType;
+                if (actualRowType == null) {
+                    Schema arrowSchema = currentDataset.getSchema();
+                    actualRowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
+                }
+                converter = new RowDataConverter(actualRowType);
+            }
+
+            // Find the target Fragment
+            List<Fragment> fragments = currentDataset.getFragments();
+            Fragment targetFragment = null;
+            for (Fragment fragment : fragments) {
+                if (fragment.getId() == split.getFragmentId()) {
+                    targetFragment = fragment;
+                    break;
+                }
+            }
+
+            if (targetFragment == null) {
+                throw new IOException("Fragment not found: " + split.getFragmentId());
+            }
+
+            // Build scan options
+            ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder();
+            scanOptionsBuilder.batchSize(options.getReadBatchSize());
+
+            if (selectedColumns != null && selectedColumns.length > 0) {
+                scanOptionsBuilder.columns(Arrays.asList(selectedColumns));
+            }
+
+            // Fragment level does not support filter, filter is only supported at Dataset level
+            // filter has been pushed down in LanceFilterSplitEnumerator (can be extended later if needed)
+
+            ScanOptions scanOptions = scanOptionsBuilder.build();
+
+            // Create Scanner and read data
+            currentScanner = targetFragment.newScan(scanOptions);
+            currentReader = currentScanner.scanBatches();
+
+            // Load first batch of data
+            if (currentReader.loadNextBatch()) {
+                VectorSchemaRoot root = currentReader.getVectorSchemaRoot();
+                List<RowData> rows = converter.toRowDataList(root);
+                currentBatchIterator = rows.iterator();
+            }
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException("Failed to open Split: " + split, e);
+        }
+    }
+
+    /**
+     * Close the resources of the currently reading Split.
+     */
+    private void closeCurrentSplit() {
+        if (currentReader != null) {
+            try {
+                currentReader.close();
+            } catch (Exception e) {
+                LOG.warn("Failed to close Reader", e);
+            }
+            currentReader = null;
+        }
+
+        if (currentScanner != null) {
+            try {
+                currentScanner.close();
+            } catch (Exception e) {
+                LOG.warn("Failed to close Scanner", e);
+            }
+            currentScanner = null;
+        }
+
+        if (currentDataset != null) {
+            try {
+                currentDataset.close();
+            } catch (Exception e) {
+                LOG.warn("Failed to close Dataset", e);
+            }
+            currentDataset = null;
+        }
+
+        currentBatchIterator = null;
+    }
+
+    @Override
+    public List<LanceSourceSplit> snapshotState(long checkpointId) {
+        List<LanceSourceSplit> state = new ArrayList<>(pendingSplits);
+        // If there's a currently processing Split, save it too
+        if (currentSplit != null) {
+            state.add(0, currentSplit);
+        }
+        LOG.debug("Checkpoint {} snapshot, saving {} Splits", checkpointId, state.size());
+        return state;
+    }
+
+    @Override
+    public CompletableFuture<Void> isAvailable() {
+        if (!pendingSplits.isEmpty() || currentBatchIterator != null || currentReader != null) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        if (availableFuture == null || availableFuture.isDone()) {
+            availableFuture = new CompletableFuture<>();
+        }
+        return availableFuture;
+    }
+
+    @Override
+    public void addSplits(List<LanceSourceSplit> splits) {
+        LOG.info("Received {} new Splits", splits.size());
+        pendingSplits.addAll(splits);
+
+        // Notify that new data is available
+        if (availableFuture != null && !availableFuture.isDone()) {
+            availableFuture.complete(null);
+        }
+    }
+
+    @Override
+    public void notifyNoMoreSplits() {
+        LOG.info("Notified no more Splits");
+        this.noMoreSplits = true;
+
+        // Notify of state change
+        if (availableFuture != null && !availableFuture.isDone()) {
+            availableFuture.complete(null);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        LOG.info("Closing LanceSourceReader, total rows emitted: {}", emittedCount);
+        closeCurrentSplit();
+
+        if (allocator != null) {
+            try {
+                allocator.close();
+            } catch (Exception e) {
+                LOG.warn("Failed to close allocator", e);
+            }
+            allocator = null;
+        }
+    }
+
+    /**
+     * Check if Limit has been reached.
+     */
+    private boolean isLimitReached() {
+        return readLimit != null && emittedCount >= readLimit;
+    }
+}

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceSourceReader.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceSourceReader.java
@@ -25,6 +25,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.connector.lance.config.LanceDatasetFactory;
 import org.apache.flink.connector.lance.config.LanceOptions;
 import org.apache.flink.connector.lance.converter.LanceTypeConverter;
 import org.apache.flink.connector.lance.converter.RowDataConverter;
@@ -189,7 +190,7 @@ public class LanceSourceReader implements SourceReader<RowData, LanceSourceSplit
 
       // Open Dataset
       String datasetPath = split.getDatasetPath();
-      currentDataset = Dataset.open(datasetPath, allocator);
+      currentDataset = LanceDatasetFactory.open(datasetPath, allocator);
 
       // Initialize converter (if not already initialized)
       if (converter == null) {

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceSourceReader.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceSourceReader.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,18 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.source;
-
-import org.apache.flink.api.connector.source.ReaderOutput;
-import org.apache.flink.api.connector.source.SourceReader;
-import org.apache.flink.api.connector.source.SourceReaderContext;
-import org.apache.flink.connector.lance.config.LanceOptions;
-import org.apache.flink.connector.lance.converter.LanceTypeConverter;
-import org.apache.flink.connector.lance.converter.RowDataConverter;
-import org.apache.flink.core.io.InputStatus;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.types.logical.RowType;
 
 import com.lancedb.lance.Dataset;
 import com.lancedb.lance.Fragment;
@@ -37,6 +22,15 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.flink.api.connector.source.ReaderOutput;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.connector.lance.config.LanceOptions;
+import org.apache.flink.connector.lance.converter.LanceTypeConverter;
+import org.apache.flink.connector.lance.converter.RowDataConverter;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,304 +48,297 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Data reader for Lance Source.
  *
- * <p>Reads data from assigned {@link LanceSourceSplit}s and converts Arrow data to Flink {@link RowData}.
- * Similar to the PageSource role in Trino.
+ * <p>Reads data from assigned {@link LanceSourceSplit}s and converts Arrow data to Flink {@link
+ * RowData}. Similar to the PageSource role in Trino.
  *
  * <p>Main responsibilities:
+ *
  * <ul>
- *   <li>Receive Splits assigned by SplitEnumerator</li>
- *   <li>Open Fragment Scanner to read data</li>
- *   <li>Convert Arrow data to RowData</li>
- *   <li>Support column pruning, filter push-down and limit push-down</li>
+ *   <li>Receive Splits assigned by SplitEnumerator
+ *   <li>Open Fragment Scanner to read data
+ *   <li>Convert Arrow data to RowData
+ *   <li>Support column pruning, filter push-down and limit push-down
  * </ul>
  */
 public class LanceSourceReader implements SourceReader<RowData, LanceSourceSplit> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(LanceSourceReader.class);
+  private static final Logger LOG = LoggerFactory.getLogger(LanceSourceReader.class);
 
-    private final SourceReaderContext readerContext;
-    private final LanceOptions options;
-    private final RowType rowType;
-    private final String[] selectedColumns;
-    private final Long readLimit;
+  private final SourceReaderContext readerContext;
+  private final LanceOptions options;
+  private final RowType rowType;
+  private final String[] selectedColumns;
+  private final Long readLimit;
 
-    /** Queue of pending Splits to process */
-    private final Queue<LanceSourceSplit> pendingSplits;
+  /** Queue of pending Splits to process */
+  private final Queue<LanceSourceSplit> pendingSplits;
 
-    /** Current reading resources */
-    private transient BufferAllocator allocator;
-    private transient Dataset currentDataset;
-    private transient LanceScanner currentScanner;
-    private transient ArrowReader currentReader;
-    private transient Iterator<RowData> currentBatchIterator;
-    private transient RowDataConverter converter;
-    private transient LanceSourceSplit currentSplit;
+  /** Current reading resources */
+  private transient BufferAllocator allocator;
 
-    /** Whether there are no more Splits */
-    private boolean noMoreSplits;
+  private transient Dataset currentDataset;
+  private transient LanceScanner currentScanner;
+  private transient ArrowReader currentReader;
+  private transient Iterator<RowData> currentBatchIterator;
+  private transient RowDataConverter converter;
+  private transient LanceSourceSplit currentSplit;
 
-    /** Number of emitted rows (for Limit) */
-    private long emittedCount;
+  /** Whether there are no more Splits */
+  private boolean noMoreSplits;
 
-    /** Future for available data notification */
-    private CompletableFuture<Void> availableFuture;
+  /** Number of emitted rows (for Limit) */
+  private long emittedCount;
 
-    /**
-     * Create a LanceSourceReader.
-     *
-     * @param readerContext Reader context
-     * @param options       Lance configuration
-     * @param rowType       Row type (nullable, auto-inferred)
-     */
-    public LanceSourceReader(
-            SourceReaderContext readerContext,
-            LanceOptions options,
-            @Nullable RowType rowType) {
-        this.readerContext = readerContext;
-        this.options = options;
-        this.rowType = rowType;
-        this.pendingSplits = new ArrayDeque<>();
-        this.noMoreSplits = false;
-        this.emittedCount = 0;
+  /** Future for available data notification */
+  private CompletableFuture<Void> availableFuture;
 
-        List<String> columns = options.getReadColumns();
-        this.selectedColumns = columns != null && !columns.isEmpty()
-                ? columns.toArray(new String[0])
-                : null;
-        this.readLimit = options.getReadLimit();
+  /**
+   * Create a LanceSourceReader.
+   *
+   * @param readerContext Reader context
+   * @param options Lance configuration
+   * @param rowType Row type (nullable, auto-inferred)
+   */
+  public LanceSourceReader(
+      SourceReaderContext readerContext, LanceOptions options, @Nullable RowType rowType) {
+    this.readerContext = readerContext;
+    this.options = options;
+    this.rowType = rowType;
+    this.pendingSplits = new ArrayDeque<>();
+    this.noMoreSplits = false;
+    this.emittedCount = 0;
+
+    List<String> columns = options.getReadColumns();
+    this.selectedColumns =
+        columns != null && !columns.isEmpty() ? columns.toArray(new String[0]) : null;
+    this.readLimit = options.getReadLimit();
+  }
+
+  @Override
+  public void start() {
+    LOG.info("Starting LanceSourceReader, subtask: {}", readerContext.getIndexOfSubtask());
+    // Request the first Split
+    readerContext.sendSplitRequest();
+  }
+
+  @Override
+  public InputStatus pollNext(ReaderOutput<RowData> output) throws Exception {
+    // Check if Limit has been reached
+    if (isLimitReached()) {
+      return InputStatus.END_OF_INPUT;
     }
 
-    @Override
-    public void start() {
-        LOG.info("Starting LanceSourceReader, subtask: {}", readerContext.getIndexOfSubtask());
-        // Request the first Split
-        readerContext.sendSplitRequest();
-    }
-
-    @Override
-    public InputStatus pollNext(ReaderOutput<RowData> output) throws Exception {
-        // Check if Limit has been reached
-        if (isLimitReached()) {
-            return InputStatus.END_OF_INPUT;
-        }
-
-        // Try to read data from current batch
-        if (currentBatchIterator != null && currentBatchIterator.hasNext()) {
-            RowData row = currentBatchIterator.next();
-            output.collect(row);
-            emittedCount++;
-            if (isLimitReached()) {
-                closeCurrentSplit();
-                return InputStatus.END_OF_INPUT;
-            }
-            return InputStatus.MORE_AVAILABLE;
-        }
-
-        // Current batch exhausted, try to load next batch
-        if (currentReader != null) {
-            try {
-                if (currentReader.loadNextBatch()) {
-                    VectorSchemaRoot root = currentReader.getVectorSchemaRoot();
-                    List<RowData> rows = converter.toRowDataList(root);
-                    currentBatchIterator = rows.iterator();
-                    return InputStatus.MORE_AVAILABLE;
-                }
-            } catch (Exception e) {
-                throw new IOException("Failed to load data batch", e);
-            }
-
-            // Current Split reading completed
-            closeCurrentSplit();
-            LOG.info("Split {} 读取完成", currentSplit != null ? currentSplit.splitId() : "unknown");
-            currentSplit = null;
-        }
-
-        // Try to open the next Split
-        if (!pendingSplits.isEmpty()) {
-            LanceSourceSplit split = pendingSplits.poll();
-            openSplit(split);
-            return InputStatus.MORE_AVAILABLE;
-        }
-
-        // No more pending Splits
-        if (noMoreSplits) {
-            LOG.info("All Splits read, total rows emitted: {}", emittedCount);
-            return InputStatus.END_OF_INPUT;
-        }
-
-        // More Splits may be coming, wait
-        return InputStatus.NOTHING_AVAILABLE;
-    }
-
-    /**
-     * Open a Split and start reading.
-     */
-    private void openSplit(LanceSourceSplit split) throws IOException {
-        LOG.info("Opening Split: {}", split);
-        this.currentSplit = split;
-
-        try {
-            // Initialize allocator (if not already initialized)
-            if (allocator == null) {
-                allocator = new RootAllocator(Long.MAX_VALUE);
-            }
-
-            // Open Dataset
-            String datasetPath = split.getDatasetPath();
-            currentDataset = Dataset.open(datasetPath, allocator);
-
-            // Initialize converter (if not already initialized)
-            if (converter == null) {
-                RowType actualRowType = this.rowType;
-                if (actualRowType == null) {
-                    Schema arrowSchema = currentDataset.getSchema();
-                    actualRowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
-                }
-                converter = new RowDataConverter(actualRowType);
-            }
-
-            // Find the target Fragment
-            List<Fragment> fragments = currentDataset.getFragments();
-            Fragment targetFragment = null;
-            for (Fragment fragment : fragments) {
-                if (fragment.getId() == split.getFragmentId()) {
-                    targetFragment = fragment;
-                    break;
-                }
-            }
-
-            if (targetFragment == null) {
-                throw new IOException("Fragment not found: " + split.getFragmentId());
-            }
-
-            // Build scan options
-            ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder();
-            scanOptionsBuilder.batchSize(options.getReadBatchSize());
-
-            if (selectedColumns != null && selectedColumns.length > 0) {
-                scanOptionsBuilder.columns(Arrays.asList(selectedColumns));
-            }
-
-            // Fragment level does not support filter, filter is only supported at Dataset level
-            // filter has been pushed down in LanceFilterSplitEnumerator (can be extended later if needed)
-
-            ScanOptions scanOptions = scanOptionsBuilder.build();
-
-            // Create Scanner and read data
-            currentScanner = targetFragment.newScan(scanOptions);
-            currentReader = currentScanner.scanBatches();
-
-            // Load first batch of data
-            if (currentReader.loadNextBatch()) {
-                VectorSchemaRoot root = currentReader.getVectorSchemaRoot();
-                List<RowData> rows = converter.toRowDataList(root);
-                currentBatchIterator = rows.iterator();
-            }
-        } catch (IOException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new IOException("Failed to open Split: " + split, e);
-        }
-    }
-
-    /**
-     * Close the resources of the currently reading Split.
-     */
-    private void closeCurrentSplit() {
-        if (currentReader != null) {
-            try {
-                currentReader.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close Reader", e);
-            }
-            currentReader = null;
-        }
-
-        if (currentScanner != null) {
-            try {
-                currentScanner.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close Scanner", e);
-            }
-            currentScanner = null;
-        }
-
-        if (currentDataset != null) {
-            try {
-                currentDataset.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close Dataset", e);
-            }
-            currentDataset = null;
-        }
-
-        currentBatchIterator = null;
-    }
-
-    @Override
-    public List<LanceSourceSplit> snapshotState(long checkpointId) {
-        List<LanceSourceSplit> state = new ArrayList<>(pendingSplits);
-        // If there's a currently processing Split, save it too
-        if (currentSplit != null) {
-            state.add(0, currentSplit);
-        }
-        LOG.debug("Checkpoint {} snapshot, saving {} Splits", checkpointId, state.size());
-        return state;
-    }
-
-    @Override
-    public CompletableFuture<Void> isAvailable() {
-        if (!pendingSplits.isEmpty() || currentBatchIterator != null || currentReader != null) {
-            return CompletableFuture.completedFuture(null);
-        }
-
-        if (availableFuture == null || availableFuture.isDone()) {
-            availableFuture = new CompletableFuture<>();
-        }
-        return availableFuture;
-    }
-
-    @Override
-    public void addSplits(List<LanceSourceSplit> splits) {
-        LOG.info("Received {} new Splits", splits.size());
-        pendingSplits.addAll(splits);
-
-        // Notify that new data is available
-        if (availableFuture != null && !availableFuture.isDone()) {
-            availableFuture.complete(null);
-        }
-    }
-
-    @Override
-    public void notifyNoMoreSplits() {
-        LOG.info("Notified no more Splits");
-        this.noMoreSplits = true;
-
-        // Notify of state change
-        if (availableFuture != null && !availableFuture.isDone()) {
-            availableFuture.complete(null);
-        }
-    }
-
-    @Override
-    public void close() throws Exception {
-        LOG.info("Closing LanceSourceReader, total rows emitted: {}", emittedCount);
+    // Try to read data from current batch
+    if (currentBatchIterator != null && currentBatchIterator.hasNext()) {
+      RowData row = currentBatchIterator.next();
+      output.collect(row);
+      emittedCount++;
+      if (isLimitReached()) {
         closeCurrentSplit();
+        return InputStatus.END_OF_INPUT;
+      }
+      return InputStatus.MORE_AVAILABLE;
+    }
 
-        if (allocator != null) {
-            try {
-                allocator.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close allocator", e);
-            }
-            allocator = null;
+    // Current batch exhausted, try to load next batch
+    if (currentReader != null) {
+      try {
+        if (currentReader.loadNextBatch()) {
+          VectorSchemaRoot root = currentReader.getVectorSchemaRoot();
+          List<RowData> rows = converter.toRowDataList(root);
+          currentBatchIterator = rows.iterator();
+          return InputStatus.MORE_AVAILABLE;
         }
+      } catch (Exception e) {
+        throw new IOException("Failed to load data batch", e);
+      }
+
+      // Current Split reading completed
+      closeCurrentSplit();
+      LOG.info("Split {} 读取完成", currentSplit != null ? currentSplit.splitId() : "unknown");
+      currentSplit = null;
     }
 
-    /**
-     * Check if Limit has been reached.
-     */
-    private boolean isLimitReached() {
-        return readLimit != null && emittedCount >= readLimit;
+    // Try to open the next Split
+    if (!pendingSplits.isEmpty()) {
+      LanceSourceSplit split = pendingSplits.poll();
+      openSplit(split);
+      return InputStatus.MORE_AVAILABLE;
     }
+
+    // No more pending Splits
+    if (noMoreSplits) {
+      LOG.info("All Splits read, total rows emitted: {}", emittedCount);
+      return InputStatus.END_OF_INPUT;
+    }
+
+    // More Splits may be coming, wait
+    return InputStatus.NOTHING_AVAILABLE;
+  }
+
+  /** Open a Split and start reading. */
+  private void openSplit(LanceSourceSplit split) throws IOException {
+    LOG.info("Opening Split: {}", split);
+    this.currentSplit = split;
+
+    try {
+      // Initialize allocator (if not already initialized)
+      if (allocator == null) {
+        allocator = new RootAllocator(Long.MAX_VALUE);
+      }
+
+      // Open Dataset
+      String datasetPath = split.getDatasetPath();
+      currentDataset = Dataset.open(datasetPath, allocator);
+
+      // Initialize converter (if not already initialized)
+      if (converter == null) {
+        RowType actualRowType = this.rowType;
+        if (actualRowType == null) {
+          Schema arrowSchema = currentDataset.getSchema();
+          actualRowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
+        }
+        converter = new RowDataConverter(actualRowType);
+      }
+
+      // Find the target Fragment
+      List<Fragment> fragments = currentDataset.getFragments();
+      Fragment targetFragment = null;
+      for (Fragment fragment : fragments) {
+        if (fragment.getId() == split.getFragmentId()) {
+          targetFragment = fragment;
+          break;
+        }
+      }
+
+      if (targetFragment == null) {
+        throw new IOException("Fragment not found: " + split.getFragmentId());
+      }
+
+      // Build scan options
+      ScanOptions.Builder scanOptionsBuilder = new ScanOptions.Builder();
+      scanOptionsBuilder.batchSize(options.getReadBatchSize());
+
+      if (selectedColumns != null && selectedColumns.length > 0) {
+        scanOptionsBuilder.columns(Arrays.asList(selectedColumns));
+      }
+
+      // Fragment level does not support filter, filter is only supported at Dataset level
+      // filter has been pushed down in LanceFilterSplitEnumerator (can be extended later if needed)
+
+      ScanOptions scanOptions = scanOptionsBuilder.build();
+
+      // Create Scanner and read data
+      currentScanner = targetFragment.newScan(scanOptions);
+      currentReader = currentScanner.scanBatches();
+
+      // Load first batch of data
+      if (currentReader.loadNextBatch()) {
+        VectorSchemaRoot root = currentReader.getVectorSchemaRoot();
+        List<RowData> rows = converter.toRowDataList(root);
+        currentBatchIterator = rows.iterator();
+      }
+    } catch (IOException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IOException("Failed to open Split: " + split, e);
+    }
+  }
+
+  /** Close the resources of the currently reading Split. */
+  private void closeCurrentSplit() {
+    if (currentReader != null) {
+      try {
+        currentReader.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close Reader", e);
+      }
+      currentReader = null;
+    }
+
+    if (currentScanner != null) {
+      try {
+        currentScanner.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close Scanner", e);
+      }
+      currentScanner = null;
+    }
+
+    if (currentDataset != null) {
+      try {
+        currentDataset.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close Dataset", e);
+      }
+      currentDataset = null;
+    }
+
+    currentBatchIterator = null;
+  }
+
+  @Override
+  public List<LanceSourceSplit> snapshotState(long checkpointId) {
+    List<LanceSourceSplit> state = new ArrayList<>(pendingSplits);
+    // If there's a currently processing Split, save it too
+    if (currentSplit != null) {
+      state.add(0, currentSplit);
+    }
+    LOG.debug("Checkpoint {} snapshot, saving {} Splits", checkpointId, state.size());
+    return state;
+  }
+
+  @Override
+  public CompletableFuture<Void> isAvailable() {
+    if (!pendingSplits.isEmpty() || currentBatchIterator != null || currentReader != null) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    if (availableFuture == null || availableFuture.isDone()) {
+      availableFuture = new CompletableFuture<>();
+    }
+    return availableFuture;
+  }
+
+  @Override
+  public void addSplits(List<LanceSourceSplit> splits) {
+    LOG.info("Received {} new Splits", splits.size());
+    pendingSplits.addAll(splits);
+
+    // Notify that new data is available
+    if (availableFuture != null && !availableFuture.isDone()) {
+      availableFuture.complete(null);
+    }
+  }
+
+  @Override
+  public void notifyNoMoreSplits() {
+    LOG.info("Notified no more Splits");
+    this.noMoreSplits = true;
+
+    // Notify of state change
+    if (availableFuture != null && !availableFuture.isDone()) {
+      availableFuture.complete(null);
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    LOG.info("Closing LanceSourceReader, total rows emitted: {}", emittedCount);
+    closeCurrentSplit();
+
+    if (allocator != null) {
+      try {
+        allocator.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close allocator", e);
+      }
+      allocator = null;
+    }
+  }
+
+  /** Check if Limit has been reached. */
+  private boolean isLimitReached() {
+    return readLimit != null && emittedCount >= readLimit;
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceSourceSplit.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceSourceSplit.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.lance.source;
+
+import org.apache.flink.api.connector.source.SourceSplit;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Lance Source V2 data split.
+ *
+ * <p>Represents a Fragment in a Lance Dataset, used for parallel data reading.
+ * Each Split corresponds to a Fragment, assigned by {@link LanceSplitEnumerator} to {@link LanceSourceReader}.
+ *
+ * <p>This class is immutable; all fields cannot be modified after construction.
+ */
+public class LanceSourceSplit implements SourceSplit, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Fragment ID */
+    private final int fragmentId;
+
+    /** Dataset path */
+    private final String datasetPath;
+
+    /** Estimated row count in the Fragment */
+    private final long rowCount;
+
+    /**
+     * Create a LanceSourceSplit.
+     *
+     * @param fragmentId  Fragment ID
+     * @param datasetPath Dataset path
+     * @param rowCount    Row count
+     */
+    public LanceSourceSplit(int fragmentId, String datasetPath, long rowCount) {
+        this.fragmentId = fragmentId;
+        this.datasetPath = Objects.requireNonNull(datasetPath, "datasetPath must not be null");
+        this.rowCount = rowCount;
+    }
+
+    @Override
+    public String splitId() {
+        return "lance-split-" + fragmentId;
+    }
+
+    /**
+     * Get Fragment ID.
+     */
+    public int getFragmentId() {
+        return fragmentId;
+    }
+
+    /**
+     * Get Dataset path.
+     */
+    public String getDatasetPath() {
+        return datasetPath;
+    }
+
+    /**
+     * Get row count.
+     */
+    public long getRowCount() {
+        return rowCount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LanceSourceSplit that = (LanceSourceSplit) o;
+        return fragmentId == that.fragmentId
+                && rowCount == that.rowCount
+                && Objects.equals(datasetPath, that.datasetPath);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fragmentId, datasetPath, rowCount);
+    }
+
+    @Override
+    public String toString() {
+        return "LanceSourceSplit{"
+                + "fragmentId=" + fragmentId
+                + ", datasetPath='" + datasetPath + '\''
+                + ", rowCount=" + rowCount
+                + '}';
+    }
+}

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceSourceSplit.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceSourceSplit.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.source;
 
 import org.apache.flink.api.connector.source.SourceSplit;
@@ -26,84 +21,82 @@ import java.util.Objects;
 /**
  * Lance Source V2 data split.
  *
- * <p>Represents a Fragment in a Lance Dataset, used for parallel data reading.
- * Each Split corresponds to a Fragment, assigned by {@link LanceSplitEnumerator} to {@link LanceSourceReader}.
+ * <p>Represents a Fragment in a Lance Dataset, used for parallel data reading. Each Split
+ * corresponds to a Fragment, assigned by {@link LanceSplitEnumerator} to {@link LanceSourceReader}.
  *
  * <p>This class is immutable; all fields cannot be modified after construction.
  */
 public class LanceSourceSplit implements SourceSplit, Serializable {
 
-    private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 1L;
 
-    /** Fragment ID */
-    private final int fragmentId;
+  /** Fragment ID */
+  private final int fragmentId;
 
-    /** Dataset path */
-    private final String datasetPath;
+  /** Dataset path */
+  private final String datasetPath;
 
-    /** Estimated row count in the Fragment */
-    private final long rowCount;
+  /** Estimated row count in the Fragment */
+  private final long rowCount;
 
-    /**
-     * Create a LanceSourceSplit.
-     *
-     * @param fragmentId  Fragment ID
-     * @param datasetPath Dataset path
-     * @param rowCount    Row count
-     */
-    public LanceSourceSplit(int fragmentId, String datasetPath, long rowCount) {
-        this.fragmentId = fragmentId;
-        this.datasetPath = Objects.requireNonNull(datasetPath, "datasetPath must not be null");
-        this.rowCount = rowCount;
-    }
+  /**
+   * Create a LanceSourceSplit.
+   *
+   * @param fragmentId Fragment ID
+   * @param datasetPath Dataset path
+   * @param rowCount Row count
+   */
+  public LanceSourceSplit(int fragmentId, String datasetPath, long rowCount) {
+    this.fragmentId = fragmentId;
+    this.datasetPath = Objects.requireNonNull(datasetPath, "datasetPath must not be null");
+    this.rowCount = rowCount;
+  }
 
-    @Override
-    public String splitId() {
-        return "lance-split-" + fragmentId;
-    }
+  @Override
+  public String splitId() {
+    return "lance-split-" + fragmentId;
+  }
 
-    /**
-     * Get Fragment ID.
-     */
-    public int getFragmentId() {
-        return fragmentId;
-    }
+  /** Get Fragment ID. */
+  public int getFragmentId() {
+    return fragmentId;
+  }
 
-    /**
-     * Get Dataset path.
-     */
-    public String getDatasetPath() {
-        return datasetPath;
-    }
+  /** Get Dataset path. */
+  public String getDatasetPath() {
+    return datasetPath;
+  }
 
-    /**
-     * Get row count.
-     */
-    public long getRowCount() {
-        return rowCount;
-    }
+  /** Get row count. */
+  public long getRowCount() {
+    return rowCount;
+  }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        LanceSourceSplit that = (LanceSourceSplit) o;
-        return fragmentId == that.fragmentId
-                && rowCount == that.rowCount
-                && Objects.equals(datasetPath, that.datasetPath);
-    }
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    LanceSourceSplit that = (LanceSourceSplit) o;
+    return fragmentId == that.fragmentId
+        && rowCount == that.rowCount
+        && Objects.equals(datasetPath, that.datasetPath);
+  }
 
-    @Override
-    public int hashCode() {
-        return Objects.hash(fragmentId, datasetPath, rowCount);
-    }
+  @Override
+  public int hashCode() {
+    return Objects.hash(fragmentId, datasetPath, rowCount);
+  }
 
-    @Override
-    public String toString() {
-        return "LanceSourceSplit{"
-                + "fragmentId=" + fragmentId
-                + ", datasetPath='" + datasetPath + '\''
-                + ", rowCount=" + rowCount
-                + '}';
-    }
+  @Override
+  public String toString() {
+    return "LanceSourceSplit{"
+        + "fragmentId="
+        + fragmentId
+        + ", datasetPath='"
+        + datasetPath
+        + '\''
+        + ", rowCount="
+        + rowCount
+        + '}';
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceSourceSplitSerializer.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceSourceSplitSerializer.java
@@ -61,7 +61,9 @@ public class LanceSourceSplitSerializer implements SimpleVersionedSerializer<Lan
     @Override
     public LanceSourceSplit deserialize(int version, byte[] serialized) throws IOException {
         if (version != CURRENT_VERSION) {
-            throw new IOException("Unsupported serialization version: " + version + ", current version: " + CURRENT_VERSION);
+            throw new IOException(
+                    "Unsupported serialization version: " + version
+                            + ", current version: " + CURRENT_VERSION);
         }
 
         DataInputStream in = new DataInputStream(new ByteArrayInputStream(serialized));

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceSourceSplitSerializer.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceSourceSplitSerializer.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.source;
 
 import org.apache.flink.core.io.SimpleVersionedSerializer;
@@ -33,45 +28,46 @@ import java.io.IOException;
  */
 public class LanceSourceSplitSerializer implements SimpleVersionedSerializer<LanceSourceSplit> {
 
-    public static final LanceSourceSplitSerializer INSTANCE = new LanceSourceSplitSerializer();
+  public static final LanceSourceSplitSerializer INSTANCE = new LanceSourceSplitSerializer();
 
-    private static final int CURRENT_VERSION = 1;
+  private static final int CURRENT_VERSION = 1;
 
-    private LanceSourceSplitSerializer() {
+  private LanceSourceSplitSerializer() {}
+
+  @Override
+  public int getVersion() {
+    return CURRENT_VERSION;
+  }
+
+  @Override
+  public byte[] serialize(LanceSourceSplit split) throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream out = new DataOutputStream(baos);
+
+    out.writeInt(split.getFragmentId());
+    out.writeUTF(split.getDatasetPath());
+    out.writeLong(split.getRowCount());
+
+    out.flush();
+    return baos.toByteArray();
+  }
+
+  @Override
+  public LanceSourceSplit deserialize(int version, byte[] serialized) throws IOException {
+    if (version != CURRENT_VERSION) {
+      throw new IOException(
+          "Unsupported serialization version: "
+              + version
+              + ", current version: "
+              + CURRENT_VERSION);
     }
 
-    @Override
-    public int getVersion() {
-        return CURRENT_VERSION;
-    }
+    DataInputStream in = new DataInputStream(new ByteArrayInputStream(serialized));
 
-    @Override
-    public byte[] serialize(LanceSourceSplit split) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        DataOutputStream out = new DataOutputStream(baos);
+    int fragmentId = in.readInt();
+    String datasetPath = in.readUTF();
+    long rowCount = in.readLong();
 
-        out.writeInt(split.getFragmentId());
-        out.writeUTF(split.getDatasetPath());
-        out.writeLong(split.getRowCount());
-
-        out.flush();
-        return baos.toByteArray();
-    }
-
-    @Override
-    public LanceSourceSplit deserialize(int version, byte[] serialized) throws IOException {
-        if (version != CURRENT_VERSION) {
-            throw new IOException(
-                    "Unsupported serialization version: " + version
-                            + ", current version: " + CURRENT_VERSION);
-        }
-
-        DataInputStream in = new DataInputStream(new ByteArrayInputStream(serialized));
-
-        int fragmentId = in.readInt();
-        String datasetPath = in.readUTF();
-        long rowCount = in.readLong();
-
-        return new LanceSourceSplit(fragmentId, datasetPath, rowCount);
-    }
+    return new LanceSourceSplit(fragmentId, datasetPath, rowCount);
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceSourceSplitSerializer.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceSourceSplitSerializer.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.lance.source;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/**
+ * Serializer for {@link LanceSourceSplit}.
+ *
+ * <p>Used for serializing/deserializing Splits during checkpoint and recovery.
+ */
+public class LanceSourceSplitSerializer implements SimpleVersionedSerializer<LanceSourceSplit> {
+
+    public static final LanceSourceSplitSerializer INSTANCE = new LanceSourceSplitSerializer();
+
+    private static final int CURRENT_VERSION = 1;
+
+    private LanceSourceSplitSerializer() {
+    }
+
+    @Override
+    public int getVersion() {
+        return CURRENT_VERSION;
+    }
+
+    @Override
+    public byte[] serialize(LanceSourceSplit split) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream out = new DataOutputStream(baos);
+
+        out.writeInt(split.getFragmentId());
+        out.writeUTF(split.getDatasetPath());
+        out.writeLong(split.getRowCount());
+
+        out.flush();
+        return baos.toByteArray();
+    }
+
+    @Override
+    public LanceSourceSplit deserialize(int version, byte[] serialized) throws IOException {
+        if (version != CURRENT_VERSION) {
+            throw new IOException("Unsupported serialization version: " + version + ", current version: " + CURRENT_VERSION);
+        }
+
+        DataInputStream in = new DataInputStream(new ByteArrayInputStream(serialized));
+
+        int fragmentId = in.readInt();
+        String datasetPath = in.readUTF();
+        long rowCount = in.readLong();
+
+        return new LanceSourceSplit(fragmentId, datasetPath, rowCount);
+    }
+}

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceSplitEnumerator.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceSplitEnumerator.java
@@ -16,9 +16,9 @@ package org.apache.flink.connector.lance.source;
 import com.lancedb.lance.Dataset;
 import com.lancedb.lance.Fragment;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.connector.lance.config.LanceDatasetFactory;
 import org.apache.flink.connector.lance.config.LanceOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -108,13 +108,11 @@ public class LanceSplitEnumerator
     LOG.info("Starting to discover Lance Dataset Fragments...");
 
     String datasetPath = options.getPath();
-    if (datasetPath == null || datasetPath.isEmpty()) {
-      throw new RuntimeException("Lance dataset path must not be empty");
-    }
+    LanceDatasetFactory.validatePath(datasetPath);
 
-    BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+    BufferAllocator allocator = LanceDatasetFactory.createAllocator();
     try {
-      Dataset dataset = Dataset.open(datasetPath, allocator);
+      Dataset dataset = LanceDatasetFactory.open(datasetPath, allocator);
       try {
         List<Fragment> fragments = dataset.getFragments();
         List<LanceSourceSplit> splits = new ArrayList<>(fragments.size());
@@ -133,7 +131,7 @@ public class LanceSplitEnumerator
       } finally {
         dataset.close();
       }
-    } catch (Exception e) {
+    } catch (IOException e) {
       throw new RuntimeException("Unable to open Lance Dataset: " + datasetPath, e);
     } finally {
       allocator.close();

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceSplitEnumerator.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceSplitEnumerator.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,17 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.source;
-
-import org.apache.flink.api.connector.source.SplitEnumerator;
-import org.apache.flink.api.connector.source.SplitEnumeratorContext;
-import org.apache.flink.connector.lance.config.LanceOptions;
 
 import com.lancedb.lance.Dataset;
 import com.lancedb.lance.Fragment;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.connector.lance.config.LanceOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,204 +41,200 @@ import java.util.Queue;
  * Similar to the SplitManager role in Trino.
  *
  * <p>Main responsibilities:
+ *
  * <ul>
- *   <li>Open Dataset and enumerate all Fragments</li>
- *   <li>Wrap Fragments as {@link LanceSourceSplit}</li>
- *   <li>Respond to SourceReader split requests and assign on demand</li>
- *   <li>Support checkpoint and recovery</li>
+ *   <li>Open Dataset and enumerate all Fragments
+ *   <li>Wrap Fragments as {@link LanceSourceSplit}
+ *   <li>Respond to SourceReader split requests and assign on demand
+ *   <li>Support checkpoint and recovery
  * </ul>
  */
-public class LanceSplitEnumerator implements SplitEnumerator<LanceSourceSplit, LanceEnumeratorState> {
+public class LanceSplitEnumerator
+    implements SplitEnumerator<LanceSourceSplit, LanceEnumeratorState> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(LanceSplitEnumerator.class);
+  private static final Logger LOG = LoggerFactory.getLogger(LanceSplitEnumerator.class);
 
-    private final SplitEnumeratorContext<LanceSourceSplit> context;
-    private final LanceOptions options;
+  private final SplitEnumeratorContext<LanceSourceSplit> context;
+  private final LanceOptions options;
 
-    /** Queue of pending Splits to be assigned */
-    private final Queue<LanceSourceSplit> pendingSplits;
+  /** Queue of pending Splits to be assigned */
+  private final Queue<LanceSourceSplit> pendingSplits;
 
-    /** Set of registered reader IDs */
-    private final java.util.Set<Integer> registeredReaders;
+  /** Set of registered reader IDs */
+  private final java.util.Set<Integer> registeredReaders;
 
-    /** Whether split discovery has finished */
-    private boolean splitDiscoveryFinished;
+  /** Whether split discovery has finished */
+  private boolean splitDiscoveryFinished;
 
-    /**
-     * Create a new LanceSplitEnumerator.
-     *
-     * @param context Enumerator context
-     * @param options Lance configuration
-     */
-    public LanceSplitEnumerator(
-            SplitEnumeratorContext<LanceSourceSplit> context,
-            LanceOptions options) {
-        this(context, options, new ArrayList<>());
+  /**
+   * Create a new LanceSplitEnumerator.
+   *
+   * @param context Enumerator context
+   * @param options Lance configuration
+   */
+  public LanceSplitEnumerator(
+      SplitEnumeratorContext<LanceSourceSplit> context, LanceOptions options) {
+    this(context, options, new ArrayList<>());
+  }
+
+  /**
+   * Create a LanceSplitEnumerator restored from checkpoint.
+   *
+   * @param context Enumerator context
+   * @param options Lance configuration
+   * @param pendingSplits Recovered pending Splits
+   */
+  public LanceSplitEnumerator(
+      SplitEnumeratorContext<LanceSourceSplit> context,
+      LanceOptions options,
+      Collection<LanceSourceSplit> pendingSplits) {
+    this.context = context;
+    this.options = options;
+    this.pendingSplits = new ArrayDeque<>(pendingSplits);
+    this.registeredReaders = new java.util.HashSet<>();
+    this.splitDiscoveryFinished = !pendingSplits.isEmpty();
+  }
+
+  @Override
+  public void start() {
+    LOG.info("Starting LanceSplitEnumerator, dataset path: {}", options.getPath());
+    if (!splitDiscoveryFinished) {
+      context.callAsync(this::discoverSplits, this::handleSplitDiscovery);
+    }
+  }
+
+  /** Discover all Splits (executed in async thread). */
+  private List<LanceSourceSplit> discoverSplits() {
+    LOG.info("Starting to discover Lance Dataset Fragments...");
+
+    String datasetPath = options.getPath();
+    if (datasetPath == null || datasetPath.isEmpty()) {
+      throw new RuntimeException("Lance dataset path must not be empty");
     }
 
-    /**
-     * Create a LanceSplitEnumerator restored from checkpoint.
-     *
-     * @param context       Enumerator context
-     * @param options       Lance configuration
-     * @param pendingSplits Recovered pending Splits
-     */
-    public LanceSplitEnumerator(
-            SplitEnumeratorContext<LanceSourceSplit> context,
-            LanceOptions options,
-            Collection<LanceSourceSplit> pendingSplits) {
-        this.context = context;
-        this.options = options;
-        this.pendingSplits = new ArrayDeque<>(pendingSplits);
-        this.registeredReaders = new java.util.HashSet<>();
-        this.splitDiscoveryFinished = !pendingSplits.isEmpty();
-    }
+    BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+    try {
+      Dataset dataset = Dataset.open(datasetPath, allocator);
+      try {
+        List<Fragment> fragments = dataset.getFragments();
+        List<LanceSourceSplit> splits = new ArrayList<>(fragments.size());
 
-    @Override
-    public void start() {
-        LOG.info("Starting LanceSplitEnumerator, dataset path: {}", options.getPath());
-        if (!splitDiscoveryFinished) {
-            context.callAsync(this::discoverSplits, this::handleSplitDiscovery);
-        }
-    }
-
-    /**
-     * Discover all Splits (executed in async thread).
-     */
-    private List<LanceSourceSplit> discoverSplits() {
-        LOG.info("Starting to discover Lance Dataset Fragments...");
-
-        String datasetPath = options.getPath();
-        if (datasetPath == null || datasetPath.isEmpty()) {
-            throw new RuntimeException("Lance dataset path must not be empty");
-        }
-
-        BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-        try {
-            Dataset dataset = Dataset.open(datasetPath, allocator);
-            try {
-                List<Fragment> fragments = dataset.getFragments();
-                List<LanceSourceSplit> splits = new ArrayList<>(fragments.size());
-
-                for (Fragment fragment : fragments) {
-                    long rowCount = fragment.countRows();
-                    splits.add(new LanceSourceSplit(fragment.getId(), datasetPath, rowCount));
-                }
-
-                LOG.info("Discovered {} Fragments, total rows: {}",
-                        splits.size(),
-                        splits.stream().mapToLong(LanceSourceSplit::getRowCount).sum());
-
-                return splits;
-            } finally {
-                dataset.close();
-            }
-        } catch (Exception e) {
-            throw new RuntimeException("Unable to open Lance Dataset: " + datasetPath, e);
-        } finally {
-            allocator.close();
-        }
-    }
-
-    /**
-     * Handle split discovery result (executed in main thread).
-     */
-    private void handleSplitDiscovery(List<LanceSourceSplit> splits, Throwable error) {
-        if (error != null) {
-            LOG.error("Error during split discovery", error);
-            throw new RuntimeException("Split discovery failed", error);
+        for (Fragment fragment : fragments) {
+          long rowCount = fragment.countRows();
+          splits.add(new LanceSourceSplit(fragment.getId(), datasetPath, rowCount));
         }
 
-        pendingSplits.addAll(splits);
-        splitDiscoveryFinished = true;
+        LOG.info(
+            "Discovered {} Fragments, total rows: {}",
+            splits.size(),
+            splits.stream().mapToLong(LanceSourceSplit::getRowCount).sum());
 
-        LOG.info("Split discovery completed, {} pending Splits", pendingSplits.size());
+        return splits;
+      } finally {
+        dataset.close();
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Unable to open Lance Dataset: " + datasetPath, e);
+    } finally {
+      allocator.close();
+    }
+  }
 
-        // Assign Splits to all registered readers
-        assignPendingSplits();
+  /** Handle split discovery result (executed in main thread). */
+  private void handleSplitDiscovery(List<LanceSourceSplit> splits, Throwable error) {
+    if (error != null) {
+      LOG.error("Error during split discovery", error);
+      throw new RuntimeException("Split discovery failed", error);
     }
 
-    @Override
-    public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
-        LOG.debug("Received split request from subtask {}", subtaskId);
+    pendingSplits.addAll(splits);
+    splitDiscoveryFinished = true;
 
-        if (!pendingSplits.isEmpty()) {
-            LanceSourceSplit split = pendingSplits.poll();
-            if (split != null) {
-                LOG.info("Assigning Split {} to subtask {}", split.splitId(), subtaskId);
-                List<LanceSourceSplit> assignment = new ArrayList<>();
-                assignment.add(split);
-                context.assignSplits(new org.apache.flink.api.connector.source.SplitsAssignment<>(
-                        java.util.Collections.singletonMap(subtaskId, assignment)));
-            }
-        } else if (splitDiscoveryFinished) {
-            // All Splits have been assigned, notify Reader that there are no more Splits
-            LOG.info("All Splits assigned, notifying subtask {} no more Splits", subtaskId);
-            context.signalNoMoreSplits(subtaskId);
-        }
-        // If split discovery hasn't finished yet, do nothing; splits will be assigned after discovery
+    LOG.info("Split discovery completed, {} pending Splits", pendingSplits.size());
+
+    // Assign Splits to all registered readers
+    assignPendingSplits();
+  }
+
+  @Override
+  public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
+    LOG.debug("Received split request from subtask {}", subtaskId);
+
+    if (!pendingSplits.isEmpty()) {
+      LanceSourceSplit split = pendingSplits.poll();
+      if (split != null) {
+        LOG.info("Assigning Split {} to subtask {}", split.splitId(), subtaskId);
+        List<LanceSourceSplit> assignment = new ArrayList<>();
+        assignment.add(split);
+        context.assignSplits(
+            new org.apache.flink.api.connector.source.SplitsAssignment<>(
+                java.util.Collections.singletonMap(subtaskId, assignment)));
+      }
+    } else if (splitDiscoveryFinished) {
+      // All Splits have been assigned, notify Reader that there are no more Splits
+      LOG.info("All Splits assigned, notifying subtask {} no more Splits", subtaskId);
+      context.signalNoMoreSplits(subtaskId);
+    }
+    // If split discovery hasn't finished yet, do nothing; splits will be assigned after discovery
+  }
+
+  @Override
+  public void addSplitsBack(List<LanceSourceSplit> splits, int subtaskId) {
+    LOG.info("Subtask {} returned {} Splits", subtaskId, splits.size());
+    pendingSplits.addAll(splits);
+  }
+
+  @Override
+  public void addReader(int subtaskId) {
+    LOG.info("Reader {} registered", subtaskId);
+    registeredReaders.add(subtaskId);
+    // When reader registers, assign pending splits immediately if available
+    if (splitDiscoveryFinished && !pendingSplits.isEmpty()) {
+      assignSplitToReader(subtaskId);
+    }
+  }
+
+  @Override
+  public LanceEnumeratorState snapshotState(long checkpointId) throws Exception {
+    LOG.debug("Checkpoint {} snapshot, pending Splits: {}", checkpointId, pendingSplits.size());
+    return new LanceEnumeratorState(new ArrayList<>(pendingSplits));
+  }
+
+  @Override
+  public void close() throws IOException {
+    LOG.info("Closing LanceSplitEnumerator");
+  }
+
+  /** Assign pending Splits to all registered readers. */
+  private void assignPendingSplits() {
+    // Only assign Splits to registered readers
+    for (Integer readerId : registeredReaders) {
+      if (pendingSplits.isEmpty()) {
+        break;
+      }
+      assignSplitToReader(readerId);
+    }
+  }
+
+  /** Assign a single Split to the specified reader. */
+  private void assignSplitToReader(int subtaskId) {
+    if (pendingSplits.isEmpty()) {
+      if (splitDiscoveryFinished) {
+        context.signalNoMoreSplits(subtaskId);
+      }
+      return;
     }
 
-    @Override
-    public void addSplitsBack(List<LanceSourceSplit> splits, int subtaskId) {
-        LOG.info("Subtask {} returned {} Splits", subtaskId, splits.size());
-        pendingSplits.addAll(splits);
+    LanceSourceSplit split = pendingSplits.poll();
+    if (split != null) {
+      Map<Integer, List<LanceSourceSplit>> assignment = new HashMap<>();
+      List<LanceSourceSplit> splitList = new ArrayList<>();
+      splitList.add(split);
+      assignment.put(subtaskId, splitList);
+
+      LOG.info("Assigning Split {} to subtask {}", split.splitId(), subtaskId);
+      context.assignSplits(
+          new org.apache.flink.api.connector.source.SplitsAssignment<>(assignment));
     }
-
-    @Override
-    public void addReader(int subtaskId) {
-        LOG.info("Reader {} registered", subtaskId);
-        registeredReaders.add(subtaskId);
-        // When reader registers, assign pending splits immediately if available
-        if (splitDiscoveryFinished && !pendingSplits.isEmpty()) {
-            assignSplitToReader(subtaskId);
-        }
-    }
-
-    @Override
-    public LanceEnumeratorState snapshotState(long checkpointId) throws Exception {
-        LOG.debug("Checkpoint {} snapshot, pending Splits: {}", checkpointId, pendingSplits.size());
-        return new LanceEnumeratorState(new ArrayList<>(pendingSplits));
-    }
-
-    @Override
-    public void close() throws IOException {
-        LOG.info("Closing LanceSplitEnumerator");
-    }
-
-    /**
-     * Assign pending Splits to all registered readers.
-     */
-    private void assignPendingSplits() {
-        // Only assign Splits to registered readers
-        for (Integer readerId : registeredReaders) {
-            if (pendingSplits.isEmpty()) {
-                break;
-            }
-            assignSplitToReader(readerId);
-        }
-    }
-
-    /**
-     * Assign a single Split to the specified reader.
-     */
-    private void assignSplitToReader(int subtaskId) {
-        if (pendingSplits.isEmpty()) {
-            if (splitDiscoveryFinished) {
-                context.signalNoMoreSplits(subtaskId);
-            }
-            return;
-        }
-
-        LanceSourceSplit split = pendingSplits.poll();
-        if (split != null) {
-            Map<Integer, List<LanceSourceSplit>> assignment = new HashMap<>();
-            List<LanceSourceSplit> splitList = new ArrayList<>();
-            splitList.add(split);
-            assignment.put(subtaskId, splitList);
-
-            LOG.info("Assigning Split {} to subtask {}", split.splitId(), subtaskId);
-            context.assignSplits(new org.apache.flink.api.connector.source.SplitsAssignment<>(assignment));
-        }
-    }
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/source/LanceSplitEnumerator.java
+++ b/src/main/java/org/apache/flink/connector/lance/source/LanceSplitEnumerator.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.lance.source;
+
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.connector.lance.config.LanceOptions;
+
+import com.lancedb.lance.Dataset;
+import com.lancedb.lance.Fragment;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+
+/**
+ * Split coordinator for Lance Source.
+ *
+ * <p>Discovers all Fragments in a Lance Dataset and assigns them as Splits to SourceReaders.
+ * Similar to the SplitManager role in Trino.
+ *
+ * <p>Main responsibilities:
+ * <ul>
+ *   <li>Open Dataset and enumerate all Fragments</li>
+ *   <li>Wrap Fragments as {@link LanceSourceSplit}</li>
+ *   <li>Respond to SourceReader split requests and assign on demand</li>
+ *   <li>Support checkpoint and recovery</li>
+ * </ul>
+ */
+public class LanceSplitEnumerator implements SplitEnumerator<LanceSourceSplit, LanceEnumeratorState> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LanceSplitEnumerator.class);
+
+    private final SplitEnumeratorContext<LanceSourceSplit> context;
+    private final LanceOptions options;
+
+    /** Queue of pending Splits to be assigned */
+    private final Queue<LanceSourceSplit> pendingSplits;
+
+    /** Set of registered reader IDs */
+    private final java.util.Set<Integer> registeredReaders;
+
+    /** Whether split discovery has finished */
+    private boolean splitDiscoveryFinished;
+
+    /**
+     * Create a new LanceSplitEnumerator.
+     *
+     * @param context Enumerator context
+     * @param options Lance configuration
+     */
+    public LanceSplitEnumerator(
+            SplitEnumeratorContext<LanceSourceSplit> context,
+            LanceOptions options) {
+        this(context, options, new ArrayList<>());
+    }
+
+    /**
+     * Create a LanceSplitEnumerator restored from checkpoint.
+     *
+     * @param context       Enumerator context
+     * @param options       Lance configuration
+     * @param pendingSplits Recovered pending Splits
+     */
+    public LanceSplitEnumerator(
+            SplitEnumeratorContext<LanceSourceSplit> context,
+            LanceOptions options,
+            Collection<LanceSourceSplit> pendingSplits) {
+        this.context = context;
+        this.options = options;
+        this.pendingSplits = new ArrayDeque<>(pendingSplits);
+        this.registeredReaders = new java.util.HashSet<>();
+        this.splitDiscoveryFinished = !pendingSplits.isEmpty();
+    }
+
+    @Override
+    public void start() {
+        LOG.info("Starting LanceSplitEnumerator, dataset path: {}", options.getPath());
+        if (!splitDiscoveryFinished) {
+            context.callAsync(this::discoverSplits, this::handleSplitDiscovery);
+        }
+    }
+
+    /**
+     * Discover all Splits (executed in async thread).
+     */
+    private List<LanceSourceSplit> discoverSplits() {
+        LOG.info("Starting to discover Lance Dataset Fragments...");
+
+        String datasetPath = options.getPath();
+        if (datasetPath == null || datasetPath.isEmpty()) {
+            throw new RuntimeException("Lance dataset path must not be empty");
+        }
+
+        BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        try {
+            Dataset dataset = Dataset.open(datasetPath, allocator);
+            try {
+                List<Fragment> fragments = dataset.getFragments();
+                List<LanceSourceSplit> splits = new ArrayList<>(fragments.size());
+
+                for (Fragment fragment : fragments) {
+                    long rowCount = fragment.countRows();
+                    splits.add(new LanceSourceSplit(fragment.getId(), datasetPath, rowCount));
+                }
+
+                LOG.info("Discovered {} Fragments, total rows: {}",
+                        splits.size(),
+                        splits.stream().mapToLong(LanceSourceSplit::getRowCount).sum());
+
+                return splits;
+            } finally {
+                dataset.close();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to open Lance Dataset: " + datasetPath, e);
+        } finally {
+            allocator.close();
+        }
+    }
+
+    /**
+     * Handle split discovery result (executed in main thread).
+     */
+    private void handleSplitDiscovery(List<LanceSourceSplit> splits, Throwable error) {
+        if (error != null) {
+            LOG.error("Error during split discovery", error);
+            throw new RuntimeException("Split discovery failed", error);
+        }
+
+        pendingSplits.addAll(splits);
+        splitDiscoveryFinished = true;
+
+        LOG.info("Split discovery completed, {} pending Splits", pendingSplits.size());
+
+        // Assign Splits to all registered readers
+        assignPendingSplits();
+    }
+
+    @Override
+    public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
+        LOG.debug("Received split request from subtask {}", subtaskId);
+
+        if (!pendingSplits.isEmpty()) {
+            LanceSourceSplit split = pendingSplits.poll();
+            if (split != null) {
+                LOG.info("Assigning Split {} to subtask {}", split.splitId(), subtaskId);
+                List<LanceSourceSplit> assignment = new ArrayList<>();
+                assignment.add(split);
+                context.assignSplits(new org.apache.flink.api.connector.source.SplitsAssignment<>(
+                        java.util.Collections.singletonMap(subtaskId, assignment)));
+            }
+        } else if (splitDiscoveryFinished) {
+            // All Splits have been assigned, notify Reader that there are no more Splits
+            LOG.info("All Splits assigned, notifying subtask {} no more Splits", subtaskId);
+            context.signalNoMoreSplits(subtaskId);
+        }
+        // If split discovery hasn't finished yet, do nothing; splits will be assigned after discovery
+    }
+
+    @Override
+    public void addSplitsBack(List<LanceSourceSplit> splits, int subtaskId) {
+        LOG.info("Subtask {} returned {} Splits", subtaskId, splits.size());
+        pendingSplits.addAll(splits);
+    }
+
+    @Override
+    public void addReader(int subtaskId) {
+        LOG.info("Reader {} registered", subtaskId);
+        registeredReaders.add(subtaskId);
+        // When reader registers, assign pending splits immediately if available
+        if (splitDiscoveryFinished && !pendingSplits.isEmpty()) {
+            assignSplitToReader(subtaskId);
+        }
+    }
+
+    @Override
+    public LanceEnumeratorState snapshotState(long checkpointId) throws Exception {
+        LOG.debug("Checkpoint {} snapshot, pending Splits: {}", checkpointId, pendingSplits.size());
+        return new LanceEnumeratorState(new ArrayList<>(pendingSplits));
+    }
+
+    @Override
+    public void close() throws IOException {
+        LOG.info("Closing LanceSplitEnumerator");
+    }
+
+    /**
+     * Assign pending Splits to all registered readers.
+     */
+    private void assignPendingSplits() {
+        // Only assign Splits to registered readers
+        for (Integer readerId : registeredReaders) {
+            if (pendingSplits.isEmpty()) {
+                break;
+            }
+            assignSplitToReader(readerId);
+        }
+    }
+
+    /**
+     * Assign a single Split to the specified reader.
+     */
+    private void assignSplitToReader(int subtaskId) {
+        if (pendingSplits.isEmpty()) {
+            if (splitDiscoveryFinished) {
+                context.signalNoMoreSplits(subtaskId);
+            }
+            return;
+        }
+
+        LanceSourceSplit split = pendingSplits.poll();
+        if (split != null) {
+            Map<Integer, List<LanceSourceSplit>> assignment = new HashMap<>();
+            List<LanceSourceSplit> splitList = new ArrayList<>();
+            splitList.add(split);
+            assignment.put(subtaskId, splitList);
+
+            LOG.info("Assigning Split {} to subtask {}", split.splitId(), subtaskId);
+            context.assignSplits(new org.apache.flink.api.connector.source.SplitsAssignment<>(assignment));
+        }
+    }
+}

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceCatalog.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceCatalog.java
@@ -19,7 +19,6 @@
 package org.apache.flink.connector.lance.table;
 
 import org.apache.flink.connector.lance.converter.LanceTypeConverter;
-import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.catalog.AbstractCatalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
@@ -30,7 +29,6 @@ import org.apache.flink.table.catalog.CatalogPartition;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectPath;
-import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
@@ -56,14 +54,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -72,10 +68,10 @@ import java.util.stream.Collectors;
 
 /**
  * Lance Catalog implementation.
- * 
+ *
  * <p>Implements Flink Catalog interface, supports managing Lance datasets as Flink tables.
  * Supports local file system and S3 protocol object storage.
- * 
+ *
  * <p>Usage example (local path):
  * <pre>{@code
  * CREATE CATALOG lance_catalog WITH (
@@ -84,7 +80,7 @@ import java.util.stream.Collectors;
  *     'default-database' = 'default'
  * );
  * }</pre>
- * 
+ *
  * <p>Usage example (S3 path):
  * <pre>{@code
  * CREATE CATALOG lance_s3_catalog WITH (
@@ -107,7 +103,7 @@ public class LanceCatalog extends AbstractCatalog {
     private final Map<String, String> storageOptions;
     private final boolean isRemoteStorage;
     private transient BufferAllocator allocator;
-    
+
     // Cache known databases and tables for remote storage
     private final Set<String> knownDatabases = ConcurrentHashMap.newKeySet();
     private final Set<String> knownTables = ConcurrentHashMap.newKeySet();
@@ -146,9 +142,9 @@ public class LanceCatalog extends AbstractCatalog {
             return false;
         }
         String lowerPath = path.toLowerCase();
-        return lowerPath.startsWith("s3://") || 
-               lowerPath.startsWith("s3a://") || 
-               lowerPath.startsWith("gs://") || 
+        return lowerPath.startsWith("s3://") ||
+               lowerPath.startsWith("s3a://") ||
+               lowerPath.startsWith("gs://") ||
                lowerPath.startsWith("az://") ||
                lowerPath.startsWith("https://") ||
                lowerPath.startsWith("http://");
@@ -170,10 +166,12 @@ public class LanceCatalog extends AbstractCatalog {
 
     @Override
     public void open() throws CatalogException {
-        LOG.info("Opening Lance Catalog: {}, warehouse path: {}, remote storage: {}", getName(), warehouse, isRemoteStorage);
-        
+        LOG.info("Opening Lance Catalog: {}, warehouse path: {},"
+                        + " remote storage: {}",
+                getName(), warehouse, isRemoteStorage);
+
         this.allocator = new RootAllocator(Long.MAX_VALUE);
-        
+
         if (isRemoteStorage) {
             // Remote storage: initialize default database record
             knownDatabases.add(getDefaultDatabase());
@@ -188,7 +186,7 @@ public class LanceCatalog extends AbstractCatalog {
                     throw new CatalogException("Cannot create warehouse directory: " + warehouse, e);
                 }
             }
-            
+
             // Ensure default database exists
             Path defaultDbPath = warehousePath.resolve(getDefaultDatabase());
             if (!Files.exists(defaultDbPath)) {
@@ -204,7 +202,7 @@ public class LanceCatalog extends AbstractCatalog {
     @Override
     public void close() throws CatalogException {
         LOG.info("Closing Lance Catalog: {}", getName());
-        
+
         if (allocator != null) {
             try {
                 allocator.close();
@@ -213,7 +211,7 @@ public class LanceCatalog extends AbstractCatalog {
             }
             allocator = null;
         }
-        
+
         knownDatabases.clear();
         knownTables.clear();
     }
@@ -226,13 +224,13 @@ public class LanceCatalog extends AbstractCatalog {
             // Remote storage: return known database list
             return new ArrayList<>(knownDatabases);
         }
-        
+
         try {
             Path warehousePath = Paths.get(warehouse);
             if (!Files.exists(warehousePath)) {
                 return Collections.emptyList();
             }
-            
+
             return Files.list(warehousePath)
                     .filter(Files::isDirectory)
                     .map(path -> path.getFileName().toString())
@@ -247,7 +245,7 @@ public class LanceCatalog extends AbstractCatalog {
         if (!databaseExists(databaseName)) {
             throw new DatabaseNotExistException(getName(), databaseName);
         }
-        
+
         return new CatalogDatabaseImpl(Collections.emptyMap(), "Lance Database: " + databaseName);
     }
 
@@ -267,7 +265,7 @@ public class LanceCatalog extends AbstractCatalog {
                 return false;
             }
         }
-        
+
         Path dbPath = Paths.get(warehouse, databaseName);
         return Files.exists(dbPath) && Files.isDirectory(dbPath);
     }
@@ -287,14 +285,14 @@ public class LanceCatalog extends AbstractCatalog {
             LOG.info("Registered remote database: {}", name);
             return;
         }
-        
+
         if (databaseExists(name)) {
             if (!ignoreIfExists) {
                 throw new DatabaseAlreadyExistException(getName(), name);
             }
             return;
         }
-        
+
         Path dbPath = Paths.get(warehouse, name);
         try {
             Files.createDirectories(dbPath);
@@ -315,13 +313,13 @@ public class LanceCatalog extends AbstractCatalog {
                 }
                 return;
             }
-            
+
             // Check if has tables
             List<String> tables = listTables(name);
             if (!tables.isEmpty() && !cascade) {
                 throw new DatabaseNotEmptyException(getName(), name);
             }
-            
+
             // If cascade, delete all tables
             if (cascade) {
                 for (String table : tables) {
@@ -332,26 +330,26 @@ public class LanceCatalog extends AbstractCatalog {
                     }
                 }
             }
-            
+
             knownDatabases.remove(name);
             LOG.info("Removed remote database record: {}", name);
             return;
         }
-        
+
         if (!databaseExists(name)) {
             if (!ignoreIfNotExists) {
                 throw new DatabaseNotExistException(getName(), name);
             }
             return;
         }
-        
+
         Path dbPath = Paths.get(warehouse, name);
         try {
             List<String> tables = listTables(name);
             if (!tables.isEmpty() && !cascade) {
                 throw new DatabaseNotEmptyException(getName(), name);
             }
-            
+
             // Delete database directory
             deleteDirectory(dbPath);
             LOG.info("Deleted database: {}", name);
@@ -380,7 +378,7 @@ public class LanceCatalog extends AbstractCatalog {
         if (!databaseExists(databaseName)) {
             throw new DatabaseNotExistException(getName(), databaseName);
         }
-        
+
         if (isRemoteStorage) {
             // Remote storage: return known table list
             String prefix = databaseName + "/";
@@ -389,7 +387,7 @@ public class LanceCatalog extends AbstractCatalog {
                     .map(t -> t.substring(prefix.length()))
                     .collect(Collectors.toList());
         }
-        
+
         try {
             Path dbPath = Paths.get(warehouse, databaseName);
             return Files.list(dbPath)
@@ -413,37 +411,37 @@ public class LanceCatalog extends AbstractCatalog {
         if (!tableExists(tablePath)) {
             throw new TableNotExistException(getName(), tablePath);
         }
-        
+
         String datasetPath = getDatasetPath(tablePath);
-        
+
         try {
             // For remote storage, configure S3 credentials via environment variables
             if (isRemoteStorage) {
                 configureStorageEnvironment();
             }
             Dataset dataset = Dataset.open(datasetPath, allocator);
-            
+
             try {
                 // Infer Flink Schema from Lance Schema
                 org.apache.arrow.vector.types.pojo.Schema arrowSchema = dataset.getSchema();
                 RowType rowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
-                
+
                 // Build CatalogTable
                 Schema.Builder schemaBuilder = Schema.newBuilder();
                 for (RowType.RowField field : rowType.getFields()) {
                     DataType dataType = LanceTypeConverter.toDataType(field.getType());
                     schemaBuilder.column(field.getName(), dataType);
                 }
-                
+
                 Map<String, String> options = new HashMap<>();
                 options.put("connector", LanceDynamicTableFactory.IDENTIFIER);
                 options.put("path", datasetPath);
-                
+
                 // If remote storage, add storage config to table options
                 if (isRemoteStorage) {
                     options.putAll(getStorageOptionsForTable());
                 }
-                
+
                 return CatalogTable.of(
                         schemaBuilder.build(),
                         "Lance Table: " + tablePath.getFullName(),
@@ -463,16 +461,16 @@ public class LanceCatalog extends AbstractCatalog {
         if (!databaseExists(tablePath.getDatabaseName())) {
             return false;
         }
-        
+
         String datasetPath = getDatasetPath(tablePath);
-        
+
         if (isRemoteStorage) {
             // Remote storage: check known tables or try opening dataset
             String tableKey = tablePath.getDatabaseName() + "/" + tablePath.getObjectName();
             if (knownTables.contains(tableKey)) {
                 return true;
             }
-            
+
             // Try to open dataset to verify existence
             try {
                 configureStorageEnvironment();
@@ -485,11 +483,11 @@ public class LanceCatalog extends AbstractCatalog {
                 return false;
             }
         }
-        
+
         Path path = Paths.get(datasetPath);
-        
+
         // Check if valid Lance dataset
-        return Files.exists(path) && Files.isDirectory(path) && 
+        return Files.exists(path) && Files.isDirectory(path) &&
                Files.exists(path.resolve("_versions"));
     }
 
@@ -502,18 +500,21 @@ public class LanceCatalog extends AbstractCatalog {
             }
             return;
         }
-        
+
         String datasetPath = getDatasetPath(tablePath);
-        
+
         if (isRemoteStorage) {
             // Remote storage: Lance Java SDK does not directly support deleting remote datasets
             // Only remove record here, actual deletion requires cloud storage API
             String tableKey = tablePath.getDatabaseName() + "/" + tablePath.getObjectName();
             knownTables.remove(tableKey);
-            LOG.warn("Remote storage mode, table record removed, but actual data needs manual deletion from storage: {}", datasetPath);
+            LOG.warn("Remote storage mode, table record removed,"
+                            + " but actual data needs manual deletion"
+                            + " from storage: {}",
+                    datasetPath);
             return;
         }
-        
+
         try {
             deleteDirectory(Paths.get(datasetPath));
             LOG.info("Deleted table: {}", tablePath);
@@ -531,20 +532,20 @@ public class LanceCatalog extends AbstractCatalog {
             }
             return;
         }
-        
+
         ObjectPath newTablePath = new ObjectPath(tablePath.getDatabaseName(), newTableName);
         if (tableExists(newTablePath)) {
             throw new TableAlreadyExistException(getName(), newTablePath);
         }
-        
+
         if (isRemoteStorage) {
             // Remote storage: does not support renaming
             throw new CatalogException("Remote storage mode does not support renaming tables");
         }
-        
+
         String oldPath = getDatasetPath(tablePath);
         String newPath = getDatasetPath(newTablePath);
-        
+
         try {
             Files.move(Paths.get(oldPath), Paths.get(newPath));
             LOG.info("Renamed table: {} -> {}", tablePath, newTablePath);
@@ -559,20 +560,20 @@ public class LanceCatalog extends AbstractCatalog {
         if (!databaseExists(tablePath.getDatabaseName())) {
             throw new DatabaseNotExistException(getName(), tablePath.getDatabaseName());
         }
-        
+
         if (tableExists(tablePath)) {
             if (!ignoreIfExists) {
                 throw new TableAlreadyExistException(getName(), tablePath);
             }
             return;
         }
-        
+
         if (isRemoteStorage) {
             // Remote storage: record table info, actual creation on write
             String tableKey = tablePath.getDatabaseName() + "/" + tablePath.getObjectName();
             knownTables.add(tableKey);
         }
-        
+
         // Actual table creation happens on first write
         // Only record table metadata here
         LOG.info("Registered table: {} (actual dataset will be created on write)", tablePath);
@@ -587,7 +588,7 @@ public class LanceCatalog extends AbstractCatalog {
             }
             return;
         }
-        
+
         // Lance does not support modifying table structure
         throw new CatalogException("Lance Catalog does not support altering table structure");
     }
@@ -601,8 +602,13 @@ public class LanceCatalog extends AbstractCatalog {
     }
 
     @Override
-    public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
-            throws TableNotExistException, TableNotPartitionedException, PartitionSpecInvalidException, CatalogException {
+    public List<CatalogPartitionSpec> listPartitions(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec)
+            throws TableNotExistException,
+                    TableNotPartitionedException,
+                    PartitionSpecInvalidException,
+                    CatalogException {
         return Collections.emptyList();
     }
 
@@ -625,8 +631,16 @@ public class LanceCatalog extends AbstractCatalog {
     }
 
     @Override
-    public void createPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogPartition partition, boolean ignoreIfExists)
-            throws TableNotExistException, TableNotPartitionedException, PartitionSpecInvalidException, PartitionAlreadyExistsException, CatalogException {
+    public void createPartition(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogPartition partition,
+            boolean ignoreIfExists)
+            throws TableNotExistException,
+                    TableNotPartitionedException,
+                    PartitionSpecInvalidException,
+                    PartitionAlreadyExistsException,
+                    CatalogException {
         throw new CatalogException("Lance Catalog does not support partition operations");
     }
 
@@ -637,8 +651,13 @@ public class LanceCatalog extends AbstractCatalog {
     }
 
     @Override
-    public void alterPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogPartition newPartition, boolean ignoreIfNotExists)
-            throws PartitionNotExistException, CatalogException {
+    public void alterPartition(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogPartition newPartition,
+            boolean ignoreIfNotExists)
+            throws PartitionNotExistException,
+                    CatalogException {
         throw new CatalogException("Lance Catalog does not support partition operations");
     }
 
@@ -698,32 +717,53 @@ public class LanceCatalog extends AbstractCatalog {
     }
 
     @Override
-    public CatalogColumnStatistics getPartitionColumnStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
-            throws PartitionNotExistException, CatalogException {
+    public CatalogColumnStatistics getPartitionColumnStatistics(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec)
+            throws PartitionNotExistException,
+                    CatalogException {
         return CatalogColumnStatistics.UNKNOWN;
     }
 
     @Override
-    public void alterTableStatistics(ObjectPath tablePath, CatalogTableStatistics tableStatistics, boolean ignoreIfNotExists)
-            throws TableNotExistException, CatalogException {
+    public void alterTableStatistics(
+            ObjectPath tablePath,
+            CatalogTableStatistics tableStatistics,
+            boolean ignoreIfNotExists)
+            throws TableNotExistException,
+                    CatalogException {
         // Not supported
     }
 
     @Override
-    public void alterTableColumnStatistics(ObjectPath tablePath, CatalogColumnStatistics columnStatistics, boolean ignoreIfNotExists)
-            throws TableNotExistException, CatalogException {
+    public void alterTableColumnStatistics(
+            ObjectPath tablePath,
+            CatalogColumnStatistics columnStatistics,
+            boolean ignoreIfNotExists)
+            throws TableNotExistException,
+                    CatalogException {
         // Not supported
     }
 
     @Override
-    public void alterPartitionStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogTableStatistics partitionStatistics, boolean ignoreIfNotExists)
-            throws PartitionNotExistException, CatalogException {
+    public void alterPartitionStatistics(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogTableStatistics partitionStatistics,
+            boolean ignoreIfNotExists)
+            throws PartitionNotExistException,
+                    CatalogException {
         // Not supported
     }
 
     @Override
-    public void alterPartitionColumnStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, CatalogColumnStatistics columnStatistics, boolean ignoreIfNotExists)
-            throws PartitionNotExistException, CatalogException {
+    public void alterPartitionColumnStatistics(
+            ObjectPath tablePath,
+            CatalogPartitionSpec partitionSpec,
+            CatalogColumnStatistics columnStatistics,
+            boolean ignoreIfNotExists)
+            throws PartitionNotExistException,
+                    CatalogException {
         // Not supported
     }
 
@@ -731,7 +771,7 @@ public class LanceCatalog extends AbstractCatalog {
 
     /**
      * Configure storage environment variables (for S3 and other remote storage)
-     * 
+     *
      * <p>Lance configures S3 credentials via environment variables:
      * <ul>
      *   <li>AWS_ACCESS_KEY_ID - AWS access key ID</li>
@@ -744,11 +784,11 @@ public class LanceCatalog extends AbstractCatalog {
         if (!isRemoteStorage || storageOptions.isEmpty()) {
             return;
         }
-        
+
         // Set environment variables for Lance SDK object_store configuration
         // Note: Since Java cannot directly modify environment variables, system properties are used as fallback
         // Lance's Rust backend will read these environment variables
-        
+
         if (storageOptions.containsKey("aws_access_key_id")) {
             System.setProperty("AWS_ACCESS_KEY_ID", storageOptions.get("aws_access_key_id"));
         }
@@ -762,13 +802,13 @@ public class LanceCatalog extends AbstractCatalog {
             System.setProperty("AWS_ENDPOINT", storageOptions.get("aws_endpoint"));
         }
         if (storageOptions.containsKey("aws_virtual_hosted_style_request")) {
-            System.setProperty("AWS_VIRTUAL_HOSTED_STYLE_REQUEST", 
+            System.setProperty("AWS_VIRTUAL_HOSTED_STYLE_REQUEST",
                     storageOptions.get("aws_virtual_hosted_style_request"));
         }
         if (storageOptions.containsKey("allow_http")) {
             System.setProperty("AWS_ALLOW_HTTP", storageOptions.get("allow_http"));
         }
-        
+
         LOG.debug("Configured remote storage environment variables");
     }
 
@@ -797,7 +837,7 @@ public class LanceCatalog extends AbstractCatalog {
      */
     private Map<String, String> getStorageOptionsForTable() {
         Map<String, String> options = new HashMap<>();
-        
+
         // Convert storage options to table config format
         if (storageOptions.containsKey("aws_access_key_id")) {
             options.put("s3-access-key", storageOptions.get("aws_access_key_id"));
@@ -811,7 +851,7 @@ public class LanceCatalog extends AbstractCatalog {
         if (storageOptions.containsKey("aws_endpoint")) {
             options.put("s3-endpoint", storageOptions.get("aws_endpoint"));
         }
-        
+
         return options;
     }
 

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceCatalog.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceCatalog.java
@@ -14,6 +14,7 @@
 package org.apache.flink.connector.lance.table;
 
 import com.lancedb.lance.Dataset;
+import com.lancedb.lance.WriteParams;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.flink.connector.lance.catalog.LanceCatalogPathResolver;
 import org.apache.flink.connector.lance.catalog.LanceStorageProvider;
@@ -53,10 +54,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Lance Catalog implementation.
@@ -104,6 +107,12 @@ public class LanceCatalog extends AbstractCatalog {
   private final Map<String, String> storageOptions;
   private final LanceStorageProvider storageProvider;
   private transient BufferAllocator allocator;
+
+  /**
+   * In-memory cache of user-provided table options from CREATE TABLE. Key: "database/table", Value:
+   * user options map.
+   */
+  private final Map<String, Map<String, String>> tableOptionsCache = new ConcurrentHashMap<>();
 
   /**
    * Create LanceCatalog (local storage)
@@ -327,6 +336,18 @@ public class LanceCatalog extends AbstractCatalog {
           options.putAll(StorageEnvironmentManager.toTableOptions(storageOptions));
         }
 
+        // Merge user-provided table options from CREATE TABLE
+        String tableKey = tablePath.getDatabaseName() + "/" + tablePath.getObjectName();
+        Map<String, String> cachedOptions = tableOptionsCache.get(tableKey);
+        if (cachedOptions != null) {
+          for (Map.Entry<String, String> entry : cachedOptions.entrySet()) {
+            // Do not override connector and path
+            if (!"connector".equals(entry.getKey()) && !"path".equals(entry.getKey())) {
+              options.put(entry.getKey(), entry.getValue());
+            }
+          }
+        }
+
         return CatalogTable.of(
             schemaBuilder.build(),
             "Lance Table: " + tablePath.getFullName(),
@@ -407,10 +428,47 @@ public class LanceCatalog extends AbstractCatalog {
       return;
     }
 
-    storageProvider.registerTable(tablePath.getDatabaseName(), tablePath.getObjectName());
+    String datasetPath =
+        pathResolver.resolveTablePath(tablePath.getDatabaseName(), tablePath.getObjectName());
 
-    // Actual table creation happens on first write
-    LOG.info("Registered table: {} (actual dataset will be created on write)", tablePath);
+    try {
+      storageProvider.configureEnvironment();
+
+      // Extract physical columns from the table schema and build Arrow Schema
+      Schema tableSchema = table.getUnresolvedSchema();
+      List<Schema.UnresolvedColumn> columns = tableSchema.getColumns();
+      List<RowType.RowField> rowFields = new ArrayList<>();
+      for (Schema.UnresolvedColumn column : columns) {
+        if (column instanceof Schema.UnresolvedPhysicalColumn) {
+          Schema.UnresolvedPhysicalColumn physCol = (Schema.UnresolvedPhysicalColumn) column;
+          DataType dataType = (DataType) physCol.getDataType();
+          rowFields.add(new RowType.RowField(physCol.getName(), dataType.getLogicalType()));
+        }
+      }
+
+      if (!rowFields.isEmpty()) {
+        RowType rowType = new RowType(rowFields);
+        org.apache.arrow.vector.types.pojo.Schema arrowSchema =
+            LanceTypeConverter.toArrowSchema(rowType);
+
+        // Create an empty dataset with just the schema using Dataset.create()
+        WriteParams writeParams = new WriteParams.Builder().build();
+        Dataset dataset = Dataset.create(allocator, datasetPath, arrowSchema, writeParams);
+        dataset.close();
+      }
+
+      // Cache user-provided table options
+      if (table.getOptions() != null && !table.getOptions().isEmpty()) {
+        String tableKey = tablePath.getDatabaseName() + "/" + tablePath.getObjectName();
+        tableOptionsCache.put(tableKey, new HashMap<>(table.getOptions()));
+      }
+
+      storageProvider.registerTable(tablePath.getDatabaseName(), tablePath.getObjectName());
+      LOG.info("Created table with empty dataset: {}", tablePath);
+
+    } catch (Exception e) {
+      throw new CatalogException("Failed to create table: " + tablePath, e);
+    }
   }
 
   @Override

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceCatalog.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceCatalog.java
@@ -16,6 +16,7 @@ package org.apache.flink.connector.lance.table;
 import com.lancedb.lance.Dataset;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.flink.connector.lance.config.LanceDatasetFactory;
 import org.apache.flink.connector.lance.converter.LanceTypeConverter;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.catalog.AbstractCatalog;
@@ -420,7 +421,7 @@ public class LanceCatalog extends AbstractCatalog {
       if (isRemoteStorage) {
         configureStorageEnvironment();
       }
-      Dataset dataset = Dataset.open(datasetPath, allocator);
+      Dataset dataset = LanceDatasetFactory.open(datasetPath, allocator);
 
       try {
         // Infer Flink Schema from Lance Schema
@@ -474,7 +475,7 @@ public class LanceCatalog extends AbstractCatalog {
       // Try to open dataset to verify existence
       try {
         configureStorageEnvironment();
-        Dataset dataset = Dataset.open(datasetPath, allocator);
+        Dataset dataset = LanceDatasetFactory.open(datasetPath, allocator);
         dataset.close();
         knownTables.add(tableKey);
         return true;

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceCatalog.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceCatalog.java
@@ -15,7 +15,11 @@ package org.apache.flink.connector.lance.table;
 
 import com.lancedb.lance.Dataset;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
+import org.apache.flink.connector.lance.catalog.LanceCatalogPathResolver;
+import org.apache.flink.connector.lance.catalog.LanceStorageProvider;
+import org.apache.flink.connector.lance.catalog.LocalStorageProvider;
+import org.apache.flink.connector.lance.catalog.RemoteStorageProvider;
+import org.apache.flink.connector.lance.catalog.StorageEnvironmentManager;
 import org.apache.flink.connector.lance.config.LanceDatasetFactory;
 import org.apache.flink.connector.lance.converter.LanceTypeConverter;
 import org.apache.flink.table.api.Schema;
@@ -49,23 +53,23 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 /**
  * Lance Catalog implementation.
  *
  * <p>Implements Flink Catalog interface, supports managing Lance datasets as Flink tables. Supports
  * local file system and S3 protocol object storage.
+ *
+ * <p>Storage-specific logic is delegated to {@link LanceStorageProvider} implementations:
+ *
+ * <ul>
+ *   <li>{@link LocalStorageProvider} — Local filesystem
+ *   <li>{@link RemoteStorageProvider} — S3/GCS/Azure object storage
+ * </ul>
  *
  * <p>Usage example (local path):
  *
@@ -96,14 +100,10 @@ public class LanceCatalog extends AbstractCatalog {
 
   public static final String DEFAULT_DATABASE = "default";
 
-  private final String warehouse;
+  private final LanceCatalogPathResolver pathResolver;
   private final Map<String, String> storageOptions;
-  private final boolean isRemoteStorage;
+  private final LanceStorageProvider storageProvider;
   private transient BufferAllocator allocator;
-
-  // Cache known databases and tables for remote storage
-  private final Set<String> knownDatabases = ConcurrentHashMap.newKeySet();
-  private final Set<String> knownTables = ConcurrentHashMap.newKeySet();
 
   /**
    * Create LanceCatalog (local storage)
@@ -127,73 +127,40 @@ public class LanceCatalog extends AbstractCatalog {
   public LanceCatalog(
       String name, String defaultDatabase, String warehouse, Map<String, String> storageOptions) {
     super(name, defaultDatabase);
-    this.warehouse = normalizeWarehousePath(warehouse);
+    this.pathResolver = new LanceCatalogPathResolver(warehouse);
     this.storageOptions =
         storageOptions != null ? new HashMap<>(storageOptions) : Collections.emptyMap();
-    this.isRemoteStorage = isRemotePath(warehouse);
+    this.storageProvider = createStorageProvider();
   }
 
-  /** Check if path is remote storage path */
-  private boolean isRemotePath(String path) {
-    if (path == null) {
-      return false;
+  /** Create the appropriate storage provider based on the warehouse path. */
+  private LanceStorageProvider createStorageProvider() {
+    if (pathResolver.isRemote()) {
+      return new RemoteStorageProvider(pathResolver, storageOptions);
+    } else {
+      return new LocalStorageProvider(pathResolver);
     }
-    String lowerPath = path.toLowerCase();
-    return lowerPath.startsWith("s3://")
-        || lowerPath.startsWith("s3a://")
-        || lowerPath.startsWith("gs://")
-        || lowerPath.startsWith("az://")
-        || lowerPath.startsWith("https://")
-        || lowerPath.startsWith("http://");
-  }
-
-  /** Normalize warehouse path */
-  private String normalizeWarehousePath(String path) {
-    if (path == null) {
-      return null;
-    }
-    // Remove trailing slashes
-    while (path.endsWith("/") && path.length() > 1) {
-      path = path.substring(0, path.length() - 1);
-    }
-    return path;
   }
 
   @Override
   public void open() throws CatalogException {
     LOG.info(
-        "Opening Lance Catalog: {}, warehouse path: {}," + " remote storage: {}",
+        "Opening Lance Catalog: {}, warehouse path: {}, remote storage: {}",
         getName(),
-        warehouse,
-        isRemoteStorage);
+        pathResolver.getWarehouse(),
+        pathResolver.isRemote());
 
-    this.allocator = new RootAllocator(Long.MAX_VALUE);
+    this.allocator = LanceDatasetFactory.createAllocator();
 
-    if (isRemoteStorage) {
-      // Remote storage: initialize default database record
-      knownDatabases.add(getDefaultDatabase());
-      LOG.info("Remote storage mode enabled, storage config count: {}", storageOptions.size());
-    } else {
-      // Local storage: ensure warehouse directory exists
-      Path warehousePath = Paths.get(warehouse);
-      if (!Files.exists(warehousePath)) {
-        try {
-          Files.createDirectories(warehousePath);
-        } catch (IOException e) {
-          throw new CatalogException("Cannot create warehouse directory: " + warehouse, e);
-        }
-      }
+    // For remote provider, set the allocator so it can probe dataset existence
+    if (storageProvider instanceof RemoteStorageProvider) {
+      ((RemoteStorageProvider) storageProvider).setAllocator(allocator);
+    }
 
-      // Ensure default database exists
-      Path defaultDbPath = warehousePath.resolve(getDefaultDatabase());
-      if (!Files.exists(defaultDbPath)) {
-        try {
-          Files.createDirectories(defaultDbPath);
-        } catch (IOException e) {
-          throw new CatalogException(
-              "Cannot create default database directory: " + defaultDbPath, e);
-        }
-      }
+    try {
+      storageProvider.initializeWarehouse(getDefaultDatabase());
+    } catch (IOException e) {
+      throw new CatalogException("Failed to initialize warehouse", e);
     }
   }
 
@@ -201,38 +168,20 @@ public class LanceCatalog extends AbstractCatalog {
   public void close() throws CatalogException {
     LOG.info("Closing Lance Catalog: {}", getName());
 
-    if (allocator != null) {
-      try {
-        allocator.close();
-      } catch (Exception e) {
-        LOG.warn("Failed to close allocator", e);
-      }
-      allocator = null;
-    }
+    LanceDatasetFactory.closeQuietly(allocator);
+    allocator = null;
 
-    knownDatabases.clear();
-    knownTables.clear();
+    if (storageProvider instanceof RemoteStorageProvider) {
+      ((RemoteStorageProvider) storageProvider).clear();
+    }
   }
 
   // ==================== Database Operations ====================
 
   @Override
   public List<String> listDatabases() throws CatalogException {
-    if (isRemoteStorage) {
-      // Remote storage: return known database list
-      return new ArrayList<>(knownDatabases);
-    }
-
     try {
-      Path warehousePath = Paths.get(warehouse);
-      if (!Files.exists(warehousePath)) {
-        return Collections.emptyList();
-      }
-
-      return Files.list(warehousePath)
-          .filter(Files::isDirectory)
-          .map(path -> path.getFileName().toString())
-          .collect(Collectors.toList());
+      return storageProvider.listDatabases();
     } catch (IOException e) {
       throw new CatalogException("Failed to list databases", e);
     }
@@ -250,41 +199,12 @@ public class LanceCatalog extends AbstractCatalog {
 
   @Override
   public boolean databaseExists(String databaseName) throws CatalogException {
-    if (isRemoteStorage) {
-      // Remote storage: check known databases or try listing tables to verify
-      if (knownDatabases.contains(databaseName)) {
-        return true;
-      }
-      // Try to confirm database exists by checking for tables
-      try {
-        String dbPath = getDatabasePath(databaseName);
-        // For remote storage, assume database always exists (actual table operations will verify)
-        return true;
-      } catch (Exception e) {
-        return false;
-      }
-    }
-
-    Path dbPath = Paths.get(warehouse, databaseName);
-    return Files.exists(dbPath) && Files.isDirectory(dbPath);
+    return storageProvider.databaseExists(databaseName);
   }
 
   @Override
   public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists)
       throws DatabaseAlreadyExistException, CatalogException {
-    if (isRemoteStorage) {
-      // Remote storage: only record database name, actual directory created when creating table
-      if (knownDatabases.contains(name)) {
-        if (!ignoreIfExists) {
-          throw new DatabaseAlreadyExistException(getName(), name);
-        }
-        return;
-      }
-      knownDatabases.add(name);
-      LOG.info("Registered remote database: {}", name);
-      return;
-    }
-
     if (databaseExists(name)) {
       if (!ignoreIfExists) {
         throw new DatabaseAlreadyExistException(getName(), name);
@@ -292,9 +212,8 @@ public class LanceCatalog extends AbstractCatalog {
       return;
     }
 
-    Path dbPath = Paths.get(warehouse, name);
     try {
-      Files.createDirectories(dbPath);
+      storageProvider.createDatabase(name);
       LOG.info("Created database: {}", name);
     } catch (IOException e) {
       throw new CatalogException("Failed to create database: " + name, e);
@@ -304,22 +223,20 @@ public class LanceCatalog extends AbstractCatalog {
   @Override
   public void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade)
       throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
-    if (isRemoteStorage) {
-      // Remote storage: remove database record
-      if (!knownDatabases.contains(name)) {
-        if (!ignoreIfNotExists) {
-          throw new DatabaseNotExistException(getName(), name);
-        }
-        return;
+    if (!databaseExists(name)) {
+      if (!ignoreIfNotExists) {
+        throw new DatabaseNotExistException(getName(), name);
       }
+      return;
+    }
 
-      // Check if has tables
+    try {
       List<String> tables = listTables(name);
       if (!tables.isEmpty() && !cascade) {
         throw new DatabaseNotEmptyException(getName(), name);
       }
 
-      // If cascade, delete all tables
+      // If cascade, delete all tables first
       if (cascade) {
         for (String table : tables) {
           try {
@@ -330,30 +247,12 @@ public class LanceCatalog extends AbstractCatalog {
         }
       }
 
-      knownDatabases.remove(name);
-      LOG.info("Removed remote database record: {}", name);
-      return;
-    }
-
-    if (!databaseExists(name)) {
-      if (!ignoreIfNotExists) {
-        throw new DatabaseNotExistException(getName(), name);
-      }
-      return;
-    }
-
-    Path dbPath = Paths.get(warehouse, name);
-    try {
-      List<String> tables = listTables(name);
-      if (!tables.isEmpty() && !cascade) {
-        throw new DatabaseNotEmptyException(getName(), name);
-      }
-
-      // Delete database directory
-      deleteDirectory(dbPath);
-      LOG.info("Deleted database: {}", name);
+      storageProvider.dropDatabase(name, cascade);
+      LOG.info("Dropped database: {}", name);
+    } catch (DatabaseNotEmptyException e) {
+      throw e;
     } catch (IOException e) {
-      throw new CatalogException("Failed to delete database: " + name, e);
+      throw new CatalogException("Failed to drop database: " + name, e);
     }
   }
 
@@ -379,22 +278,8 @@ public class LanceCatalog extends AbstractCatalog {
       throw new DatabaseNotExistException(getName(), databaseName);
     }
 
-    if (isRemoteStorage) {
-      // Remote storage: return known table list
-      String prefix = databaseName + "/";
-      return knownTables.stream()
-          .filter(t -> t.startsWith(prefix))
-          .map(t -> t.substring(prefix.length()))
-          .collect(Collectors.toList());
-    }
-
     try {
-      Path dbPath = Paths.get(warehouse, databaseName);
-      return Files.list(dbPath)
-          .filter(Files::isDirectory)
-          .filter(path -> Files.exists(path.resolve("_versions"))) // Lance dataset identifier
-          .map(path -> path.getFileName().toString())
-          .collect(Collectors.toList());
+      return storageProvider.listTables(databaseName);
     } catch (IOException e) {
       throw new CatalogException("Failed to list tables", e);
     }
@@ -414,13 +299,11 @@ public class LanceCatalog extends AbstractCatalog {
       throw new TableNotExistException(getName(), tablePath);
     }
 
-    String datasetPath = getDatasetPath(tablePath);
+    String datasetPath =
+        pathResolver.resolveTablePath(tablePath.getDatabaseName(), tablePath.getObjectName());
 
     try {
-      // For remote storage, configure S3 credentials via environment variables
-      if (isRemoteStorage) {
-        configureStorageEnvironment();
-      }
+      storageProvider.configureEnvironment();
       Dataset dataset = LanceDatasetFactory.open(datasetPath, allocator);
 
       try {
@@ -440,8 +323,8 @@ public class LanceCatalog extends AbstractCatalog {
         options.put("path", datasetPath);
 
         // If remote storage, add storage config to table options
-        if (isRemoteStorage) {
-          options.putAll(getStorageOptionsForTable());
+        if (pathResolver.isRemote()) {
+          options.putAll(StorageEnvironmentManager.toTableOptions(storageOptions));
         }
 
         return CatalogTable.of(
@@ -463,32 +346,7 @@ public class LanceCatalog extends AbstractCatalog {
       return false;
     }
 
-    String datasetPath = getDatasetPath(tablePath);
-
-    if (isRemoteStorage) {
-      // Remote storage: check known tables or try opening dataset
-      String tableKey = tablePath.getDatabaseName() + "/" + tablePath.getObjectName();
-      if (knownTables.contains(tableKey)) {
-        return true;
-      }
-
-      // Try to open dataset to verify existence
-      try {
-        configureStorageEnvironment();
-        Dataset dataset = LanceDatasetFactory.open(datasetPath, allocator);
-        dataset.close();
-        knownTables.add(tableKey);
-        return true;
-      } catch (Exception e) {
-        LOG.debug("Table does not exist or cannot be accessed: {}", datasetPath, e);
-        return false;
-      }
-    }
-
-    Path path = Paths.get(datasetPath);
-
-    // Check if valid Lance dataset
-    return Files.exists(path) && Files.isDirectory(path) && Files.exists(path.resolve("_versions"));
+    return storageProvider.tableExists(tablePath.getDatabaseName(), tablePath.getObjectName());
   }
 
   @Override
@@ -501,26 +359,11 @@ public class LanceCatalog extends AbstractCatalog {
       return;
     }
 
-    String datasetPath = getDatasetPath(tablePath);
-
-    if (isRemoteStorage) {
-      // Remote storage: Lance Java SDK does not directly support deleting remote datasets
-      // Only remove record here, actual deletion requires cloud storage API
-      String tableKey = tablePath.getDatabaseName() + "/" + tablePath.getObjectName();
-      knownTables.remove(tableKey);
-      LOG.warn(
-          "Remote storage mode, table record removed,"
-              + " but actual data needs manual deletion"
-              + " from storage: {}",
-          datasetPath);
-      return;
-    }
-
     try {
-      deleteDirectory(Paths.get(datasetPath));
-      LOG.info("Deleted table: {}", tablePath);
+      storageProvider.dropTable(tablePath.getDatabaseName(), tablePath.getObjectName());
+      LOG.info("Dropped table: {}", tablePath);
     } catch (IOException e) {
-      throw new CatalogException("Failed to delete table: " + tablePath, e);
+      throw new CatalogException("Failed to drop table: " + tablePath, e);
     }
   }
 
@@ -539,17 +382,12 @@ public class LanceCatalog extends AbstractCatalog {
       throw new TableAlreadyExistException(getName(), newTablePath);
     }
 
-    if (isRemoteStorage) {
-      // Remote storage: does not support renaming
-      throw new CatalogException("Remote storage mode does not support renaming tables");
-    }
-
-    String oldPath = getDatasetPath(tablePath);
-    String newPath = getDatasetPath(newTablePath);
-
     try {
-      Files.move(Paths.get(oldPath), Paths.get(newPath));
+      storageProvider.renameTable(
+          tablePath.getDatabaseName(), tablePath.getObjectName(), newTableName);
       LOG.info("Renamed table: {} -> {}", tablePath, newTablePath);
+    } catch (UnsupportedOperationException e) {
+      throw new CatalogException(e.getMessage());
     } catch (IOException e) {
       throw new CatalogException("Failed to rename table: " + tablePath, e);
     }
@@ -569,14 +407,9 @@ public class LanceCatalog extends AbstractCatalog {
       return;
     }
 
-    if (isRemoteStorage) {
-      // Remote storage: record table info, actual creation on write
-      String tableKey = tablePath.getDatabaseName() + "/" + tablePath.getObjectName();
-      knownTables.add(tableKey);
-    }
+    storageProvider.registerTable(tablePath.getDatabaseName(), tablePath.getObjectName());
 
     // Actual table creation happens on first write
-    // Only record table metadata here
     LOG.info("Registered table: {} (actual dataset will be created on write)", tablePath);
   }
 
@@ -764,110 +597,11 @@ public class LanceCatalog extends AbstractCatalog {
     // Not supported
   }
 
-  // ==================== Utility Methods ====================
-
-  /**
-   * Configure storage environment variables (for S3 and other remote storage)
-   *
-   * <p>Lance configures S3 credentials via environment variables:
-   *
-   * <ul>
-   *   <li>AWS_ACCESS_KEY_ID - AWS access key ID
-   *   <li>AWS_SECRET_ACCESS_KEY - AWS secret access key
-   *   <li>AWS_DEFAULT_REGION - AWS region
-   *   <li>AWS_ENDPOINT - Custom endpoint URL (for S3-compatible storage)
-   * </ul>
-   */
-  private void configureStorageEnvironment() {
-    if (!isRemoteStorage || storageOptions.isEmpty()) {
-      return;
-    }
-
-    // Set environment variables for Lance SDK object_store configuration
-    // Note: Since Java cannot directly modify environment variables, system properties are used as
-    // fallback
-    // Lance's Rust backend will read these environment variables
-
-    if (storageOptions.containsKey("aws_access_key_id")) {
-      System.setProperty("AWS_ACCESS_KEY_ID", storageOptions.get("aws_access_key_id"));
-    }
-    if (storageOptions.containsKey("aws_secret_access_key")) {
-      System.setProperty("AWS_SECRET_ACCESS_KEY", storageOptions.get("aws_secret_access_key"));
-    }
-    if (storageOptions.containsKey("aws_region")) {
-      System.setProperty("AWS_DEFAULT_REGION", storageOptions.get("aws_region"));
-    }
-    if (storageOptions.containsKey("aws_endpoint")) {
-      System.setProperty("AWS_ENDPOINT", storageOptions.get("aws_endpoint"));
-    }
-    if (storageOptions.containsKey("aws_virtual_hosted_style_request")) {
-      System.setProperty(
-          "AWS_VIRTUAL_HOSTED_STYLE_REQUEST",
-          storageOptions.get("aws_virtual_hosted_style_request"));
-    }
-    if (storageOptions.containsKey("allow_http")) {
-      System.setProperty("AWS_ALLOW_HTTP", storageOptions.get("allow_http"));
-    }
-
-    LOG.debug("Configured remote storage environment variables");
-  }
-
-  /** Get database path */
-  private String getDatabasePath(String databaseName) {
-    if (isRemoteStorage) {
-      return warehouse + "/" + databaseName;
-    }
-    return Paths.get(warehouse, databaseName).toString();
-  }
-
-  /** Get dataset path */
-  private String getDatasetPath(ObjectPath tablePath) {
-    if (isRemoteStorage) {
-      return warehouse + "/" + tablePath.getDatabaseName() + "/" + tablePath.getObjectName();
-    }
-    return Paths.get(warehouse, tablePath.getDatabaseName(), tablePath.getObjectName()).toString();
-  }
-
-  /** Get storage options for table configuration */
-  private Map<String, String> getStorageOptionsForTable() {
-    Map<String, String> options = new HashMap<>();
-
-    // Convert storage options to table config format
-    if (storageOptions.containsKey("aws_access_key_id")) {
-      options.put("s3-access-key", storageOptions.get("aws_access_key_id"));
-    }
-    if (storageOptions.containsKey("aws_secret_access_key")) {
-      options.put("s3-secret-key", storageOptions.get("aws_secret_access_key"));
-    }
-    if (storageOptions.containsKey("aws_region")) {
-      options.put("s3-region", storageOptions.get("aws_region"));
-    }
-    if (storageOptions.containsKey("aws_endpoint")) {
-      options.put("s3-endpoint", storageOptions.get("aws_endpoint"));
-    }
-
-    return options;
-  }
-
-  /** Recursively delete directory */
-  private void deleteDirectory(Path path) throws IOException {
-    if (Files.isDirectory(path)) {
-      Files.list(path)
-          .forEach(
-              child -> {
-                try {
-                  deleteDirectory(child);
-                } catch (IOException e) {
-                  LOG.warn("Failed to delete file: {}", child, e);
-                }
-              });
-    }
-    Files.deleteIfExists(path);
-  }
+  // ==================== Accessor Methods ====================
 
   /** Get warehouse path */
   public String getWarehouse() {
-    return warehouse;
+    return pathResolver.getWarehouse();
   }
 
   /** Get storage configuration options */
@@ -877,6 +611,16 @@ public class LanceCatalog extends AbstractCatalog {
 
   /** Whether is remote storage */
   public boolean isRemoteStorage() {
-    return isRemoteStorage;
+    return pathResolver.isRemote();
+  }
+
+  /** Get the path resolver (for testing). */
+  public LanceCatalogPathResolver getPathResolver() {
+    return pathResolver;
+  }
+
+  /** Get the storage provider (for testing). */
+  public LanceStorageProvider getStorageProvider() {
+    return storageProvider;
   }
 }

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceCatalog.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceCatalog.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,9 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.table;
 
+import com.lancedb.lance.Dataset;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
 import org.apache.flink.connector.lance.converter.LanceTypeConverter;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.catalog.AbstractCatalog;
@@ -46,10 +44,6 @@ import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
-
-import com.lancedb.lance.Dataset;
-import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,10 +63,11 @@ import java.util.stream.Collectors;
 /**
  * Lance Catalog implementation.
  *
- * <p>Implements Flink Catalog interface, supports managing Lance datasets as Flink tables.
- * Supports local file system and S3 protocol object storage.
+ * <p>Implements Flink Catalog interface, supports managing Lance datasets as Flink tables. Supports
+ * local file system and S3 protocol object storage.
  *
  * <p>Usage example (local path):
+ *
  * <pre>{@code
  * CREATE CATALOG lance_catalog WITH (
  *     'type' = 'lance',
@@ -82,6 +77,7 @@ import java.util.stream.Collectors;
  * }</pre>
  *
  * <p>Usage example (S3 path):
+ *
  * <pre>{@code
  * CREATE CATALOG lance_s3_catalog WITH (
  *     'type' = 'lance',
@@ -95,800 +91,791 @@ import java.util.stream.Collectors;
  */
 public class LanceCatalog extends AbstractCatalog {
 
-    private static final Logger LOG = LoggerFactory.getLogger(LanceCatalog.class);
+  private static final Logger LOG = LoggerFactory.getLogger(LanceCatalog.class);
 
-    public static final String DEFAULT_DATABASE = "default";
+  public static final String DEFAULT_DATABASE = "default";
 
-    private final String warehouse;
-    private final Map<String, String> storageOptions;
-    private final boolean isRemoteStorage;
-    private transient BufferAllocator allocator;
+  private final String warehouse;
+  private final Map<String, String> storageOptions;
+  private final boolean isRemoteStorage;
+  private transient BufferAllocator allocator;
 
-    // Cache known databases and tables for remote storage
-    private final Set<String> knownDatabases = ConcurrentHashMap.newKeySet();
-    private final Set<String> knownTables = ConcurrentHashMap.newKeySet();
+  // Cache known databases and tables for remote storage
+  private final Set<String> knownDatabases = ConcurrentHashMap.newKeySet();
+  private final Set<String> knownTables = ConcurrentHashMap.newKeySet();
 
-    /**
-     * Create LanceCatalog (local storage)
-     *
-     * @param name Catalog name
-     * @param defaultDatabase Default database name
-     * @param warehouse Warehouse path
-     */
-    public LanceCatalog(String name, String defaultDatabase, String warehouse) {
-        this(name, defaultDatabase, warehouse, Collections.emptyMap());
+  /**
+   * Create LanceCatalog (local storage)
+   *
+   * @param name Catalog name
+   * @param defaultDatabase Default database name
+   * @param warehouse Warehouse path
+   */
+  public LanceCatalog(String name, String defaultDatabase, String warehouse) {
+    this(name, defaultDatabase, warehouse, Collections.emptyMap());
+  }
+
+  /**
+   * Create LanceCatalog (supports remote storage)
+   *
+   * @param name Catalog name
+   * @param defaultDatabase Default database name
+   * @param warehouse Warehouse path (local path or S3 URI)
+   * @param storageOptions Storage configuration options (e.g., S3 credentials)
+   */
+  public LanceCatalog(
+      String name, String defaultDatabase, String warehouse, Map<String, String> storageOptions) {
+    super(name, defaultDatabase);
+    this.warehouse = normalizeWarehousePath(warehouse);
+    this.storageOptions =
+        storageOptions != null ? new HashMap<>(storageOptions) : Collections.emptyMap();
+    this.isRemoteStorage = isRemotePath(warehouse);
+  }
+
+  /** Check if path is remote storage path */
+  private boolean isRemotePath(String path) {
+    if (path == null) {
+      return false;
     }
+    String lowerPath = path.toLowerCase();
+    return lowerPath.startsWith("s3://")
+        || lowerPath.startsWith("s3a://")
+        || lowerPath.startsWith("gs://")
+        || lowerPath.startsWith("az://")
+        || lowerPath.startsWith("https://")
+        || lowerPath.startsWith("http://");
+  }
 
-    /**
-     * Create LanceCatalog (supports remote storage)
-     *
-     * @param name Catalog name
-     * @param defaultDatabase Default database name
-     * @param warehouse Warehouse path (local path or S3 URI)
-     * @param storageOptions Storage configuration options (e.g., S3 credentials)
-     */
-    public LanceCatalog(String name, String defaultDatabase, String warehouse, Map<String, String> storageOptions) {
-        super(name, defaultDatabase);
-        this.warehouse = normalizeWarehousePath(warehouse);
-        this.storageOptions = storageOptions != null ? new HashMap<>(storageOptions) : Collections.emptyMap();
-        this.isRemoteStorage = isRemotePath(warehouse);
+  /** Normalize warehouse path */
+  private String normalizeWarehousePath(String path) {
+    if (path == null) {
+      return null;
     }
-
-    /**
-     * Check if path is remote storage path
-     */
-    private boolean isRemotePath(String path) {
-        if (path == null) {
-            return false;
-        }
-        String lowerPath = path.toLowerCase();
-        return lowerPath.startsWith("s3://") ||
-               lowerPath.startsWith("s3a://") ||
-               lowerPath.startsWith("gs://") ||
-               lowerPath.startsWith("az://") ||
-               lowerPath.startsWith("https://") ||
-               lowerPath.startsWith("http://");
+    // Remove trailing slashes
+    while (path.endsWith("/") && path.length() > 1) {
+      path = path.substring(0, path.length() - 1);
     }
+    return path;
+  }
 
-    /**
-     * Normalize warehouse path
-     */
-    private String normalizeWarehousePath(String path) {
-        if (path == null) {
-            return null;
-        }
-        // Remove trailing slashes
-        while (path.endsWith("/") && path.length() > 1) {
-            path = path.substring(0, path.length() - 1);
-        }
-        return path;
-    }
+  @Override
+  public void open() throws CatalogException {
+    LOG.info(
+        "Opening Lance Catalog: {}, warehouse path: {}," + " remote storage: {}",
+        getName(),
+        warehouse,
+        isRemoteStorage);
 
-    @Override
-    public void open() throws CatalogException {
-        LOG.info("Opening Lance Catalog: {}, warehouse path: {},"
-                        + " remote storage: {}",
-                getName(), warehouse, isRemoteStorage);
+    this.allocator = new RootAllocator(Long.MAX_VALUE);
 
-        this.allocator = new RootAllocator(Long.MAX_VALUE);
-
-        if (isRemoteStorage) {
-            // Remote storage: initialize default database record
-            knownDatabases.add(getDefaultDatabase());
-            LOG.info("Remote storage mode enabled, storage config count: {}", storageOptions.size());
-        } else {
-            // Local storage: ensure warehouse directory exists
-            Path warehousePath = Paths.get(warehouse);
-            if (!Files.exists(warehousePath)) {
-                try {
-                    Files.createDirectories(warehousePath);
-                } catch (IOException e) {
-                    throw new CatalogException("Cannot create warehouse directory: " + warehouse, e);
-                }
-            }
-
-            // Ensure default database exists
-            Path defaultDbPath = warehousePath.resolve(getDefaultDatabase());
-            if (!Files.exists(defaultDbPath)) {
-                try {
-                    Files.createDirectories(defaultDbPath);
-                } catch (IOException e) {
-                    throw new CatalogException("Cannot create default database directory: " + defaultDbPath, e);
-                }
-            }
-        }
-    }
-
-    @Override
-    public void close() throws CatalogException {
-        LOG.info("Closing Lance Catalog: {}", getName());
-
-        if (allocator != null) {
-            try {
-                allocator.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close allocator", e);
-            }
-            allocator = null;
-        }
-
-        knownDatabases.clear();
-        knownTables.clear();
-    }
-
-    // ==================== Database Operations ====================
-
-    @Override
-    public List<String> listDatabases() throws CatalogException {
-        if (isRemoteStorage) {
-            // Remote storage: return known database list
-            return new ArrayList<>(knownDatabases);
-        }
-
+    if (isRemoteStorage) {
+      // Remote storage: initialize default database record
+      knownDatabases.add(getDefaultDatabase());
+      LOG.info("Remote storage mode enabled, storage config count: {}", storageOptions.size());
+    } else {
+      // Local storage: ensure warehouse directory exists
+      Path warehousePath = Paths.get(warehouse);
+      if (!Files.exists(warehousePath)) {
         try {
-            Path warehousePath = Paths.get(warehouse);
-            if (!Files.exists(warehousePath)) {
-                return Collections.emptyList();
-            }
-
-            return Files.list(warehousePath)
-                    .filter(Files::isDirectory)
-                    .map(path -> path.getFileName().toString())
-                    .collect(Collectors.toList());
+          Files.createDirectories(warehousePath);
         } catch (IOException e) {
-            throw new CatalogException("Failed to list databases", e);
+          throw new CatalogException("Cannot create warehouse directory: " + warehouse, e);
         }
-    }
+      }
 
-    @Override
-    public CatalogDatabase getDatabase(String databaseName) throws DatabaseNotExistException, CatalogException {
-        if (!databaseExists(databaseName)) {
-            throw new DatabaseNotExistException(getName(), databaseName);
-        }
-
-        return new CatalogDatabaseImpl(Collections.emptyMap(), "Lance Database: " + databaseName);
-    }
-
-    @Override
-    public boolean databaseExists(String databaseName) throws CatalogException {
-        if (isRemoteStorage) {
-            // Remote storage: check known databases or try listing tables to verify
-            if (knownDatabases.contains(databaseName)) {
-                return true;
-            }
-            // Try to confirm database exists by checking for tables
-            try {
-                String dbPath = getDatabasePath(databaseName);
-                // For remote storage, assume database always exists (actual table operations will verify)
-                return true;
-            } catch (Exception e) {
-                return false;
-            }
-        }
-
-        Path dbPath = Paths.get(warehouse, databaseName);
-        return Files.exists(dbPath) && Files.isDirectory(dbPath);
-    }
-
-    @Override
-    public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists)
-            throws DatabaseAlreadyExistException, CatalogException {
-        if (isRemoteStorage) {
-            // Remote storage: only record database name, actual directory created when creating table
-            if (knownDatabases.contains(name)) {
-                if (!ignoreIfExists) {
-                    throw new DatabaseAlreadyExistException(getName(), name);
-                }
-                return;
-            }
-            knownDatabases.add(name);
-            LOG.info("Registered remote database: {}", name);
-            return;
-        }
-
-        if (databaseExists(name)) {
-            if (!ignoreIfExists) {
-                throw new DatabaseAlreadyExistException(getName(), name);
-            }
-            return;
-        }
-
-        Path dbPath = Paths.get(warehouse, name);
+      // Ensure default database exists
+      Path defaultDbPath = warehousePath.resolve(getDefaultDatabase());
+      if (!Files.exists(defaultDbPath)) {
         try {
-            Files.createDirectories(dbPath);
-            LOG.info("Created database: {}", name);
+          Files.createDirectories(defaultDbPath);
         } catch (IOException e) {
-            throw new CatalogException("Failed to create database: " + name, e);
+          throw new CatalogException(
+              "Cannot create default database directory: " + defaultDbPath, e);
         }
+      }
+    }
+  }
+
+  @Override
+  public void close() throws CatalogException {
+    LOG.info("Closing Lance Catalog: {}", getName());
+
+    if (allocator != null) {
+      try {
+        allocator.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close allocator", e);
+      }
+      allocator = null;
     }
 
-    @Override
-    public void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade)
-            throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
-        if (isRemoteStorage) {
-            // Remote storage: remove database record
-            if (!knownDatabases.contains(name)) {
-                if (!ignoreIfNotExists) {
-                    throw new DatabaseNotExistException(getName(), name);
-                }
-                return;
-            }
+    knownDatabases.clear();
+    knownTables.clear();
+  }
 
-            // Check if has tables
-            List<String> tables = listTables(name);
-            if (!tables.isEmpty() && !cascade) {
-                throw new DatabaseNotEmptyException(getName(), name);
-            }
+  // ==================== Database Operations ====================
 
-            // If cascade, delete all tables
-            if (cascade) {
-                for (String table : tables) {
-                    try {
-                        dropTable(new ObjectPath(name, table), true);
-                    } catch (TableNotExistException e) {
-                        // Ignore
-                    }
-                }
-            }
-
-            knownDatabases.remove(name);
-            LOG.info("Removed remote database record: {}", name);
-            return;
-        }
-
-        if (!databaseExists(name)) {
-            if (!ignoreIfNotExists) {
-                throw new DatabaseNotExistException(getName(), name);
-            }
-            return;
-        }
-
-        Path dbPath = Paths.get(warehouse, name);
-        try {
-            List<String> tables = listTables(name);
-            if (!tables.isEmpty() && !cascade) {
-                throw new DatabaseNotEmptyException(getName(), name);
-            }
-
-            // Delete database directory
-            deleteDirectory(dbPath);
-            LOG.info("Deleted database: {}", name);
-        } catch (IOException e) {
-            throw new CatalogException("Failed to delete database: " + name, e);
-        }
+  @Override
+  public List<String> listDatabases() throws CatalogException {
+    if (isRemoteStorage) {
+      // Remote storage: return known database list
+      return new ArrayList<>(knownDatabases);
     }
 
-    @Override
-    public void alterDatabase(String name, CatalogDatabase newDatabase, boolean ignoreIfNotExists)
-            throws DatabaseNotExistException, CatalogException {
-        if (!databaseExists(name)) {
-            if (!ignoreIfNotExists) {
-                throw new DatabaseNotExistException(getName(), name);
-            }
-            return;
-        }
-        // Lance database does not support modifying properties
-        LOG.warn("Lance Catalog does not support modifying database properties");
-    }
-
-    // ==================== Table Operations ====================
-
-    @Override
-    public List<String> listTables(String databaseName) throws DatabaseNotExistException, CatalogException {
-        if (!databaseExists(databaseName)) {
-            throw new DatabaseNotExistException(getName(), databaseName);
-        }
-
-        if (isRemoteStorage) {
-            // Remote storage: return known table list
-            String prefix = databaseName + "/";
-            return knownTables.stream()
-                    .filter(t -> t.startsWith(prefix))
-                    .map(t -> t.substring(prefix.length()))
-                    .collect(Collectors.toList());
-        }
-
-        try {
-            Path dbPath = Paths.get(warehouse, databaseName);
-            return Files.list(dbPath)
-                    .filter(Files::isDirectory)
-                    .filter(path -> Files.exists(path.resolve("_versions"))) // Lance dataset identifier
-                    .map(path -> path.getFileName().toString())
-                    .collect(Collectors.toList());
-        } catch (IOException e) {
-            throw new CatalogException("Failed to list tables", e);
-        }
-    }
-
-    @Override
-    public List<String> listViews(String databaseName) throws DatabaseNotExistException, CatalogException {
-        // Lance does not support views
+    try {
+      Path warehousePath = Paths.get(warehouse);
+      if (!Files.exists(warehousePath)) {
         return Collections.emptyList();
+      }
+
+      return Files.list(warehousePath)
+          .filter(Files::isDirectory)
+          .map(path -> path.getFileName().toString())
+          .collect(Collectors.toList());
+    } catch (IOException e) {
+      throw new CatalogException("Failed to list databases", e);
+    }
+  }
+
+  @Override
+  public CatalogDatabase getDatabase(String databaseName)
+      throws DatabaseNotExistException, CatalogException {
+    if (!databaseExists(databaseName)) {
+      throw new DatabaseNotExistException(getName(), databaseName);
     }
 
-    @Override
-    public CatalogBaseTable getTable(ObjectPath tablePath) throws TableNotExistException, CatalogException {
-        if (!tableExists(tablePath)) {
-            throw new TableNotExistException(getName(), tablePath);
-        }
+    return new CatalogDatabaseImpl(Collections.emptyMap(), "Lance Database: " + databaseName);
+  }
 
-        String datasetPath = getDatasetPath(tablePath);
-
-        try {
-            // For remote storage, configure S3 credentials via environment variables
-            if (isRemoteStorage) {
-                configureStorageEnvironment();
-            }
-            Dataset dataset = Dataset.open(datasetPath, allocator);
-
-            try {
-                // Infer Flink Schema from Lance Schema
-                org.apache.arrow.vector.types.pojo.Schema arrowSchema = dataset.getSchema();
-                RowType rowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
-
-                // Build CatalogTable
-                Schema.Builder schemaBuilder = Schema.newBuilder();
-                for (RowType.RowField field : rowType.getFields()) {
-                    DataType dataType = LanceTypeConverter.toDataType(field.getType());
-                    schemaBuilder.column(field.getName(), dataType);
-                }
-
-                Map<String, String> options = new HashMap<>();
-                options.put("connector", LanceDynamicTableFactory.IDENTIFIER);
-                options.put("path", datasetPath);
-
-                // If remote storage, add storage config to table options
-                if (isRemoteStorage) {
-                    options.putAll(getStorageOptionsForTable());
-                }
-
-                return CatalogTable.of(
-                        schemaBuilder.build(),
-                        "Lance Table: " + tablePath.getFullName(),
-                        Collections.emptyList(),
-                        options
-                );
-            } finally {
-                dataset.close();
-            }
-        } catch (Exception e) {
-            throw new CatalogException("Failed to get table info: " + tablePath, e);
-        }
-    }
-
-    @Override
-    public boolean tableExists(ObjectPath tablePath) throws CatalogException {
-        if (!databaseExists(tablePath.getDatabaseName())) {
-            return false;
-        }
-
-        String datasetPath = getDatasetPath(tablePath);
-
-        if (isRemoteStorage) {
-            // Remote storage: check known tables or try opening dataset
-            String tableKey = tablePath.getDatabaseName() + "/" + tablePath.getObjectName();
-            if (knownTables.contains(tableKey)) {
-                return true;
-            }
-
-            // Try to open dataset to verify existence
-            try {
-                configureStorageEnvironment();
-                Dataset dataset = Dataset.open(datasetPath, allocator);
-                dataset.close();
-                knownTables.add(tableKey);
-                return true;
-            } catch (Exception e) {
-                LOG.debug("Table does not exist or cannot be accessed: {}", datasetPath, e);
-                return false;
-            }
-        }
-
-        Path path = Paths.get(datasetPath);
-
-        // Check if valid Lance dataset
-        return Files.exists(path) && Files.isDirectory(path) &&
-               Files.exists(path.resolve("_versions"));
-    }
-
-    @Override
-    public void dropTable(ObjectPath tablePath, boolean ignoreIfNotExists)
-            throws TableNotExistException, CatalogException {
-        if (!tableExists(tablePath)) {
-            if (!ignoreIfNotExists) {
-                throw new TableNotExistException(getName(), tablePath);
-            }
-            return;
-        }
-
-        String datasetPath = getDatasetPath(tablePath);
-
-        if (isRemoteStorage) {
-            // Remote storage: Lance Java SDK does not directly support deleting remote datasets
-            // Only remove record here, actual deletion requires cloud storage API
-            String tableKey = tablePath.getDatabaseName() + "/" + tablePath.getObjectName();
-            knownTables.remove(tableKey);
-            LOG.warn("Remote storage mode, table record removed,"
-                            + " but actual data needs manual deletion"
-                            + " from storage: {}",
-                    datasetPath);
-            return;
-        }
-
-        try {
-            deleteDirectory(Paths.get(datasetPath));
-            LOG.info("Deleted table: {}", tablePath);
-        } catch (IOException e) {
-            throw new CatalogException("Failed to delete table: " + tablePath, e);
-        }
-    }
-
-    @Override
-    public void renameTable(ObjectPath tablePath, String newTableName, boolean ignoreIfNotExists)
-            throws TableNotExistException, TableAlreadyExistException, CatalogException {
-        if (!tableExists(tablePath)) {
-            if (!ignoreIfNotExists) {
-                throw new TableNotExistException(getName(), tablePath);
-            }
-            return;
-        }
-
-        ObjectPath newTablePath = new ObjectPath(tablePath.getDatabaseName(), newTableName);
-        if (tableExists(newTablePath)) {
-            throw new TableAlreadyExistException(getName(), newTablePath);
-        }
-
-        if (isRemoteStorage) {
-            // Remote storage: does not support renaming
-            throw new CatalogException("Remote storage mode does not support renaming tables");
-        }
-
-        String oldPath = getDatasetPath(tablePath);
-        String newPath = getDatasetPath(newTablePath);
-
-        try {
-            Files.move(Paths.get(oldPath), Paths.get(newPath));
-            LOG.info("Renamed table: {} -> {}", tablePath, newTablePath);
-        } catch (IOException e) {
-            throw new CatalogException("Failed to rename table: " + tablePath, e);
-        }
-    }
-
-    @Override
-    public void createTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists)
-            throws TableAlreadyExistException, DatabaseNotExistException, CatalogException {
-        if (!databaseExists(tablePath.getDatabaseName())) {
-            throw new DatabaseNotExistException(getName(), tablePath.getDatabaseName());
-        }
-
-        if (tableExists(tablePath)) {
-            if (!ignoreIfExists) {
-                throw new TableAlreadyExistException(getName(), tablePath);
-            }
-            return;
-        }
-
-        if (isRemoteStorage) {
-            // Remote storage: record table info, actual creation on write
-            String tableKey = tablePath.getDatabaseName() + "/" + tablePath.getObjectName();
-            knownTables.add(tableKey);
-        }
-
-        // Actual table creation happens on first write
-        // Only record table metadata here
-        LOG.info("Registered table: {} (actual dataset will be created on write)", tablePath);
-    }
-
-    @Override
-    public void alterTable(ObjectPath tablePath, CatalogBaseTable newTable, boolean ignoreIfNotExists)
-            throws TableNotExistException, CatalogException {
-        if (!tableExists(tablePath)) {
-            if (!ignoreIfNotExists) {
-                throw new TableNotExistException(getName(), tablePath);
-            }
-            return;
-        }
-
-        // Lance does not support modifying table structure
-        throw new CatalogException("Lance Catalog does not support altering table structure");
-    }
-
-    // ==================== Partition Operations (Lance does not support partitions) ====================
-
-    @Override
-    public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath)
-            throws TableNotExistException, TableNotPartitionedException, CatalogException {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public List<CatalogPartitionSpec> listPartitions(
-            ObjectPath tablePath,
-            CatalogPartitionSpec partitionSpec)
-            throws TableNotExistException,
-                    TableNotPartitionedException,
-                    PartitionSpecInvalidException,
-                    CatalogException {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public List<CatalogPartitionSpec> listPartitionsByFilter(ObjectPath tablePath, List<Expression> filters)
-            throws TableNotExistException, TableNotPartitionedException, CatalogException {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public CatalogPartition getPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
-            throws PartitionNotExistException, CatalogException {
-        throw new PartitionNotExistException(getName(), tablePath, partitionSpec);
-    }
-
-    @Override
-    public boolean partitionExists(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
-            throws CatalogException {
+  @Override
+  public boolean databaseExists(String databaseName) throws CatalogException {
+    if (isRemoteStorage) {
+      // Remote storage: check known databases or try listing tables to verify
+      if (knownDatabases.contains(databaseName)) {
+        return true;
+      }
+      // Try to confirm database exists by checking for tables
+      try {
+        String dbPath = getDatabasePath(databaseName);
+        // For remote storage, assume database always exists (actual table operations will verify)
+        return true;
+      } catch (Exception e) {
         return false;
+      }
     }
 
-    @Override
-    public void createPartition(
-            ObjectPath tablePath,
-            CatalogPartitionSpec partitionSpec,
-            CatalogPartition partition,
-            boolean ignoreIfExists)
-            throws TableNotExistException,
-                    TableNotPartitionedException,
-                    PartitionSpecInvalidException,
-                    PartitionAlreadyExistsException,
-                    CatalogException {
-        throw new CatalogException("Lance Catalog does not support partition operations");
+    Path dbPath = Paths.get(warehouse, databaseName);
+    return Files.exists(dbPath) && Files.isDirectory(dbPath);
+  }
+
+  @Override
+  public void createDatabase(String name, CatalogDatabase database, boolean ignoreIfExists)
+      throws DatabaseAlreadyExistException, CatalogException {
+    if (isRemoteStorage) {
+      // Remote storage: only record database name, actual directory created when creating table
+      if (knownDatabases.contains(name)) {
+        if (!ignoreIfExists) {
+          throw new DatabaseAlreadyExistException(getName(), name);
+        }
+        return;
+      }
+      knownDatabases.add(name);
+      LOG.info("Registered remote database: {}", name);
+      return;
     }
 
-    @Override
-    public void dropPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec, boolean ignoreIfNotExists)
-            throws PartitionNotExistException, CatalogException {
-        throw new CatalogException("Lance Catalog does not support partition operations");
+    if (databaseExists(name)) {
+      if (!ignoreIfExists) {
+        throw new DatabaseAlreadyExistException(getName(), name);
+      }
+      return;
     }
 
-    @Override
-    public void alterPartition(
-            ObjectPath tablePath,
-            CatalogPartitionSpec partitionSpec,
-            CatalogPartition newPartition,
-            boolean ignoreIfNotExists)
-            throws PartitionNotExistException,
-                    CatalogException {
-        throw new CatalogException("Lance Catalog does not support partition operations");
+    Path dbPath = Paths.get(warehouse, name);
+    try {
+      Files.createDirectories(dbPath);
+      LOG.info("Created database: {}", name);
+    } catch (IOException e) {
+      throw new CatalogException("Failed to create database: " + name, e);
+    }
+  }
+
+  @Override
+  public void dropDatabase(String name, boolean ignoreIfNotExists, boolean cascade)
+      throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
+    if (isRemoteStorage) {
+      // Remote storage: remove database record
+      if (!knownDatabases.contains(name)) {
+        if (!ignoreIfNotExists) {
+          throw new DatabaseNotExistException(getName(), name);
+        }
+        return;
+      }
+
+      // Check if has tables
+      List<String> tables = listTables(name);
+      if (!tables.isEmpty() && !cascade) {
+        throw new DatabaseNotEmptyException(getName(), name);
+      }
+
+      // If cascade, delete all tables
+      if (cascade) {
+        for (String table : tables) {
+          try {
+            dropTable(new ObjectPath(name, table), true);
+          } catch (TableNotExistException e) {
+            // Ignore
+          }
+        }
+      }
+
+      knownDatabases.remove(name);
+      LOG.info("Removed remote database record: {}", name);
+      return;
     }
 
-    // ==================== Function Operations (Lance does not support UDFs) ====================
-
-    @Override
-    public List<String> listFunctions(String dbName) throws DatabaseNotExistException, CatalogException {
-        return Collections.emptyList();
+    if (!databaseExists(name)) {
+      if (!ignoreIfNotExists) {
+        throw new DatabaseNotExistException(getName(), name);
+      }
+      return;
     }
 
-    @Override
-    public CatalogFunction getFunction(ObjectPath functionPath) throws FunctionNotExistException, CatalogException {
-        throw new FunctionNotExistException(getName(), functionPath);
+    Path dbPath = Paths.get(warehouse, name);
+    try {
+      List<String> tables = listTables(name);
+      if (!tables.isEmpty() && !cascade) {
+        throw new DatabaseNotEmptyException(getName(), name);
+      }
+
+      // Delete database directory
+      deleteDirectory(dbPath);
+      LOG.info("Deleted database: {}", name);
+    } catch (IOException e) {
+      throw new CatalogException("Failed to delete database: " + name, e);
+    }
+  }
+
+  @Override
+  public void alterDatabase(String name, CatalogDatabase newDatabase, boolean ignoreIfNotExists)
+      throws DatabaseNotExistException, CatalogException {
+    if (!databaseExists(name)) {
+      if (!ignoreIfNotExists) {
+        throw new DatabaseNotExistException(getName(), name);
+      }
+      return;
+    }
+    // Lance database does not support modifying properties
+    LOG.warn("Lance Catalog does not support modifying database properties");
+  }
+
+  // ==================== Table Operations ====================
+
+  @Override
+  public List<String> listTables(String databaseName)
+      throws DatabaseNotExistException, CatalogException {
+    if (!databaseExists(databaseName)) {
+      throw new DatabaseNotExistException(getName(), databaseName);
     }
 
-    @Override
-    public boolean functionExists(ObjectPath functionPath) throws CatalogException {
-        return false;
+    if (isRemoteStorage) {
+      // Remote storage: return known table list
+      String prefix = databaseName + "/";
+      return knownTables.stream()
+          .filter(t -> t.startsWith(prefix))
+          .map(t -> t.substring(prefix.length()))
+          .collect(Collectors.toList());
     }
 
-    @Override
-    public void createFunction(ObjectPath functionPath, CatalogFunction function, boolean ignoreIfExists)
-            throws FunctionAlreadyExistException, DatabaseNotExistException, CatalogException {
-        throw new CatalogException("Lance Catalog does not support user-defined functions");
+    try {
+      Path dbPath = Paths.get(warehouse, databaseName);
+      return Files.list(dbPath)
+          .filter(Files::isDirectory)
+          .filter(path -> Files.exists(path.resolve("_versions"))) // Lance dataset identifier
+          .map(path -> path.getFileName().toString())
+          .collect(Collectors.toList());
+    } catch (IOException e) {
+      throw new CatalogException("Failed to list tables", e);
+    }
+  }
+
+  @Override
+  public List<String> listViews(String databaseName)
+      throws DatabaseNotExistException, CatalogException {
+    // Lance does not support views
+    return Collections.emptyList();
+  }
+
+  @Override
+  public CatalogBaseTable getTable(ObjectPath tablePath)
+      throws TableNotExistException, CatalogException {
+    if (!tableExists(tablePath)) {
+      throw new TableNotExistException(getName(), tablePath);
     }
 
-    @Override
-    public void alterFunction(ObjectPath functionPath, CatalogFunction newFunction, boolean ignoreIfNotExists)
-            throws FunctionNotExistException, CatalogException {
-        throw new CatalogException("Lance Catalog does not support user-defined functions");
-    }
+    String datasetPath = getDatasetPath(tablePath);
 
-    @Override
-    public void dropFunction(ObjectPath functionPath, boolean ignoreIfNotExists)
-            throws FunctionNotExistException, CatalogException {
-        throw new CatalogException("Lance Catalog does not support user-defined functions");
-    }
+    try {
+      // For remote storage, configure S3 credentials via environment variables
+      if (isRemoteStorage) {
+        configureStorageEnvironment();
+      }
+      Dataset dataset = Dataset.open(datasetPath, allocator);
 
-    // ==================== Statistics Operations ====================
+      try {
+        // Infer Flink Schema from Lance Schema
+        org.apache.arrow.vector.types.pojo.Schema arrowSchema = dataset.getSchema();
+        RowType rowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
 
-    @Override
-    public CatalogTableStatistics getTableStatistics(ObjectPath tablePath)
-            throws TableNotExistException, CatalogException {
-        return CatalogTableStatistics.UNKNOWN;
-    }
-
-    @Override
-    public CatalogColumnStatistics getTableColumnStatistics(ObjectPath tablePath)
-            throws TableNotExistException, CatalogException {
-        return CatalogColumnStatistics.UNKNOWN;
-    }
-
-    @Override
-    public CatalogTableStatistics getPartitionStatistics(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
-            throws PartitionNotExistException, CatalogException {
-        return CatalogTableStatistics.UNKNOWN;
-    }
-
-    @Override
-    public CatalogColumnStatistics getPartitionColumnStatistics(
-            ObjectPath tablePath,
-            CatalogPartitionSpec partitionSpec)
-            throws PartitionNotExistException,
-                    CatalogException {
-        return CatalogColumnStatistics.UNKNOWN;
-    }
-
-    @Override
-    public void alterTableStatistics(
-            ObjectPath tablePath,
-            CatalogTableStatistics tableStatistics,
-            boolean ignoreIfNotExists)
-            throws TableNotExistException,
-                    CatalogException {
-        // Not supported
-    }
-
-    @Override
-    public void alterTableColumnStatistics(
-            ObjectPath tablePath,
-            CatalogColumnStatistics columnStatistics,
-            boolean ignoreIfNotExists)
-            throws TableNotExistException,
-                    CatalogException {
-        // Not supported
-    }
-
-    @Override
-    public void alterPartitionStatistics(
-            ObjectPath tablePath,
-            CatalogPartitionSpec partitionSpec,
-            CatalogTableStatistics partitionStatistics,
-            boolean ignoreIfNotExists)
-            throws PartitionNotExistException,
-                    CatalogException {
-        // Not supported
-    }
-
-    @Override
-    public void alterPartitionColumnStatistics(
-            ObjectPath tablePath,
-            CatalogPartitionSpec partitionSpec,
-            CatalogColumnStatistics columnStatistics,
-            boolean ignoreIfNotExists)
-            throws PartitionNotExistException,
-                    CatalogException {
-        // Not supported
-    }
-
-    // ==================== Utility Methods ====================
-
-    /**
-     * Configure storage environment variables (for S3 and other remote storage)
-     *
-     * <p>Lance configures S3 credentials via environment variables:
-     * <ul>
-     *   <li>AWS_ACCESS_KEY_ID - AWS access key ID</li>
-     *   <li>AWS_SECRET_ACCESS_KEY - AWS secret access key</li>
-     *   <li>AWS_DEFAULT_REGION - AWS region</li>
-     *   <li>AWS_ENDPOINT - Custom endpoint URL (for S3-compatible storage)</li>
-     * </ul>
-     */
-    private void configureStorageEnvironment() {
-        if (!isRemoteStorage || storageOptions.isEmpty()) {
-            return;
+        // Build CatalogTable
+        Schema.Builder schemaBuilder = Schema.newBuilder();
+        for (RowType.RowField field : rowType.getFields()) {
+          DataType dataType = LanceTypeConverter.toDataType(field.getType());
+          schemaBuilder.column(field.getName(), dataType);
         }
 
-        // Set environment variables for Lance SDK object_store configuration
-        // Note: Since Java cannot directly modify environment variables, system properties are used as fallback
-        // Lance's Rust backend will read these environment variables
-
-        if (storageOptions.containsKey("aws_access_key_id")) {
-            System.setProperty("AWS_ACCESS_KEY_ID", storageOptions.get("aws_access_key_id"));
-        }
-        if (storageOptions.containsKey("aws_secret_access_key")) {
-            System.setProperty("AWS_SECRET_ACCESS_KEY", storageOptions.get("aws_secret_access_key"));
-        }
-        if (storageOptions.containsKey("aws_region")) {
-            System.setProperty("AWS_DEFAULT_REGION", storageOptions.get("aws_region"));
-        }
-        if (storageOptions.containsKey("aws_endpoint")) {
-            System.setProperty("AWS_ENDPOINT", storageOptions.get("aws_endpoint"));
-        }
-        if (storageOptions.containsKey("aws_virtual_hosted_style_request")) {
-            System.setProperty("AWS_VIRTUAL_HOSTED_STYLE_REQUEST",
-                    storageOptions.get("aws_virtual_hosted_style_request"));
-        }
-        if (storageOptions.containsKey("allow_http")) {
-            System.setProperty("AWS_ALLOW_HTTP", storageOptions.get("allow_http"));
-        }
-
-        LOG.debug("Configured remote storage environment variables");
-    }
-
-    /**
-     * Get database path
-     */
-    private String getDatabasePath(String databaseName) {
-        if (isRemoteStorage) {
-            return warehouse + "/" + databaseName;
-        }
-        return Paths.get(warehouse, databaseName).toString();
-    }
-
-    /**
-     * Get dataset path
-     */
-    private String getDatasetPath(ObjectPath tablePath) {
-        if (isRemoteStorage) {
-            return warehouse + "/" + tablePath.getDatabaseName() + "/" + tablePath.getObjectName();
-        }
-        return Paths.get(warehouse, tablePath.getDatabaseName(), tablePath.getObjectName()).toString();
-    }
-
-    /**
-     * Get storage options for table configuration
-     */
-    private Map<String, String> getStorageOptionsForTable() {
         Map<String, String> options = new HashMap<>();
+        options.put("connector", LanceDynamicTableFactory.IDENTIFIER);
+        options.put("path", datasetPath);
 
-        // Convert storage options to table config format
-        if (storageOptions.containsKey("aws_access_key_id")) {
-            options.put("s3-access-key", storageOptions.get("aws_access_key_id"));
-        }
-        if (storageOptions.containsKey("aws_secret_access_key")) {
-            options.put("s3-secret-key", storageOptions.get("aws_secret_access_key"));
-        }
-        if (storageOptions.containsKey("aws_region")) {
-            options.put("s3-region", storageOptions.get("aws_region"));
-        }
-        if (storageOptions.containsKey("aws_endpoint")) {
-            options.put("s3-endpoint", storageOptions.get("aws_endpoint"));
+        // If remote storage, add storage config to table options
+        if (isRemoteStorage) {
+          options.putAll(getStorageOptionsForTable());
         }
 
-        return options;
+        return CatalogTable.of(
+            schemaBuilder.build(),
+            "Lance Table: " + tablePath.getFullName(),
+            Collections.emptyList(),
+            options);
+      } finally {
+        dataset.close();
+      }
+    } catch (Exception e) {
+      throw new CatalogException("Failed to get table info: " + tablePath, e);
+    }
+  }
+
+  @Override
+  public boolean tableExists(ObjectPath tablePath) throws CatalogException {
+    if (!databaseExists(tablePath.getDatabaseName())) {
+      return false;
     }
 
-    /**
-     * Recursively delete directory
-     */
-    private void deleteDirectory(Path path) throws IOException {
-        if (Files.isDirectory(path)) {
-            Files.list(path).forEach(child -> {
+    String datasetPath = getDatasetPath(tablePath);
+
+    if (isRemoteStorage) {
+      // Remote storage: check known tables or try opening dataset
+      String tableKey = tablePath.getDatabaseName() + "/" + tablePath.getObjectName();
+      if (knownTables.contains(tableKey)) {
+        return true;
+      }
+
+      // Try to open dataset to verify existence
+      try {
+        configureStorageEnvironment();
+        Dataset dataset = Dataset.open(datasetPath, allocator);
+        dataset.close();
+        knownTables.add(tableKey);
+        return true;
+      } catch (Exception e) {
+        LOG.debug("Table does not exist or cannot be accessed: {}", datasetPath, e);
+        return false;
+      }
+    }
+
+    Path path = Paths.get(datasetPath);
+
+    // Check if valid Lance dataset
+    return Files.exists(path) && Files.isDirectory(path) && Files.exists(path.resolve("_versions"));
+  }
+
+  @Override
+  public void dropTable(ObjectPath tablePath, boolean ignoreIfNotExists)
+      throws TableNotExistException, CatalogException {
+    if (!tableExists(tablePath)) {
+      if (!ignoreIfNotExists) {
+        throw new TableNotExistException(getName(), tablePath);
+      }
+      return;
+    }
+
+    String datasetPath = getDatasetPath(tablePath);
+
+    if (isRemoteStorage) {
+      // Remote storage: Lance Java SDK does not directly support deleting remote datasets
+      // Only remove record here, actual deletion requires cloud storage API
+      String tableKey = tablePath.getDatabaseName() + "/" + tablePath.getObjectName();
+      knownTables.remove(tableKey);
+      LOG.warn(
+          "Remote storage mode, table record removed,"
+              + " but actual data needs manual deletion"
+              + " from storage: {}",
+          datasetPath);
+      return;
+    }
+
+    try {
+      deleteDirectory(Paths.get(datasetPath));
+      LOG.info("Deleted table: {}", tablePath);
+    } catch (IOException e) {
+      throw new CatalogException("Failed to delete table: " + tablePath, e);
+    }
+  }
+
+  @Override
+  public void renameTable(ObjectPath tablePath, String newTableName, boolean ignoreIfNotExists)
+      throws TableNotExistException, TableAlreadyExistException, CatalogException {
+    if (!tableExists(tablePath)) {
+      if (!ignoreIfNotExists) {
+        throw new TableNotExistException(getName(), tablePath);
+      }
+      return;
+    }
+
+    ObjectPath newTablePath = new ObjectPath(tablePath.getDatabaseName(), newTableName);
+    if (tableExists(newTablePath)) {
+      throw new TableAlreadyExistException(getName(), newTablePath);
+    }
+
+    if (isRemoteStorage) {
+      // Remote storage: does not support renaming
+      throw new CatalogException("Remote storage mode does not support renaming tables");
+    }
+
+    String oldPath = getDatasetPath(tablePath);
+    String newPath = getDatasetPath(newTablePath);
+
+    try {
+      Files.move(Paths.get(oldPath), Paths.get(newPath));
+      LOG.info("Renamed table: {} -> {}", tablePath, newTablePath);
+    } catch (IOException e) {
+      throw new CatalogException("Failed to rename table: " + tablePath, e);
+    }
+  }
+
+  @Override
+  public void createTable(ObjectPath tablePath, CatalogBaseTable table, boolean ignoreIfExists)
+      throws TableAlreadyExistException, DatabaseNotExistException, CatalogException {
+    if (!databaseExists(tablePath.getDatabaseName())) {
+      throw new DatabaseNotExistException(getName(), tablePath.getDatabaseName());
+    }
+
+    if (tableExists(tablePath)) {
+      if (!ignoreIfExists) {
+        throw new TableAlreadyExistException(getName(), tablePath);
+      }
+      return;
+    }
+
+    if (isRemoteStorage) {
+      // Remote storage: record table info, actual creation on write
+      String tableKey = tablePath.getDatabaseName() + "/" + tablePath.getObjectName();
+      knownTables.add(tableKey);
+    }
+
+    // Actual table creation happens on first write
+    // Only record table metadata here
+    LOG.info("Registered table: {} (actual dataset will be created on write)", tablePath);
+  }
+
+  @Override
+  public void alterTable(ObjectPath tablePath, CatalogBaseTable newTable, boolean ignoreIfNotExists)
+      throws TableNotExistException, CatalogException {
+    if (!tableExists(tablePath)) {
+      if (!ignoreIfNotExists) {
+        throw new TableNotExistException(getName(), tablePath);
+      }
+      return;
+    }
+
+    // Lance does not support modifying table structure
+    throw new CatalogException("Lance Catalog does not support altering table structure");
+  }
+
+  // ==================== Partition Operations (Lance does not support partitions)
+  // ====================
+
+  @Override
+  public List<CatalogPartitionSpec> listPartitions(ObjectPath tablePath)
+      throws TableNotExistException, TableNotPartitionedException, CatalogException {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public List<CatalogPartitionSpec> listPartitions(
+      ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+      throws TableNotExistException,
+          TableNotPartitionedException,
+          PartitionSpecInvalidException,
+          CatalogException {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public List<CatalogPartitionSpec> listPartitionsByFilter(
+      ObjectPath tablePath, List<Expression> filters)
+      throws TableNotExistException, TableNotPartitionedException, CatalogException {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public CatalogPartition getPartition(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+      throws PartitionNotExistException, CatalogException {
+    throw new PartitionNotExistException(getName(), tablePath, partitionSpec);
+  }
+
+  @Override
+  public boolean partitionExists(ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+      throws CatalogException {
+    return false;
+  }
+
+  @Override
+  public void createPartition(
+      ObjectPath tablePath,
+      CatalogPartitionSpec partitionSpec,
+      CatalogPartition partition,
+      boolean ignoreIfExists)
+      throws TableNotExistException,
+          TableNotPartitionedException,
+          PartitionSpecInvalidException,
+          PartitionAlreadyExistsException,
+          CatalogException {
+    throw new CatalogException("Lance Catalog does not support partition operations");
+  }
+
+  @Override
+  public void dropPartition(
+      ObjectPath tablePath, CatalogPartitionSpec partitionSpec, boolean ignoreIfNotExists)
+      throws PartitionNotExistException, CatalogException {
+    throw new CatalogException("Lance Catalog does not support partition operations");
+  }
+
+  @Override
+  public void alterPartition(
+      ObjectPath tablePath,
+      CatalogPartitionSpec partitionSpec,
+      CatalogPartition newPartition,
+      boolean ignoreIfNotExists)
+      throws PartitionNotExistException, CatalogException {
+    throw new CatalogException("Lance Catalog does not support partition operations");
+  }
+
+  // ==================== Function Operations (Lance does not support UDFs) ====================
+
+  @Override
+  public List<String> listFunctions(String dbName)
+      throws DatabaseNotExistException, CatalogException {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public CatalogFunction getFunction(ObjectPath functionPath)
+      throws FunctionNotExistException, CatalogException {
+    throw new FunctionNotExistException(getName(), functionPath);
+  }
+
+  @Override
+  public boolean functionExists(ObjectPath functionPath) throws CatalogException {
+    return false;
+  }
+
+  @Override
+  public void createFunction(
+      ObjectPath functionPath, CatalogFunction function, boolean ignoreIfExists)
+      throws FunctionAlreadyExistException, DatabaseNotExistException, CatalogException {
+    throw new CatalogException("Lance Catalog does not support user-defined functions");
+  }
+
+  @Override
+  public void alterFunction(
+      ObjectPath functionPath, CatalogFunction newFunction, boolean ignoreIfNotExists)
+      throws FunctionNotExistException, CatalogException {
+    throw new CatalogException("Lance Catalog does not support user-defined functions");
+  }
+
+  @Override
+  public void dropFunction(ObjectPath functionPath, boolean ignoreIfNotExists)
+      throws FunctionNotExistException, CatalogException {
+    throw new CatalogException("Lance Catalog does not support user-defined functions");
+  }
+
+  // ==================== Statistics Operations ====================
+
+  @Override
+  public CatalogTableStatistics getTableStatistics(ObjectPath tablePath)
+      throws TableNotExistException, CatalogException {
+    return CatalogTableStatistics.UNKNOWN;
+  }
+
+  @Override
+  public CatalogColumnStatistics getTableColumnStatistics(ObjectPath tablePath)
+      throws TableNotExistException, CatalogException {
+    return CatalogColumnStatistics.UNKNOWN;
+  }
+
+  @Override
+  public CatalogTableStatistics getPartitionStatistics(
+      ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+      throws PartitionNotExistException, CatalogException {
+    return CatalogTableStatistics.UNKNOWN;
+  }
+
+  @Override
+  public CatalogColumnStatistics getPartitionColumnStatistics(
+      ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+      throws PartitionNotExistException, CatalogException {
+    return CatalogColumnStatistics.UNKNOWN;
+  }
+
+  @Override
+  public void alterTableStatistics(
+      ObjectPath tablePath, CatalogTableStatistics tableStatistics, boolean ignoreIfNotExists)
+      throws TableNotExistException, CatalogException {
+    // Not supported
+  }
+
+  @Override
+  public void alterTableColumnStatistics(
+      ObjectPath tablePath, CatalogColumnStatistics columnStatistics, boolean ignoreIfNotExists)
+      throws TableNotExistException, CatalogException {
+    // Not supported
+  }
+
+  @Override
+  public void alterPartitionStatistics(
+      ObjectPath tablePath,
+      CatalogPartitionSpec partitionSpec,
+      CatalogTableStatistics partitionStatistics,
+      boolean ignoreIfNotExists)
+      throws PartitionNotExistException, CatalogException {
+    // Not supported
+  }
+
+  @Override
+  public void alterPartitionColumnStatistics(
+      ObjectPath tablePath,
+      CatalogPartitionSpec partitionSpec,
+      CatalogColumnStatistics columnStatistics,
+      boolean ignoreIfNotExists)
+      throws PartitionNotExistException, CatalogException {
+    // Not supported
+  }
+
+  // ==================== Utility Methods ====================
+
+  /**
+   * Configure storage environment variables (for S3 and other remote storage)
+   *
+   * <p>Lance configures S3 credentials via environment variables:
+   *
+   * <ul>
+   *   <li>AWS_ACCESS_KEY_ID - AWS access key ID
+   *   <li>AWS_SECRET_ACCESS_KEY - AWS secret access key
+   *   <li>AWS_DEFAULT_REGION - AWS region
+   *   <li>AWS_ENDPOINT - Custom endpoint URL (for S3-compatible storage)
+   * </ul>
+   */
+  private void configureStorageEnvironment() {
+    if (!isRemoteStorage || storageOptions.isEmpty()) {
+      return;
+    }
+
+    // Set environment variables for Lance SDK object_store configuration
+    // Note: Since Java cannot directly modify environment variables, system properties are used as
+    // fallback
+    // Lance's Rust backend will read these environment variables
+
+    if (storageOptions.containsKey("aws_access_key_id")) {
+      System.setProperty("AWS_ACCESS_KEY_ID", storageOptions.get("aws_access_key_id"));
+    }
+    if (storageOptions.containsKey("aws_secret_access_key")) {
+      System.setProperty("AWS_SECRET_ACCESS_KEY", storageOptions.get("aws_secret_access_key"));
+    }
+    if (storageOptions.containsKey("aws_region")) {
+      System.setProperty("AWS_DEFAULT_REGION", storageOptions.get("aws_region"));
+    }
+    if (storageOptions.containsKey("aws_endpoint")) {
+      System.setProperty("AWS_ENDPOINT", storageOptions.get("aws_endpoint"));
+    }
+    if (storageOptions.containsKey("aws_virtual_hosted_style_request")) {
+      System.setProperty(
+          "AWS_VIRTUAL_HOSTED_STYLE_REQUEST",
+          storageOptions.get("aws_virtual_hosted_style_request"));
+    }
+    if (storageOptions.containsKey("allow_http")) {
+      System.setProperty("AWS_ALLOW_HTTP", storageOptions.get("allow_http"));
+    }
+
+    LOG.debug("Configured remote storage environment variables");
+  }
+
+  /** Get database path */
+  private String getDatabasePath(String databaseName) {
+    if (isRemoteStorage) {
+      return warehouse + "/" + databaseName;
+    }
+    return Paths.get(warehouse, databaseName).toString();
+  }
+
+  /** Get dataset path */
+  private String getDatasetPath(ObjectPath tablePath) {
+    if (isRemoteStorage) {
+      return warehouse + "/" + tablePath.getDatabaseName() + "/" + tablePath.getObjectName();
+    }
+    return Paths.get(warehouse, tablePath.getDatabaseName(), tablePath.getObjectName()).toString();
+  }
+
+  /** Get storage options for table configuration */
+  private Map<String, String> getStorageOptionsForTable() {
+    Map<String, String> options = new HashMap<>();
+
+    // Convert storage options to table config format
+    if (storageOptions.containsKey("aws_access_key_id")) {
+      options.put("s3-access-key", storageOptions.get("aws_access_key_id"));
+    }
+    if (storageOptions.containsKey("aws_secret_access_key")) {
+      options.put("s3-secret-key", storageOptions.get("aws_secret_access_key"));
+    }
+    if (storageOptions.containsKey("aws_region")) {
+      options.put("s3-region", storageOptions.get("aws_region"));
+    }
+    if (storageOptions.containsKey("aws_endpoint")) {
+      options.put("s3-endpoint", storageOptions.get("aws_endpoint"));
+    }
+
+    return options;
+  }
+
+  /** Recursively delete directory */
+  private void deleteDirectory(Path path) throws IOException {
+    if (Files.isDirectory(path)) {
+      Files.list(path)
+          .forEach(
+              child -> {
                 try {
-                    deleteDirectory(child);
+                  deleteDirectory(child);
                 } catch (IOException e) {
-                    LOG.warn("Failed to delete file: {}", child, e);
+                  LOG.warn("Failed to delete file: {}", child, e);
                 }
-            });
-        }
-        Files.deleteIfExists(path);
+              });
     }
+    Files.deleteIfExists(path);
+  }
 
-    /**
-     * Get warehouse path
-     */
-    public String getWarehouse() {
-        return warehouse;
-    }
+  /** Get warehouse path */
+  public String getWarehouse() {
+    return warehouse;
+  }
 
-    /**
-     * Get storage configuration options
-     */
-    public Map<String, String> getStorageOptions() {
-        return Collections.unmodifiableMap(storageOptions);
-    }
+  /** Get storage configuration options */
+  public Map<String, String> getStorageOptions() {
+    return Collections.unmodifiableMap(storageOptions);
+  }
 
-    /**
-     * Whether is remote storage
-     */
-    public boolean isRemoteStorage() {
-        return isRemoteStorage;
-    }
+  /** Whether is remote storage */
+  public boolean isRemoteStorage() {
+    return isRemoteStorage;
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceCatalogFactory.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceCatalogFactory.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.table;
 
 import org.apache.flink.configuration.ConfigOption;
@@ -35,6 +30,7 @@ import java.util.Set;
  * <p>Used to create LanceCatalog via SQL DDL.
  *
  * <p>Usage example (local path):
+ *
  * <pre>{@code
  * CREATE CATALOG lance_catalog WITH (
  *     'type' = 'lance',
@@ -44,6 +40,7 @@ import java.util.Set;
  * }</pre>
  *
  * <p>Usage example (S3 path):
+ *
  * <pre>{@code
  * CREATE CATALOG lance_s3_catalog WITH (
  *     'type' = 'lance',
@@ -58,123 +55,124 @@ import java.util.Set;
  */
 public class LanceCatalogFactory implements CatalogFactory {
 
-    public static final String IDENTIFIER = "lance";
+  public static final String IDENTIFIER = "lance";
 
-    public static final ConfigOption<String> WAREHOUSE = ConfigOptions
-            .key("warehouse")
-            .stringType()
-            .noDefaultValue()
-            .withDescription("Lance data warehouse path, supports local path or S3 path (e.g., s3://bucket/path)");
+  public static final ConfigOption<String> WAREHOUSE =
+      ConfigOptions.key("warehouse")
+          .stringType()
+          .noDefaultValue()
+          .withDescription(
+              "Lance data warehouse path, supports local path or S3 path (e.g., s3://bucket/path)");
 
-    public static final ConfigOption<String> DEFAULT_DATABASE = ConfigOptions
-            .key("default-database")
-            .stringType()
-            .defaultValue(LanceCatalog.DEFAULT_DATABASE)
-            .withDescription("Default database name");
+  public static final ConfigOption<String> DEFAULT_DATABASE =
+      ConfigOptions.key("default-database")
+          .stringType()
+          .defaultValue(LanceCatalog.DEFAULT_DATABASE)
+          .withDescription("Default database name");
 
-    // ==================== S3 Configuration Options ====================
+  // ==================== S3 Configuration Options ====================
 
-    public static final ConfigOption<String> S3_ACCESS_KEY = ConfigOptions
-            .key("s3-access-key")
-            .stringType()
-            .noDefaultValue()
-            .withDescription("S3 Access Key ID");
+  public static final ConfigOption<String> S3_ACCESS_KEY =
+      ConfigOptions.key("s3-access-key")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("S3 Access Key ID");
 
-    public static final ConfigOption<String> S3_SECRET_KEY = ConfigOptions
-            .key("s3-secret-key")
-            .stringType()
-            .noDefaultValue()
-            .withDescription("S3 Secret Access Key");
+  public static final ConfigOption<String> S3_SECRET_KEY =
+      ConfigOptions.key("s3-secret-key")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("S3 Secret Access Key");
 
-    public static final ConfigOption<String> S3_REGION = ConfigOptions
-            .key("s3-region")
-            .stringType()
-            .noDefaultValue()
-            .withDescription("S3 Region (e.g., us-east-1)");
+  public static final ConfigOption<String> S3_REGION =
+      ConfigOptions.key("s3-region")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("S3 Region (e.g., us-east-1)");
 
-    public static final ConfigOption<String> S3_ENDPOINT = ConfigOptions
-            .key("s3-endpoint")
-            .stringType()
-            .noDefaultValue()
-            .withDescription("S3 Endpoint URL (for S3-compatible object storage like MinIO)");
+  public static final ConfigOption<String> S3_ENDPOINT =
+      ConfigOptions.key("s3-endpoint")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("S3 Endpoint URL (for S3-compatible object storage like MinIO)");
 
-    public static final ConfigOption<Boolean> S3_VIRTUAL_HOSTED_STYLE = ConfigOptions
-            .key("s3-virtual-hosted-style")
-            .booleanType()
-            .defaultValue(true)
-            .withDescription("Whether to use virtual hosted style URL (default true)");
+  public static final ConfigOption<Boolean> S3_VIRTUAL_HOSTED_STYLE =
+      ConfigOptions.key("s3-virtual-hosted-style")
+          .booleanType()
+          .defaultValue(true)
+          .withDescription("Whether to use virtual hosted style URL (default true)");
 
-    public static final ConfigOption<Boolean> S3_ALLOW_HTTP = ConfigOptions
-            .key("s3-allow-http")
-            .booleanType()
-            .defaultValue(false)
-            .withDescription("Whether to allow HTTP connections (default false, HTTPS only)");
+  public static final ConfigOption<Boolean> S3_ALLOW_HTTP =
+      ConfigOptions.key("s3-allow-http")
+          .booleanType()
+          .defaultValue(false)
+          .withDescription("Whether to allow HTTP connections (default false, HTTPS only)");
 
-    @Override
-    public String factoryIdentifier() {
-        return IDENTIFIER;
+  @Override
+  public String factoryIdentifier() {
+    return IDENTIFIER;
+  }
+
+  @Override
+  public Set<ConfigOption<?>> requiredOptions() {
+    Set<ConfigOption<?>> options = new HashSet<>();
+    options.add(WAREHOUSE);
+    return options;
+  }
+
+  @Override
+  public Set<ConfigOption<?>> optionalOptions() {
+    Set<ConfigOption<?>> options = new HashSet<>();
+    options.add(DEFAULT_DATABASE);
+    // S3 related options
+    options.add(S3_ACCESS_KEY);
+    options.add(S3_SECRET_KEY);
+    options.add(S3_REGION);
+    options.add(S3_ENDPOINT);
+    options.add(S3_VIRTUAL_HOSTED_STYLE);
+    options.add(S3_ALLOW_HTTP);
+    return options;
+  }
+
+  @Override
+  public Catalog createCatalog(Context context) {
+    FactoryUtil.CatalogFactoryHelper helper = FactoryUtil.createCatalogFactoryHelper(this, context);
+    helper.validate();
+
+    String catalogName = context.getName();
+    String warehouse = helper.getOptions().get(WAREHOUSE);
+    String defaultDatabase = helper.getOptions().get(DEFAULT_DATABASE);
+
+    // Collect storage configuration
+    Map<String, String> storageOptions = new HashMap<>();
+
+    // S3 configuration
+    String accessKey = helper.getOptions().get(S3_ACCESS_KEY);
+    String secretKey = helper.getOptions().get(S3_SECRET_KEY);
+    String region = helper.getOptions().get(S3_REGION);
+    String endpoint = helper.getOptions().get(S3_ENDPOINT);
+    Boolean virtualHostedStyle = helper.getOptions().get(S3_VIRTUAL_HOSTED_STYLE);
+    Boolean allowHttp = helper.getOptions().get(S3_ALLOW_HTTP);
+
+    if (accessKey != null) {
+      storageOptions.put("aws_access_key_id", accessKey);
+    }
+    if (secretKey != null) {
+      storageOptions.put("aws_secret_access_key", secretKey);
+    }
+    if (region != null) {
+      storageOptions.put("aws_region", region);
+    }
+    if (endpoint != null) {
+      storageOptions.put("aws_endpoint", endpoint);
+    }
+    if (virtualHostedStyle != null) {
+      storageOptions.put("aws_virtual_hosted_style_request", virtualHostedStyle.toString());
+    }
+    if (allowHttp != null) {
+      storageOptions.put("allow_http", allowHttp.toString());
     }
 
-    @Override
-    public Set<ConfigOption<?>> requiredOptions() {
-        Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(WAREHOUSE);
-        return options;
-    }
-
-    @Override
-    public Set<ConfigOption<?>> optionalOptions() {
-        Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(DEFAULT_DATABASE);
-        // S3 related options
-        options.add(S3_ACCESS_KEY);
-        options.add(S3_SECRET_KEY);
-        options.add(S3_REGION);
-        options.add(S3_ENDPOINT);
-        options.add(S3_VIRTUAL_HOSTED_STYLE);
-        options.add(S3_ALLOW_HTTP);
-        return options;
-    }
-
-    @Override
-    public Catalog createCatalog(Context context) {
-        FactoryUtil.CatalogFactoryHelper helper = FactoryUtil.createCatalogFactoryHelper(this, context);
-        helper.validate();
-
-        String catalogName = context.getName();
-        String warehouse = helper.getOptions().get(WAREHOUSE);
-        String defaultDatabase = helper.getOptions().get(DEFAULT_DATABASE);
-
-        // Collect storage configuration
-        Map<String, String> storageOptions = new HashMap<>();
-
-        // S3 configuration
-        String accessKey = helper.getOptions().get(S3_ACCESS_KEY);
-        String secretKey = helper.getOptions().get(S3_SECRET_KEY);
-        String region = helper.getOptions().get(S3_REGION);
-        String endpoint = helper.getOptions().get(S3_ENDPOINT);
-        Boolean virtualHostedStyle = helper.getOptions().get(S3_VIRTUAL_HOSTED_STYLE);
-        Boolean allowHttp = helper.getOptions().get(S3_ALLOW_HTTP);
-
-        if (accessKey != null) {
-            storageOptions.put("aws_access_key_id", accessKey);
-        }
-        if (secretKey != null) {
-            storageOptions.put("aws_secret_access_key", secretKey);
-        }
-        if (region != null) {
-            storageOptions.put("aws_region", region);
-        }
-        if (endpoint != null) {
-            storageOptions.put("aws_endpoint", endpoint);
-        }
-        if (virtualHostedStyle != null) {
-            storageOptions.put("aws_virtual_hosted_style_request", virtualHostedStyle.toString());
-        }
-        if (allowHttp != null) {
-            storageOptions.put("allow_http", allowHttp.toString());
-        }
-
-        return new LanceCatalog(catalogName, defaultDatabase, warehouse, storageOptions);
-    }
+    return new LanceCatalog(catalogName, defaultDatabase, warehouse, storageOptions);
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceCatalogFactory.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceCatalogFactory.java
@@ -31,9 +31,9 @@ import java.util.Set;
 
 /**
  * Lance Catalog factory.
- * 
+ *
  * <p>Used to create LanceCatalog via SQL DDL.
- * 
+ *
  * <p>Usage example (local path):
  * <pre>{@code
  * CREATE CATALOG lance_catalog WITH (
@@ -42,7 +42,7 @@ import java.util.Set;
  *     'default-database' = 'default'
  * );
  * }</pre>
- * 
+ *
  * <p>Usage example (S3 path):
  * <pre>{@code
  * CREATE CATALOG lance_s3_catalog WITH (
@@ -73,7 +73,7 @@ public class LanceCatalogFactory implements CatalogFactory {
             .withDescription("Default database name");
 
     // ==================== S3 Configuration Options ====================
-    
+
     public static final ConfigOption<String> S3_ACCESS_KEY = ConfigOptions
             .key("s3-access-key")
             .stringType()
@@ -147,7 +147,7 @@ public class LanceCatalogFactory implements CatalogFactory {
 
         // Collect storage configuration
         Map<String, String> storageOptions = new HashMap<>();
-        
+
         // S3 configuration
         String accessKey = helper.getOptions().get(S3_ACCESS_KEY);
         String secretKey = helper.getOptions().get(S3_SECRET_KEY);

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableFactory.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableFactory.java
@@ -33,10 +33,10 @@ import java.util.Set;
 
 /**
  * Lance dynamic table factory.
- * 
+ *
  * <p>Implements Flink Table API DynamicTableSourceFactory and DynamicTableSinkFactory interfaces,
  * supports creating Lance tables via SQL DDL.
- * 
+ *
  * <p>Usage example:
  * <pre>{@code
  * CREATE TABLE lance_table (

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableFactory.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableFactory.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.table;
 
 import org.apache.flink.configuration.ConfigOption;
@@ -38,6 +33,7 @@ import java.util.Set;
  * supports creating Lance tables via SQL DDL.
  *
  * <p>Usage example:
+ *
  * <pre>{@code
  * CREATE TABLE lance_table (
  *     id BIGINT,
@@ -49,189 +45,184 @@ import java.util.Set;
  * );
  * }</pre>
  */
-public class LanceDynamicTableFactory implements DynamicTableSourceFactory, DynamicTableSinkFactory {
+public class LanceDynamicTableFactory
+    implements DynamicTableSourceFactory, DynamicTableSinkFactory {
 
-    public static final String IDENTIFIER = "lance";
+  public static final String IDENTIFIER = "lance";
 
-    // ==================== Configuration Options Definition ====================
+  // ==================== Configuration Options Definition ====================
 
-    public static final ConfigOption<String> PATH = ConfigOptions
-            .key("path")
-            .stringType()
-            .noDefaultValue()
-            .withDescription("Lance dataset path");
+  public static final ConfigOption<String> PATH =
+      ConfigOptions.key("path").stringType().noDefaultValue().withDescription("Lance dataset path");
 
-    public static final ConfigOption<Integer> READ_BATCH_SIZE = ConfigOptions
-            .key("read.batch-size")
-            .intType()
-            .defaultValue(1024)
-            .withDescription("Read batch size");
+  public static final ConfigOption<Integer> READ_BATCH_SIZE =
+      ConfigOptions.key("read.batch-size")
+          .intType()
+          .defaultValue(1024)
+          .withDescription("Read batch size");
 
-    public static final ConfigOption<String> READ_COLUMNS = ConfigOptions
-            .key("read.columns")
-            .stringType()
-            .noDefaultValue()
-            .withDescription("Columns to read, comma separated");
+  public static final ConfigOption<String> READ_COLUMNS =
+      ConfigOptions.key("read.columns")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("Columns to read, comma separated");
 
-    public static final ConfigOption<String> READ_FILTER = ConfigOptions
-            .key("read.filter")
-            .stringType()
-            .noDefaultValue()
-            .withDescription("Data filter condition");
+  public static final ConfigOption<String> READ_FILTER =
+      ConfigOptions.key("read.filter")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("Data filter condition");
 
-    public static final ConfigOption<Integer> WRITE_BATCH_SIZE = ConfigOptions
-            .key("write.batch-size")
-            .intType()
-            .defaultValue(1024)
-            .withDescription("Write batch size");
+  public static final ConfigOption<Integer> WRITE_BATCH_SIZE =
+      ConfigOptions.key("write.batch-size")
+          .intType()
+          .defaultValue(1024)
+          .withDescription("Write batch size");
 
-    public static final ConfigOption<String> WRITE_MODE = ConfigOptions
-            .key("write.mode")
-            .stringType()
-            .defaultValue("append")
-            .withDescription("Write mode: append or overwrite");
+  public static final ConfigOption<String> WRITE_MODE =
+      ConfigOptions.key("write.mode")
+          .stringType()
+          .defaultValue("append")
+          .withDescription("Write mode: append or overwrite");
 
-    public static final ConfigOption<Integer> WRITE_MAX_ROWS_PER_FILE = ConfigOptions
-            .key("write.max-rows-per-file")
-            .intType()
-            .defaultValue(1000000)
-            .withDescription("Maximum rows per file");
+  public static final ConfigOption<Integer> WRITE_MAX_ROWS_PER_FILE =
+      ConfigOptions.key("write.max-rows-per-file")
+          .intType()
+          .defaultValue(1000000)
+          .withDescription("Maximum rows per file");
 
-    public static final ConfigOption<String> INDEX_TYPE = ConfigOptions
-            .key("index.type")
-            .stringType()
-            .defaultValue("IVF_PQ")
-            .withDescription("Vector index type");
+  public static final ConfigOption<String> INDEX_TYPE =
+      ConfigOptions.key("index.type")
+          .stringType()
+          .defaultValue("IVF_PQ")
+          .withDescription("Vector index type");
 
-    public static final ConfigOption<String> INDEX_COLUMN = ConfigOptions
-            .key("index.column")
-            .stringType()
-            .noDefaultValue()
-            .withDescription("Index column name");
+  public static final ConfigOption<String> INDEX_COLUMN =
+      ConfigOptions.key("index.column")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("Index column name");
 
-    public static final ConfigOption<Integer> INDEX_NUM_PARTITIONS = ConfigOptions
-            .key("index.num-partitions")
-            .intType()
-            .defaultValue(256)
-            .withDescription("IVF partition count");
+  public static final ConfigOption<Integer> INDEX_NUM_PARTITIONS =
+      ConfigOptions.key("index.num-partitions")
+          .intType()
+          .defaultValue(256)
+          .withDescription("IVF partition count");
 
-    public static final ConfigOption<Integer> INDEX_NUM_SUB_VECTORS = ConfigOptions
-            .key("index.num-sub-vectors")
-            .intType()
-            .noDefaultValue()
-            .withDescription("PQ sub-vector count");
+  public static final ConfigOption<Integer> INDEX_NUM_SUB_VECTORS =
+      ConfigOptions.key("index.num-sub-vectors")
+          .intType()
+          .noDefaultValue()
+          .withDescription("PQ sub-vector count");
 
-    public static final ConfigOption<String> VECTOR_COLUMN = ConfigOptions
-            .key("vector.column")
-            .stringType()
-            .noDefaultValue()
-            .withDescription("Vector column name");
+  public static final ConfigOption<String> VECTOR_COLUMN =
+      ConfigOptions.key("vector.column")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("Vector column name");
 
-    public static final ConfigOption<String> VECTOR_METRIC = ConfigOptions
-            .key("vector.metric")
-            .stringType()
-            .defaultValue("L2")
-            .withDescription("Distance metric type: L2, Cosine, Dot");
+  public static final ConfigOption<String> VECTOR_METRIC =
+      ConfigOptions.key("vector.metric")
+          .stringType()
+          .defaultValue("L2")
+          .withDescription("Distance metric type: L2, Cosine, Dot");
 
-    public static final ConfigOption<Integer> VECTOR_NPROBES = ConfigOptions
-            .key("vector.nprobes")
-            .intType()
-            .defaultValue(20)
-            .withDescription("IVF search probe count");
+  public static final ConfigOption<Integer> VECTOR_NPROBES =
+      ConfigOptions.key("vector.nprobes")
+          .intType()
+          .defaultValue(20)
+          .withDescription("IVF search probe count");
 
-    @Override
-    public String factoryIdentifier() {
-        return IDENTIFIER;
-    }
+  @Override
+  public String factoryIdentifier() {
+    return IDENTIFIER;
+  }
 
-    @Override
-    public Set<ConfigOption<?>> requiredOptions() {
-        Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(PATH);
-        return options;
-    }
+  @Override
+  public Set<ConfigOption<?>> requiredOptions() {
+    Set<ConfigOption<?>> options = new HashSet<>();
+    options.add(PATH);
+    return options;
+  }
 
-    @Override
-    public Set<ConfigOption<?>> optionalOptions() {
-        Set<ConfigOption<?>> options = new HashSet<>();
-        options.add(READ_BATCH_SIZE);
-        options.add(READ_COLUMNS);
-        options.add(READ_FILTER);
-        options.add(WRITE_BATCH_SIZE);
-        options.add(WRITE_MODE);
-        options.add(WRITE_MAX_ROWS_PER_FILE);
-        options.add(INDEX_TYPE);
-        options.add(INDEX_COLUMN);
-        options.add(INDEX_NUM_PARTITIONS);
-        options.add(INDEX_NUM_SUB_VECTORS);
-        options.add(VECTOR_COLUMN);
-        options.add(VECTOR_METRIC);
-        options.add(VECTOR_NPROBES);
-        return options;
-    }
+  @Override
+  public Set<ConfigOption<?>> optionalOptions() {
+    Set<ConfigOption<?>> options = new HashSet<>();
+    options.add(READ_BATCH_SIZE);
+    options.add(READ_COLUMNS);
+    options.add(READ_FILTER);
+    options.add(WRITE_BATCH_SIZE);
+    options.add(WRITE_MODE);
+    options.add(WRITE_MAX_ROWS_PER_FILE);
+    options.add(INDEX_TYPE);
+    options.add(INDEX_COLUMN);
+    options.add(INDEX_NUM_PARTITIONS);
+    options.add(INDEX_NUM_SUB_VECTORS);
+    options.add(VECTOR_COLUMN);
+    options.add(VECTOR_METRIC);
+    options.add(VECTOR_NPROBES);
+    return options;
+  }
 
-    @Override
-    public DynamicTableSource createDynamicTableSource(Context context) {
-        FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
-        helper.validate();
+  @Override
+  public DynamicTableSource createDynamicTableSource(Context context) {
+    FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+    helper.validate();
 
-        ReadableConfig config = helper.getOptions();
-        LanceOptions options = buildLanceOptions(config);
+    ReadableConfig config = helper.getOptions();
+    LanceOptions options = buildLanceOptions(config);
 
-        return new LanceDynamicTableSource(
-                options,
-                context.getCatalogTable().getResolvedSchema().toPhysicalRowDataType()
-        );
-    }
+    return new LanceDynamicTableSource(
+        options, context.getCatalogTable().getResolvedSchema().toPhysicalRowDataType());
+  }
 
-    @Override
-    public DynamicTableSink createDynamicTableSink(Context context) {
-        FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
-        helper.validate();
+  @Override
+  public DynamicTableSink createDynamicTableSink(Context context) {
+    FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+    helper.validate();
 
-        ReadableConfig config = helper.getOptions();
-        LanceOptions options = buildLanceOptions(config);
+    ReadableConfig config = helper.getOptions();
+    LanceOptions options = buildLanceOptions(config);
 
-        return new LanceDynamicTableSink(
-                options,
-                context.getCatalogTable().getResolvedSchema().toPhysicalRowDataType()
-        );
-    }
+    return new LanceDynamicTableSink(
+        options, context.getCatalogTable().getResolvedSchema().toPhysicalRowDataType());
+  }
 
-    /**
-     * Build LanceOptions from configuration
-     */
-    private LanceOptions buildLanceOptions(ReadableConfig config) {
-        LanceOptions.Builder builder = LanceOptions.builder();
+  /** Build LanceOptions from configuration */
+  private LanceOptions buildLanceOptions(ReadableConfig config) {
+    LanceOptions.Builder builder = LanceOptions.builder();
 
-        // Common configuration
-        builder.path(config.get(PATH));
+    // Common configuration
+    builder.path(config.get(PATH));
 
-        // Source configuration
-        builder.readBatchSize(config.get(READ_BATCH_SIZE));
-        config.getOptional(READ_COLUMNS).ifPresent(columns -> {
-            if (!columns.isEmpty()) {
+    // Source configuration
+    builder.readBatchSize(config.get(READ_BATCH_SIZE));
+    config
+        .getOptional(READ_COLUMNS)
+        .ifPresent(
+            columns -> {
+              if (!columns.isEmpty()) {
                 builder.readColumns(java.util.Arrays.asList(columns.split(",")));
-            }
-        });
-        config.getOptional(READ_FILTER).ifPresent(builder::readFilter);
+              }
+            });
+    config.getOptional(READ_FILTER).ifPresent(builder::readFilter);
 
-        // Sink configuration
-        builder.writeBatchSize(config.get(WRITE_BATCH_SIZE));
-        builder.writeMode(LanceOptions.WriteMode.fromValue(config.get(WRITE_MODE)));
-        builder.writeMaxRowsPerFile(config.get(WRITE_MAX_ROWS_PER_FILE));
+    // Sink configuration
+    builder.writeBatchSize(config.get(WRITE_BATCH_SIZE));
+    builder.writeMode(LanceOptions.WriteMode.fromValue(config.get(WRITE_MODE)));
+    builder.writeMaxRowsPerFile(config.get(WRITE_MAX_ROWS_PER_FILE));
 
-        // Index configuration
-        builder.indexType(LanceOptions.IndexType.fromValue(config.get(INDEX_TYPE)));
-        config.getOptional(INDEX_COLUMN).ifPresent(builder::indexColumn);
-        builder.indexNumPartitions(config.get(INDEX_NUM_PARTITIONS));
-        config.getOptional(INDEX_NUM_SUB_VECTORS).ifPresent(builder::indexNumSubVectors);
+    // Index configuration
+    builder.indexType(LanceOptions.IndexType.fromValue(config.get(INDEX_TYPE)));
+    config.getOptional(INDEX_COLUMN).ifPresent(builder::indexColumn);
+    builder.indexNumPartitions(config.get(INDEX_NUM_PARTITIONS));
+    config.getOptional(INDEX_NUM_SUB_VECTORS).ifPresent(builder::indexNumSubVectors);
 
-        // Vector search configuration
-        config.getOptional(VECTOR_COLUMN).ifPresent(builder::vectorColumn);
-        builder.vectorMetric(LanceOptions.MetricType.fromValue(config.get(VECTOR_METRIC)));
-        builder.vectorNprobes(config.get(VECTOR_NPROBES));
+    // Vector search configuration
+    config.getOptional(VECTOR_COLUMN).ifPresent(builder::vectorColumn);
+    builder.vectorMetric(LanceOptions.MetricType.fromValue(config.get(VECTOR_METRIC)));
+    builder.vectorNprobes(config.get(VECTOR_NPROBES));
 
-        return builder.build();
-    }
+    return builder.build();
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableFactory.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableFactory.java
@@ -133,6 +133,30 @@ public class LanceDynamicTableFactory
           .defaultValue(20)
           .withDescription("IVF search probe count");
 
+  public static final ConfigOption<String> S3_ACCESS_KEY =
+      ConfigOptions.key("s3-access-key")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("S3 Access Key ID (injected by Catalog)");
+
+  public static final ConfigOption<String> S3_SECRET_KEY =
+      ConfigOptions.key("s3-secret-key")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("S3 Secret Access Key (injected by Catalog)");
+
+  public static final ConfigOption<String> S3_REGION =
+      ConfigOptions.key("s3-region")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("S3 Region (injected by Catalog)");
+
+  public static final ConfigOption<String> S3_ENDPOINT =
+      ConfigOptions.key("s3-endpoint")
+          .stringType()
+          .noDefaultValue()
+          .withDescription("S3 Endpoint URL (injected by Catalog)");
+
   @Override
   public String factoryIdentifier() {
     return IDENTIFIER;
@@ -140,14 +164,14 @@ public class LanceDynamicTableFactory
 
   @Override
   public Set<ConfigOption<?>> requiredOptions() {
-    Set<ConfigOption<?>> options = new HashSet<>();
-    options.add(PATH);
-    return options;
+    // No required options — when used via Catalog, path is injected automatically
+    return new HashSet<>();
   }
 
   @Override
   public Set<ConfigOption<?>> optionalOptions() {
     Set<ConfigOption<?>> options = new HashSet<>();
+    options.add(PATH);
     options.add(READ_BATCH_SIZE);
     options.add(READ_COLUMNS);
     options.add(READ_FILTER);
@@ -161,6 +185,11 @@ public class LanceDynamicTableFactory
     options.add(VECTOR_COLUMN);
     options.add(VECTOR_METRIC);
     options.add(VECTOR_NPROBES);
+    // S3 options (injected by Catalog when using remote storage)
+    options.add(S3_ACCESS_KEY);
+    options.add(S3_SECRET_KEY);
+    options.add(S3_REGION);
+    options.add(S3_ENDPOINT);
     return options;
   }
 
@@ -193,7 +222,7 @@ public class LanceDynamicTableFactory
     LanceOptions.Builder builder = LanceOptions.builder();
 
     // Common configuration
-    builder.path(config.get(PATH));
+    config.getOptional(PATH).ifPresent(builder::path);
 
     // Source configuration
     builder.readBatchSize(config.get(READ_BATCH_SIZE));

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSink.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSink.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.table;
 
 import org.apache.flink.connector.lance.config.LanceOptions;
@@ -30,58 +25,54 @@ import org.apache.flink.types.RowKind;
 /**
  * Lance dynamic table Sink.
  *
- * <p>Implements DynamicTableSink interface, writes Flink data to Lance Dataset using Sink V2 API (FLIP-143).
+ * <p>Implements DynamicTableSink interface, writes Flink data to Lance Dataset using Sink V2 API
+ * (FLIP-143).
+ *
  * <p>Provides runtime Sink through {@link SinkV2Provider}.
  */
 public class LanceDynamicTableSink implements DynamicTableSink {
 
-    private final LanceOptions options;
-    private final DataType physicalDataType;
+  private final LanceOptions options;
+  private final DataType physicalDataType;
 
-    public LanceDynamicTableSink(LanceOptions options, DataType physicalDataType) {
-        this.options = options;
-        this.physicalDataType = physicalDataType;
-    }
+  public LanceDynamicTableSink(LanceOptions options, DataType physicalDataType) {
+    this.options = options;
+    this.physicalDataType = physicalDataType;
+  }
 
-    @Override
-    public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
-        // Lance only supports INSERT operations
-        return ChangelogMode.newBuilder()
-                .addContainedKind(RowKind.INSERT)
-                .build();
-    }
+  @Override
+  public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+    // Lance only supports INSERT operations
+    return ChangelogMode.newBuilder().addContainedKind(RowKind.INSERT).build();
+  }
 
-    @Override
-    public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
-        RowType rowType = (RowType) physicalDataType.getLogicalType();
+  @Override
+  public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+    RowType rowType = (RowType) physicalDataType.getLogicalType();
 
-        // Use Sink V2 API (FLIP-143) SinkV2Provider
-        LanceSink lanceSink = new LanceSink(options, rowType);
+    // Use Sink V2 API (FLIP-143) SinkV2Provider
+    LanceSink lanceSink = new LanceSink(options, rowType);
 
-        return SinkV2Provider.of(lanceSink);
-    }
+    return SinkV2Provider.of(lanceSink);
+  }
 
-    @Override
-    public DynamicTableSink copy() {
-        return new LanceDynamicTableSink(options, physicalDataType);
-    }
+  @Override
+  public DynamicTableSink copy() {
+    return new LanceDynamicTableSink(options, physicalDataType);
+  }
 
-    @Override
-    public String asSummaryString() {
-        return "Lance Table Sink";
-    }
+  @Override
+  public String asSummaryString() {
+    return "Lance Table Sink";
+  }
 
-    /**
-     * Get configuration options
-     */
-    public LanceOptions getOptions() {
-        return options;
-    }
+  /** Get configuration options */
+  public LanceOptions getOptions() {
+    return options;
+  }
 
-    /**
-     * Get physical data type
-     */
-    public DataType getPhysicalDataType() {
-        return physicalDataType;
-    }
+  /** Get physical data type */
+  public DataType getPhysicalDataType() {
+    return physicalDataType;
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSink.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSink.java
@@ -23,14 +23,13 @@ import org.apache.flink.connector.lance.sink.LanceSink;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.SinkV2Provider;
-import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 
 /**
  * Lance dynamic table Sink.
- * 
+ *
  * <p>Implements DynamicTableSink interface, writes Flink data to Lance Dataset using Sink V2 API (FLIP-143).
  * <p>Provides runtime Sink through {@link SinkV2Provider}.
  */

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSink.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSink.java
@@ -18,24 +18,21 @@
 
 package org.apache.flink.connector.lance.table;
 
-import org.apache.flink.connector.lance.LanceSink;
 import org.apache.flink.connector.lance.config.LanceOptions;
-import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.datastream.DataStreamSink;
-import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.connector.lance.sink.LanceSink;
 import org.apache.flink.table.connector.ChangelogMode;
-import org.apache.flink.table.connector.sink.DataStreamSinkProvider;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
-import org.apache.flink.table.connector.sink.SinkFunctionProvider;
+import org.apache.flink.table.connector.sink.SinkV2Provider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 
 /**
- * Lance dynamic table sink.
+ * Lance dynamic table Sink.
  * 
- * <p>Implements DynamicTableSink interface, supports writing Flink data to Lance dataset.
+ * <p>Implements DynamicTableSink interface, writes Flink data to Lance Dataset using Sink V2 API (FLIP-143).
+ * <p>Provides runtime Sink through {@link SinkV2Provider}.
  */
 public class LanceDynamicTableSink implements DynamicTableSink {
 
@@ -59,10 +56,10 @@ public class LanceDynamicTableSink implements DynamicTableSink {
     public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
         RowType rowType = (RowType) physicalDataType.getLogicalType();
 
-        // Create LanceSink
+        // Use Sink V2 API (FLIP-143) SinkV2Provider
         LanceSink lanceSink = new LanceSink(options, rowType);
 
-        return SinkFunctionProvider.of(lanceSink);
+        return SinkV2Provider.of(lanceSink);
     }
 
     @Override

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSource.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSource.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.table;
 
 import org.apache.flink.connector.lance.aggregate.AggregateInfo;
@@ -47,469 +42,449 @@ import java.util.stream.Collectors;
 /**
  * Lance dynamic table Source.
  *
- * <p>Implements ScanTableSource interface, supports column pruning,
- * filter push-down, limit push-down and aggregate push-down.
+ * <p>Implements ScanTableSource interface, supports column pruning, filter push-down, limit
+ * push-down and aggregate push-down.
+ *
  * <p>Uses Source V2 API (FLIP-27), provides runtime Source through {@link SourceProvider}.
  */
-public class LanceDynamicTableSource implements ScanTableSource,
-        SupportsProjectionPushDown, SupportsFilterPushDown, SupportsLimitPushDown,
+public class LanceDynamicTableSource
+    implements ScanTableSource,
+        SupportsProjectionPushDown,
+        SupportsFilterPushDown,
+        SupportsLimitPushDown,
         SupportsAggregatePushDown {
 
-    private final LanceOptions options;
-    private final DataType physicalDataType;
-    private int[] projectedFields;
-    private List<String> filters;
-    private Long limit;  // Limit push-down
-    private AggregateInfo aggregateInfo;  // Aggregate push-down
-    private boolean aggregatePushDownAccepted;  // Whether aggregate push-down is accepted
+  private final LanceOptions options;
+  private final DataType physicalDataType;
+  private int[] projectedFields;
+  private List<String> filters;
+  private Long limit; // Limit push-down
+  private AggregateInfo aggregateInfo; // Aggregate push-down
+  private boolean aggregatePushDownAccepted; // Whether aggregate push-down is accepted
 
-    public LanceDynamicTableSource(LanceOptions options, DataType physicalDataType) {
-        this.options = options;
-        this.physicalDataType = physicalDataType;
-        this.projectedFields = null;
-        this.filters = new ArrayList<>();
-        this.limit = null;
-        this.aggregateInfo = null;
-        this.aggregatePushDownAccepted = false;
+  public LanceDynamicTableSource(LanceOptions options, DataType physicalDataType) {
+    this.options = options;
+    this.physicalDataType = physicalDataType;
+    this.projectedFields = null;
+    this.filters = new ArrayList<>();
+    this.limit = null;
+    this.aggregateInfo = null;
+    this.aggregatePushDownAccepted = false;
+  }
+
+  private LanceDynamicTableSource(LanceDynamicTableSource source) {
+    this.options = source.options;
+    this.physicalDataType = source.physicalDataType;
+    this.projectedFields = source.projectedFields;
+    this.filters = new ArrayList<>(source.filters);
+    this.limit = source.limit;
+    this.aggregateInfo = source.aggregateInfo;
+    this.aggregatePushDownAccepted = source.aggregatePushDownAccepted;
+  }
+
+  @Override
+  public ChangelogMode getChangelogMode() {
+    return ChangelogMode.insertOnly();
+  }
+
+  @Override
+  public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+    RowType rowType = (RowType) physicalDataType.getLogicalType();
+
+    // If column pruning was applied, build a new RowType
+    RowType projectedRowType = rowType;
+    if (projectedFields != null) {
+      List<RowType.RowField> projectedFieldList = new ArrayList<>();
+      for (int fieldIndex : projectedFields) {
+        projectedFieldList.add(rowType.getFields().get(fieldIndex));
+      }
+      projectedRowType = new RowType(projectedFieldList);
     }
 
-    private LanceDynamicTableSource(LanceDynamicTableSource source) {
-        this.options = source.options;
-        this.physicalDataType = source.physicalDataType;
-        this.projectedFields = source.projectedFields;
-        this.filters = new ArrayList<>(source.filters);
-        this.limit = source.limit;
-        this.aggregateInfo = source.aggregateInfo;
-        this.aggregatePushDownAccepted = source.aggregatePushDownAccepted;
+    // Build LanceOptions (apply column pruning and filter conditions)
+    LanceOptions.Builder optionsBuilder =
+        LanceOptions.builder()
+            .path(options.getPath())
+            .readBatchSize(options.getReadBatchSize())
+            .readFilter(buildFilterExpression());
+
+    // Set Limit (if any)
+    if (limit != null) {
+      optionsBuilder.readLimit(limit);
     }
 
-    @Override
-    public ChangelogMode getChangelogMode() {
-        return ChangelogMode.insertOnly();
+    // Set columns to read
+    if (projectedFields != null) {
+      List<String> columnNames =
+          Arrays.stream(projectedFields)
+              .mapToObj(i -> rowType.getFieldNames().get(i))
+              .collect(Collectors.toList());
+      optionsBuilder.readColumns(columnNames);
     }
 
-    @Override
-    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
-        RowType rowType = (RowType) physicalDataType.getLogicalType();
+    LanceOptions finalOptions = optionsBuilder.build();
+    final RowType finalRowType = projectedRowType;
 
-        // If column pruning was applied, build a new RowType
-        RowType projectedRowType = rowType;
-        if (projectedFields != null) {
-            List<RowType.RowField> projectedFieldList = new ArrayList<>();
-            for (int fieldIndex : projectedFields) {
-                projectedFieldList.add(rowType.getFields().get(fieldIndex));
-            }
-            projectedRowType = new RowType(projectedFieldList);
+    // Use Source V2 API (FLIP-27) SourceProvider
+    LanceSource lanceSource = new LanceSource(finalOptions, finalRowType);
+    return SourceProvider.of(lanceSource);
+  }
+
+  @Override
+  public DynamicTableSource copy() {
+    return new LanceDynamicTableSource(this);
+  }
+
+  @Override
+  public String asSummaryString() {
+    return "Lance Table Source";
+  }
+
+  // ==================== SupportsProjectionPushDown ====================
+
+  @Override
+  public boolean supportsNestedProjection() {
+    return false;
+  }
+
+  @Override
+  public void applyProjection(int[][] projectedFields) {
+    // Only support top-level field projection
+    this.projectedFields = Arrays.stream(projectedFields).mapToInt(arr -> arr[0]).toArray();
+  }
+
+  // ==================== SupportsFilterPushDown ====================
+
+  @Override
+  public Result applyFilters(List<ResolvedExpression> filters) {
+    // Convert Flink expressions to Lance filter conditions
+    List<ResolvedExpression> acceptedFilters = new ArrayList<>();
+    List<ResolvedExpression> remainingFilters = new ArrayList<>();
+
+    for (ResolvedExpression filter : filters) {
+      String lanceFilter = convertToLanceFilter(filter);
+      if (lanceFilter != null) {
+        this.filters.add(lanceFilter);
+        acceptedFilters.add(filter);
+      } else {
+        remainingFilters.add(filter);
+      }
+    }
+
+    return Result.of(acceptedFilters, remainingFilters);
+  }
+
+  /**
+   * Convert Flink expression to Lance filter condition. Lance supports standard SQL filter syntax,
+   * e.g., column = 'value', column > 10
+   */
+  private String convertToLanceFilter(ResolvedExpression expression) {
+    try {
+      if (expression instanceof CallExpression) {
+        CallExpression callExpr = (CallExpression) expression;
+        return convertCallExpression(callExpr);
+      }
+      // Other expression types not supported for push-down
+      return null;
+    } catch (Exception e) {
+      // Return null for unconvertible expressions, handled by Flink at upper layer
+      return null;
+    }
+  }
+
+  /** Convert CallExpression to Lance filter string */
+  private String convertCallExpression(CallExpression callExpr) {
+    FunctionDefinition funcDef = callExpr.getFunctionDefinition();
+    List<ResolvedExpression> args = callExpr.getResolvedChildren();
+
+    // Comparison operators
+    if (funcDef == BuiltInFunctionDefinitions.EQUALS) {
+      return buildComparisonFilter(args, "=");
+    } else if (funcDef == BuiltInFunctionDefinitions.NOT_EQUALS) {
+      return buildComparisonFilter(args, "!=");
+    } else if (funcDef == BuiltInFunctionDefinitions.GREATER_THAN) {
+      return buildComparisonFilter(args, ">");
+    } else if (funcDef == BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL) {
+      return buildComparisonFilter(args, ">=");
+    } else if (funcDef == BuiltInFunctionDefinitions.LESS_THAN) {
+      return buildComparisonFilter(args, "<");
+    } else if (funcDef == BuiltInFunctionDefinitions.LESS_THAN_OR_EQUAL) {
+      return buildComparisonFilter(args, "<=");
+    }
+    // Logical operators
+    else if (funcDef == BuiltInFunctionDefinitions.AND) {
+      return buildLogicalFilter(args, "AND");
+    } else if (funcDef == BuiltInFunctionDefinitions.OR) {
+      return buildLogicalFilter(args, "OR");
+    } else if (funcDef == BuiltInFunctionDefinitions.NOT) {
+      if (args.size() == 1) {
+        String inner = convertToLanceFilter(args.get(0));
+        if (inner != null) {
+          return "NOT (" + inner + ")";
         }
+      }
+    }
+    // IS NULL / IS NOT NULL
+    else if (funcDef == BuiltInFunctionDefinitions.IS_NULL) {
+      if (args.size() == 1 && args.get(0) instanceof FieldReferenceExpression) {
+        String fieldName = ((FieldReferenceExpression) args.get(0)).getName();
+        return fieldName + " IS NULL";
+      }
+    } else if (funcDef == BuiltInFunctionDefinitions.IS_NOT_NULL) {
+      if (args.size() == 1 && args.get(0) instanceof FieldReferenceExpression) {
+        String fieldName = ((FieldReferenceExpression) args.get(0)).getName();
+        return fieldName + " IS NOT NULL";
+      }
+    }
+    // LIKE
+    else if (funcDef == BuiltInFunctionDefinitions.LIKE) {
+      return buildComparisonFilter(args, "LIKE");
+    }
+    // IN (not supported yet, requires more complex handling)
+    // BETWEEN (not supported yet)
 
-        // Build LanceOptions (apply column pruning and filter conditions)
-        LanceOptions.Builder optionsBuilder = LanceOptions.builder()
-                .path(options.getPath())
-                .readBatchSize(options.getReadBatchSize())
-                .readFilter(buildFilterExpression());
+    // Unsupported functions, return null
+    return null;
+  }
 
-        // Set Limit (if any)
-        if (limit != null) {
-            optionsBuilder.readLimit(limit);
-        }
-
-        // Set columns to read
-        if (projectedFields != null) {
-            List<String> columnNames = Arrays.stream(projectedFields)
-                    .mapToObj(i -> rowType.getFieldNames().get(i))
-                    .collect(Collectors.toList());
-            optionsBuilder.readColumns(columnNames);
-        }
-
-        LanceOptions finalOptions = optionsBuilder.build();
-        final RowType finalRowType = projectedRowType;
-
-        // Use Source V2 API (FLIP-27) SourceProvider
-        LanceSource lanceSource = new LanceSource(finalOptions, finalRowType);
-        return SourceProvider.of(lanceSource);
+  /** Build comparison filter expression */
+  private String buildComparisonFilter(List<ResolvedExpression> args, String operator) {
+    if (args.size() != 2) {
+      return null;
     }
 
-    @Override
-    public DynamicTableSource copy() {
-        return new LanceDynamicTableSource(this);
+    ResolvedExpression left = args.get(0);
+    ResolvedExpression right = args.get(1);
+
+    // Extract field name and value
+    String fieldName = null;
+    String value = null;
+
+    if (left instanceof FieldReferenceExpression) {
+      fieldName = ((FieldReferenceExpression) left).getName();
+      value = extractLiteralValue(right);
+    } else if (right instanceof FieldReferenceExpression) {
+      fieldName = ((FieldReferenceExpression) right).getName();
+      value = extractLiteralValue(left);
+      // For asymmetric operators, need to swap operator
+      if (">".equals(operator)) {
+        operator = "<";
+      } else if ("<".equals(operator)) {
+        operator = ">";
+      } else if (">=".equals(operator)) {
+        operator = "<=";
+      } else if ("<=".equals(operator)) {
+        operator = ">=";
+      }
     }
 
-    @Override
-    public String asSummaryString() {
-        return "Lance Table Source";
+    if (fieldName != null && value != null) {
+      return fieldName + " " + operator + " " + value;
     }
 
-    // ==================== SupportsProjectionPushDown ====================
+    return null;
+  }
 
-    @Override
-    public boolean supportsNestedProjection() {
-        return false;
+  /** Build logical filter expression */
+  private String buildLogicalFilter(List<ResolvedExpression> args, String operator) {
+    List<String> convertedArgs = new ArrayList<>();
+    for (ResolvedExpression arg : args) {
+      String converted = convertToLanceFilter(arg);
+      if (converted == null) {
+        return null; // If any sub-expression cannot be converted, don't push down entire expression
+      }
+      convertedArgs.add("(" + converted + ")");
+    }
+    return String.join(" " + operator + " ", convertedArgs);
+  }
+
+  /** Extract literal value from ValueLiteralExpression */
+  private String extractLiteralValue(ResolvedExpression expr) {
+    if (expr instanceof ValueLiteralExpression) {
+      ValueLiteralExpression literal = (ValueLiteralExpression) expr;
+      Object value = literal.getValueAs(Object.class).orElse(null);
+
+      if (value == null) {
+        return "NULL";
+      } else if (value instanceof String) {
+        // Strings need single quotes and escape internal single quotes
+        String strValue = (String) value;
+        strValue = strValue.replace("'", "''");
+        return "'" + strValue + "'";
+      } else if (value instanceof Number) {
+        return value.toString();
+      } else if (value instanceof Boolean) {
+        return value.toString().toUpperCase();
+      } else {
+        // Other types try to convert to string
+        return "'" + value.toString().replace("'", "''") + "'";
+      }
+    }
+    return null;
+  }
+
+  /** Build filter expression */
+  private String buildFilterExpression() {
+    if (filters.isEmpty()) {
+      return options.getReadFilter();
     }
 
-    @Override
-    public void applyProjection(int[][] projectedFields) {
-        // Only support top-level field projection
-        this.projectedFields = Arrays.stream(projectedFields)
-                .mapToInt(arr -> arr[0])
-                .toArray();
+    String combinedFilter = String.join(" AND ", filters);
+    String originalFilter = options.getReadFilter();
+
+    if (originalFilter != null && !originalFilter.isEmpty()) {
+      return "(" + originalFilter + ") AND (" + combinedFilter + ")";
     }
 
-    // ==================== SupportsFilterPushDown ====================
+    return combinedFilter;
+  }
 
-    @Override
-    public Result applyFilters(List<ResolvedExpression> filters) {
-        // Convert Flink expressions to Lance filter conditions
-        List<ResolvedExpression> acceptedFilters = new ArrayList<>();
-        List<ResolvedExpression> remainingFilters = new ArrayList<>();
+  /** Get configuration options */
+  public LanceOptions getOptions() {
+    return options;
+  }
 
-        for (ResolvedExpression filter : filters) {
-            String lanceFilter = convertToLanceFilter(filter);
-            if (lanceFilter != null) {
-                this.filters.add(lanceFilter);
-                acceptedFilters.add(filter);
-            } else {
-                remainingFilters.add(filter);
-            }
+  /** Get physical data type */
+  public DataType getPhysicalDataType() {
+    return physicalDataType;
+  }
+
+  // ==================== SupportsLimitPushDown ====================
+
+  @Override
+  public void applyLimit(long limit) {
+    this.limit = limit;
+  }
+
+  /** Get Limit value */
+  public Long getLimit() {
+    return limit;
+  }
+
+  // ==================== SupportsAggregatePushDown ====================
+
+  @Override
+  public boolean applyAggregates(
+      List<int[]> groupingSets,
+      List<AggregateExpression> aggregateExpressions,
+      DataType producedDataType) {
+
+    // Currently only support simple single grouping set
+    if (groupingSets.size() != 1) {
+      return false;
+    }
+
+    int[] groupingSet = groupingSets.get(0);
+    RowType rowType = (RowType) physicalDataType.getLogicalType();
+    List<String> fieldNames = rowType.getFieldNames();
+
+    try {
+      AggregateInfo.Builder builder = AggregateInfo.builder();
+
+      // Handle grouping columns
+      List<String> groupByColumns = new ArrayList<>();
+      for (int fieldIndex : groupingSet) {
+        if (fieldIndex >= 0 && fieldIndex < fieldNames.size()) {
+          groupByColumns.add(fieldNames.get(fieldIndex));
         }
+      }
+      builder.groupBy(groupByColumns);
+      builder.groupByFieldIndices(groupingSet);
 
-        return Result.of(acceptedFilters, remainingFilters);
+      // Handle aggregate expressions
+      int aggIndex = 0;
+      for (AggregateExpression aggExpr : aggregateExpressions) {
+        AggregateInfo.AggregateCall aggCall =
+            convertAggregateExpression(aggExpr, fieldNames, aggIndex++);
+        if (aggCall == null) {
+          // Unsupported aggregate function, reject push-down
+          return false;
+        }
+        builder.addAggregateCall(aggCall);
+      }
+
+      this.aggregateInfo = builder.build();
+      this.aggregatePushDownAccepted = true;
+      return true;
+
+    } catch (Exception e) {
+      // Conversion failed, reject push-down
+      return false;
     }
+  }
 
-    /**
-     * Convert Flink expression to Lance filter condition.
-     * Lance supports standard SQL filter syntax, e.g., column = 'value', column > 10
-     */
-    private String convertToLanceFilter(ResolvedExpression expression) {
-        try {
-            if (expression instanceof CallExpression) {
-                CallExpression callExpr = (CallExpression) expression;
-                return convertCallExpression(callExpr);
-            }
-            // Other expression types not supported for push-down
-            return null;
-        } catch (Exception e) {
-            // Return null for unconvertible expressions, handled by Flink at upper layer
-            return null;
-        }
-    }
+  /** Convert Flink aggregate expression to internal aggregate call */
+  private AggregateInfo.AggregateCall convertAggregateExpression(
+      AggregateExpression aggExpr, List<String> fieldNames, int aggIndex) {
 
-    /**
-     * Convert CallExpression to Lance filter string
-     */
-    private String convertCallExpression(CallExpression callExpr) {
-        FunctionDefinition funcDef = callExpr.getFunctionDefinition();
-        List<ResolvedExpression> args = callExpr.getResolvedChildren();
+    FunctionDefinition funcDef = aggExpr.getFunctionDefinition();
+    List<FieldReferenceExpression> args = aggExpr.getArgs();
+    String alias = "agg_" + aggIndex;
 
-        // Comparison operators
-        if (funcDef == BuiltInFunctionDefinitions.EQUALS) {
-            return buildComparisonFilter(args, "=");
-        } else if (funcDef == BuiltInFunctionDefinitions.NOT_EQUALS) {
-            return buildComparisonFilter(args, "!=");
-        } else if (funcDef == BuiltInFunctionDefinitions.GREATER_THAN) {
-            return buildComparisonFilter(args, ">");
-        } else if (funcDef == BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL) {
-            return buildComparisonFilter(args, ">=");
-        } else if (funcDef == BuiltInFunctionDefinitions.LESS_THAN) {
-            return buildComparisonFilter(args, "<");
-        } else if (funcDef == BuiltInFunctionDefinitions.LESS_THAN_OR_EQUAL) {
-            return buildComparisonFilter(args, "<=");
-        }
-        // Logical operators
-        else if (funcDef == BuiltInFunctionDefinitions.AND) {
-            return buildLogicalFilter(args, "AND");
-        } else if (funcDef == BuiltInFunctionDefinitions.OR) {
-            return buildLogicalFilter(args, "OR");
-        } else if (funcDef == BuiltInFunctionDefinitions.NOT) {
-            if (args.size() == 1) {
-                String inner = convertToLanceFilter(args.get(0));
-                if (inner != null) {
-                    return "NOT (" + inner + ")";
-                }
-            }
-        }
-        // IS NULL / IS NOT NULL
-        else if (funcDef == BuiltInFunctionDefinitions.IS_NULL) {
-            if (args.size() == 1 && args.get(0) instanceof FieldReferenceExpression) {
-                String fieldName = ((FieldReferenceExpression) args.get(0)).getName();
-                return fieldName + " IS NULL";
-            }
-        } else if (funcDef == BuiltInFunctionDefinitions.IS_NOT_NULL) {
-            if (args.size() == 1 && args.get(0) instanceof FieldReferenceExpression) {
-                String fieldName = ((FieldReferenceExpression) args.get(0)).getName();
-                return fieldName + " IS NOT NULL";
-            }
-        }
-        // LIKE
-        else if (funcDef == BuiltInFunctionDefinitions.LIKE) {
-            return buildComparisonFilter(args, "LIKE");
-        }
-        // IN (not supported yet, requires more complex handling)
-        // BETWEEN (not supported yet)
-
-        // Unsupported functions, return null
-        return null;
-    }
-
-    /**
-     * Build comparison filter expression
-     */
-    private String buildComparisonFilter(List<ResolvedExpression> args, String operator) {
-        if (args.size() != 2) {
-            return null;
-        }
-
-        ResolvedExpression left = args.get(0);
-        ResolvedExpression right = args.get(1);
-
-        // Extract field name and value
-        String fieldName = null;
-        String value = null;
-
-        if (left instanceof FieldReferenceExpression) {
-            fieldName = ((FieldReferenceExpression) left).getName();
-            value = extractLiteralValue(right);
-        } else if (right instanceof FieldReferenceExpression) {
-            fieldName = ((FieldReferenceExpression) right).getName();
-            value = extractLiteralValue(left);
-            // For asymmetric operators, need to swap operator
-            if (">".equals(operator)) {
-                operator = "<";
-            } else if ("<".equals(operator)) {
-                operator = ">";
-            } else if (">=".equals(operator)) {
-                operator = "<=";
-            } else if ("<=".equals(operator)) {
-                operator = ">=";
-            }
-        }
-
-        if (fieldName != null && value != null) {
-            return fieldName + " " + operator + " " + value;
-        }
-
-        return null;
-    }
-
-    /**
-     * Build logical filter expression
-     */
-    private String buildLogicalFilter(List<ResolvedExpression> args, String operator) {
-        List<String> convertedArgs = new ArrayList<>();
-        for (ResolvedExpression arg : args) {
-            String converted = convertToLanceFilter(arg);
-            if (converted == null) {
-                return null; // If any sub-expression cannot be converted, don't push down entire expression
-            }
-            convertedArgs.add("(" + converted + ")");
-        }
-        return String.join(" " + operator + " ", convertedArgs);
-    }
-
-    /**
-     * Extract literal value from ValueLiteralExpression
-     */
-    private String extractLiteralValue(ResolvedExpression expr) {
-        if (expr instanceof ValueLiteralExpression) {
-            ValueLiteralExpression literal = (ValueLiteralExpression) expr;
-            Object value = literal.getValueAs(Object.class).orElse(null);
-
-            if (value == null) {
-                return "NULL";
-            } else if (value instanceof String) {
-                // Strings need single quotes and escape internal single quotes
-                String strValue = (String) value;
-                strValue = strValue.replace("'", "''");
-                return "'" + strValue + "'";
-            } else if (value instanceof Number) {
-                return value.toString();
-            } else if (value instanceof Boolean) {
-                return value.toString().toUpperCase();
-            } else {
-                // Other types try to convert to string
-                return "'" + value.toString().replace("'", "''") + "'";
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Build filter expression
-     */
-    private String buildFilterExpression() {
-        if (filters.isEmpty()) {
-            return options.getReadFilter();
-        }
-
-        String combinedFilter = String.join(" AND ", filters);
-        String originalFilter = options.getReadFilter();
-
-        if (originalFilter != null && !originalFilter.isEmpty()) {
-            return "(" + originalFilter + ") AND (" + combinedFilter + ")";
-        }
-
-        return combinedFilter;
-    }
-
-    /**
-     * Get configuration options
-     */
-    public LanceOptions getOptions() {
-        return options;
-    }
-
-    /**
-     * Get physical data type
-     */
-    public DataType getPhysicalDataType() {
-        return physicalDataType;
-    }
-
-    // ==================== SupportsLimitPushDown ====================
-
-    @Override
-    public void applyLimit(long limit) {
-        this.limit = limit;
-    }
-
-    /**
-     * Get Limit value
-     */
-    public Long getLimit() {
-        return limit;
-    }
-
-    // ==================== SupportsAggregatePushDown ====================
-
-    @Override
-    public boolean applyAggregates(
-            List<int[]> groupingSets,
-            List<AggregateExpression> aggregateExpressions,
-            DataType producedDataType) {
-
-        // Currently only support simple single grouping set
-        if (groupingSets.size() != 1) {
-            return false;
-        }
-
-        int[] groupingSet = groupingSets.get(0);
-        RowType rowType = (RowType) physicalDataType.getLogicalType();
-        List<String> fieldNames = rowType.getFieldNames();
-
-        try {
-            AggregateInfo.Builder builder = AggregateInfo.builder();
-
-            // Handle grouping columns
-            List<String> groupByColumns = new ArrayList<>();
-            for (int fieldIndex : groupingSet) {
-                if (fieldIndex >= 0 && fieldIndex < fieldNames.size()) {
-                    groupByColumns.add(fieldNames.get(fieldIndex));
-                }
-            }
-            builder.groupBy(groupByColumns);
-            builder.groupByFieldIndices(groupingSet);
-
-            // Handle aggregate expressions
-            int aggIndex = 0;
-            for (AggregateExpression aggExpr : aggregateExpressions) {
-                AggregateInfo.AggregateCall aggCall = convertAggregateExpression(aggExpr, fieldNames, aggIndex++);
-                if (aggCall == null) {
-                    // Unsupported aggregate function, reject push-down
-                    return false;
-                }
-                builder.addAggregateCall(aggCall);
-            }
-
-            this.aggregateInfo = builder.build();
-            this.aggregatePushDownAccepted = true;
-            return true;
-
-        } catch (Exception e) {
-            // Conversion failed, reject push-down
-            return false;
-        }
-    }
-
-    /**
-     * Convert Flink aggregate expression to internal aggregate call
-     */
-    private AggregateInfo.AggregateCall convertAggregateExpression(
-            AggregateExpression aggExpr,
-            List<String> fieldNames,
-            int aggIndex) {
-
-        FunctionDefinition funcDef = aggExpr.getFunctionDefinition();
-        List<FieldReferenceExpression> args = aggExpr.getArgs();
-        String alias = "agg_" + aggIndex;
-
+    // COUNT(*)
+    if (funcDef == BuiltInFunctionDefinitions.COUNT) {
+      if (args.isEmpty()) {
         // COUNT(*)
-        if (funcDef == BuiltInFunctionDefinitions.COUNT) {
-            if (args.isEmpty()) {
-                // COUNT(*)
-                return new AggregateInfo.AggregateCall(
-                        AggregateInfo.AggregateFunction.COUNT, null, alias);
-            } else {
-                // COUNT(column)
-                String columnName = args.get(0).getName();
-                return new AggregateInfo.AggregateCall(
-                        AggregateInfo.AggregateFunction.COUNT, columnName, alias);
-            }
-        }
+        return new AggregateInfo.AggregateCall(AggregateInfo.AggregateFunction.COUNT, null, alias);
+      } else {
+        // COUNT(column)
+        String columnName = args.get(0).getName();
+        return new AggregateInfo.AggregateCall(
+            AggregateInfo.AggregateFunction.COUNT, columnName, alias);
+      }
+    }
 
-        // SUM
-        if (funcDef == BuiltInFunctionDefinitions.SUM || funcDef == BuiltInFunctionDefinitions.SUM0) {
-            if (args.isEmpty()) {
-                return null;
-            }
-            String columnName = args.get(0).getName();
-            return new AggregateInfo.AggregateCall(
-                    AggregateInfo.AggregateFunction.SUM, columnName, alias);
-        }
-
-        // AVG
-        if (funcDef == BuiltInFunctionDefinitions.AVG) {
-            if (args.isEmpty()) {
-                return null;
-            }
-            String columnName = args.get(0).getName();
-            return new AggregateInfo.AggregateCall(
-                    AggregateInfo.AggregateFunction.AVG, columnName, alias);
-        }
-
-        // MIN
-        if (funcDef == BuiltInFunctionDefinitions.MIN) {
-            if (args.isEmpty()) {
-                return null;
-            }
-            String columnName = args.get(0).getName();
-            return new AggregateInfo.AggregateCall(
-                    AggregateInfo.AggregateFunction.MIN, columnName, alias);
-        }
-
-        // MAX
-        if (funcDef == BuiltInFunctionDefinitions.MAX) {
-            if (args.isEmpty()) {
-                return null;
-            }
-            String columnName = args.get(0).getName();
-            return new AggregateInfo.AggregateCall(
-                    AggregateInfo.AggregateFunction.MAX, columnName, alias);
-        }
-
-        // Unsupported aggregate function
+    // SUM
+    if (funcDef == BuiltInFunctionDefinitions.SUM || funcDef == BuiltInFunctionDefinitions.SUM0) {
+      if (args.isEmpty()) {
         return null;
+      }
+      String columnName = args.get(0).getName();
+      return new AggregateInfo.AggregateCall(
+          AggregateInfo.AggregateFunction.SUM, columnName, alias);
     }
 
-    /**
-     * Get aggregate info
-     */
-    public AggregateInfo getAggregateInfo() {
-        return aggregateInfo;
+    // AVG
+    if (funcDef == BuiltInFunctionDefinitions.AVG) {
+      if (args.isEmpty()) {
+        return null;
+      }
+      String columnName = args.get(0).getName();
+      return new AggregateInfo.AggregateCall(
+          AggregateInfo.AggregateFunction.AVG, columnName, alias);
     }
 
-    /**
-     * Whether aggregate push-down is accepted
-     */
-    public boolean isAggregatePushDownAccepted() {
-        return aggregatePushDownAccepted;
+    // MIN
+    if (funcDef == BuiltInFunctionDefinitions.MIN) {
+      if (args.isEmpty()) {
+        return null;
+      }
+      String columnName = args.get(0).getName();
+      return new AggregateInfo.AggregateCall(
+          AggregateInfo.AggregateFunction.MIN, columnName, alias);
     }
+
+    // MAX
+    if (funcDef == BuiltInFunctionDefinitions.MAX) {
+      if (args.isEmpty()) {
+        return null;
+      }
+      String columnName = args.get(0).getName();
+      return new AggregateInfo.AggregateCall(
+          AggregateInfo.AggregateFunction.MAX, columnName, alias);
+    }
+
+    // Unsupported aggregate function
+    return null;
+  }
+
+  /** Get aggregate info */
+  public AggregateInfo getAggregateInfo() {
+    return aggregateInfo;
+  }
+
+  /** Whether aggregate push-down is accepted */
+  public boolean isAggregatePushDownAccepted() {
+    return aggregatePushDownAccepted;
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSource.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSource.java
@@ -15,6 +15,7 @@ package org.apache.flink.connector.lance.table;
 
 import org.apache.flink.connector.lance.aggregate.AggregateInfo;
 import org.apache.flink.connector.lance.config.LanceOptions;
+import org.apache.flink.connector.lance.config.LanceSourceOptions;
 import org.apache.flink.connector.lance.source.LanceSource;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.source.DynamicTableSource;
@@ -516,5 +517,45 @@ public class LanceDynamicTableSource
   /** Whether aggregate push-down is accepted */
   public boolean isAggregatePushDownAccepted() {
     return aggregatePushDownAccepted;
+  }
+
+  // ==================== Handle ====================
+
+  /**
+   * Build an immutable {@link LanceSourceHandle} snapshot that captures all current push-down
+   * state. This handle can be used to transport push-down info to the runtime without exposing
+   * mutable fields.
+   */
+  public LanceSourceHandle getHandle() {
+    return LanceSourceHandle.builder()
+        .projectedFields(projectedFields)
+        .filters(new ArrayList<>(filters))
+        .limit(limit)
+        .aggregateInfo(aggregateInfo)
+        .build();
+  }
+
+  /**
+   * Build a {@link LanceSourceOptions} that merges push-down state into source-specific options.
+   * Useful for constructing the runtime Source without going through the full LanceOptions.
+   */
+  public LanceSourceOptions buildSourceOptions() {
+    RowType rowType = (RowType) physicalDataType.getLogicalType();
+    LanceSourceOptions.Builder builder =
+        options.toSourceOptions().toBuilder().filter(buildFilterExpression());
+
+    if (limit != null) {
+      builder.limit(limit);
+    }
+
+    if (projectedFields != null) {
+      List<String> columnNames =
+          Arrays.stream(projectedFields)
+              .mapToObj(i -> rowType.getFieldNames().get(i))
+              .collect(Collectors.toList());
+      builder.columns(columnNames);
+    }
+
+    return builder.build();
   }
 }

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSource.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSource.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.connector.lance.table;
 
-import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.connector.lance.aggregate.AggregateInfo;
 import org.apache.flink.connector.lance.config.LanceOptions;
 import org.apache.flink.connector.lance.source.LanceSource;
@@ -30,7 +29,6 @@ import org.apache.flink.table.connector.source.abilities.SupportsAggregatePushDo
 import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
-import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.AggregateExpression;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
@@ -48,11 +46,12 @@ import java.util.stream.Collectors;
 
 /**
  * Lance dynamic table Source.
- * 
- * <p>Implements ScanTableSource interface, supports column pruning, filter push-down, limit push-down and aggregate push-down.
+ *
+ * <p>Implements ScanTableSource interface, supports column pruning,
+ * filter push-down, limit push-down and aggregate push-down.
  * <p>Uses Source V2 API (FLIP-27), provides runtime Source through {@link SourceProvider}.
  */
-public class LanceDynamicTableSource implements ScanTableSource, 
+public class LanceDynamicTableSource implements ScanTableSource,
         SupportsProjectionPushDown, SupportsFilterPushDown, SupportsLimitPushDown,
         SupportsAggregatePushDown {
 
@@ -92,7 +91,7 @@ public class LanceDynamicTableSource implements ScanTableSource,
     @Override
     public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
         RowType rowType = (RowType) physicalDataType.getLogicalType();
-        
+
         // If column pruning was applied, build a new RowType
         RowType projectedRowType = rowType;
         if (projectedFields != null) {
@@ -273,10 +272,15 @@ public class LanceDynamicTableSource implements ScanTableSource,
             fieldName = ((FieldReferenceExpression) right).getName();
             value = extractLiteralValue(left);
             // For asymmetric operators, need to swap operator
-            if (">".equals(operator)) operator = "<";
-            else if ("<".equals(operator)) operator = ">";
-            else if (">=".equals(operator)) operator = "<=";
-            else if ("<=".equals(operator)) operator = ">=";
+            if (">".equals(operator)) {
+                operator = "<";
+            } else if ("<".equals(operator)) {
+                operator = ">";
+            } else if (">=".equals(operator)) {
+                operator = "<=";
+            } else if ("<=".equals(operator)) {
+                operator = ">=";
+            }
         }
 
         if (fieldName != null && value != null) {
@@ -308,7 +312,7 @@ public class LanceDynamicTableSource implements ScanTableSource,
         if (expr instanceof ValueLiteralExpression) {
             ValueLiteralExpression literal = (ValueLiteralExpression) expr;
             Object value = literal.getValueAs(Object.class).orElse(null);
-            
+
             if (value == null) {
                 return "NULL";
             } else if (value instanceof String) {
@@ -381,7 +385,7 @@ public class LanceDynamicTableSource implements ScanTableSource,
             List<int[]> groupingSets,
             List<AggregateExpression> aggregateExpressions,
             DataType producedDataType) {
-        
+
         // Currently only support simple single grouping set
         if (groupingSets.size() != 1) {
             return false;
@@ -429,10 +433,10 @@ public class LanceDynamicTableSource implements ScanTableSource,
      * Convert Flink aggregate expression to internal aggregate call
      */
     private AggregateInfo.AggregateCall convertAggregateExpression(
-            AggregateExpression aggExpr, 
+            AggregateExpression aggExpr,
             List<String> fieldNames,
             int aggIndex) {
-        
+
         FunctionDefinition funcDef = aggExpr.getFunctionDefinition();
         List<FieldReferenceExpression> args = aggExpr.getArgs();
         String alias = "agg_" + aggIndex;

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSource.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSource.java
@@ -240,11 +240,41 @@ public class LanceDynamicTableSource
     else if (funcDef == BuiltInFunctionDefinitions.LIKE) {
       return buildComparisonFilter(args, "LIKE");
     }
-    // IN (not supported yet, requires more complex handling)
+    // IN
+    else if (funcDef == BuiltInFunctionDefinitions.IN) {
+      return buildInFilter(args);
+    }
     // BETWEEN (not supported yet)
 
     // Unsupported functions, return null
     return null;
+  }
+
+  /**
+   * Build IN filter expression. The first argument is the field reference, and the remaining
+   * arguments are the values. Generates: fieldName IN ('v1', 'v2', 'v3')
+   */
+  private String buildInFilter(List<ResolvedExpression> args) {
+    if (args.size() < 2) {
+      return null;
+    }
+    // First argument must be a field reference
+    if (!(args.get(0) instanceof FieldReferenceExpression)) {
+      return null;
+    }
+    String fieldName = ((FieldReferenceExpression) args.get(0)).getName();
+
+    // Remaining arguments are values
+    List<String> values = new ArrayList<>();
+    for (int i = 1; i < args.size(); i++) {
+      String val = extractLiteralValue(args.get(i));
+      if (val == null) {
+        return null;
+      }
+      values.add(val);
+    }
+
+    return fieldName + " IN (" + String.join(", ", values) + ")";
   }
 
   /** Build comparison filter expression */

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSource.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSource.java
@@ -18,19 +18,14 @@
 
 package org.apache.flink.connector.lance.table;
 
-import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.connector.lance.LanceInputFormat;
-import org.apache.flink.connector.lance.LanceSource;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.connector.lance.aggregate.AggregateInfo;
 import org.apache.flink.connector.lance.config.LanceOptions;
-import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.connector.lance.source.LanceSource;
 import org.apache.flink.table.connector.ChangelogMode;
-import org.apache.flink.table.connector.source.DataStreamScanProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
-import org.apache.flink.table.connector.source.InputFormatProvider;
 import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceProvider;
 import org.apache.flink.table.connector.source.abilities.SupportsAggregatePushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
@@ -44,9 +39,7 @@ import org.apache.flink.table.expressions.ValueLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.types.RowKind;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,9 +47,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Lance dynamic table source.
+ * Lance dynamic table Source.
  * 
- * <p>Implements ScanTableSource interface, supports column pruning and filter push-down.
+ * <p>Implements ScanTableSource interface, supports column pruning, filter push-down, limit push-down and aggregate push-down.
+ * <p>Uses Source V2 API (FLIP-27), provides runtime Source through {@link SourceProvider}.
  */
 public class LanceDynamicTableSource implements ScanTableSource, 
         SupportsProjectionPushDown, SupportsFilterPushDown, SupportsLimitPushDown,
@@ -99,7 +93,7 @@ public class LanceDynamicTableSource implements ScanTableSource,
     public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
         RowType rowType = (RowType) physicalDataType.getLogicalType();
         
-        // If column pruning applied, build new RowType
+        // If column pruning was applied, build a new RowType
         RowType projectedRowType = rowType;
         if (projectedFields != null) {
             List<RowType.RowField> projectedFieldList = new ArrayList<>();
@@ -131,19 +125,9 @@ public class LanceDynamicTableSource implements ScanTableSource,
         LanceOptions finalOptions = optionsBuilder.build();
         final RowType finalRowType = projectedRowType;
 
-        // Use DataStreamScanProvider
-        return new DataStreamScanProvider() {
-            @Override
-            public DataStream<RowData> produceDataStream(StreamExecutionEnvironment execEnv) {
-                LanceSource source = new LanceSource(finalOptions, finalRowType);
-                return execEnv.addSource(source, "LanceSource");
-            }
-
-            @Override
-            public boolean isBounded() {
-                return true; // Lance dataset is bounded
-            }
-        };
+        // Use Source V2 API (FLIP-27) SourceProvider
+        LanceSource lanceSource = new LanceSource(finalOptions, finalRowType);
+        return SourceProvider.of(lanceSource);
     }
 
     @Override

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceSourceHandle.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceSourceHandle.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.table;
+
+import org.apache.flink.connector.lance.aggregate.AggregateInfo;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Immutable handle that carries push-down information from the Table API planner to the runtime.
+ *
+ * <p>Captures the results of:
+ *
+ * <ul>
+ *   <li>Projection push-down (selected column indices)
+ *   <li>Filter push-down (Lance SQL filter strings)
+ *   <li>Limit push-down (max rows)
+ *   <li>Aggregate push-down ({@link AggregateInfo})
+ * </ul>
+ *
+ * <p>Instances are created via the {@link Builder} and are fully immutable after construction.
+ */
+public final class LanceSourceHandle implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  /** Empty handle with no push-down applied. */
+  public static final LanceSourceHandle EMPTY = builder().build();
+
+  @Nullable private final int[] projectedFields;
+  private final List<String> filters;
+  @Nullable private final Long limit;
+  @Nullable private final AggregateInfo aggregateInfo;
+
+  private LanceSourceHandle(Builder builder) {
+    this.projectedFields = builder.projectedFields != null ? builder.projectedFields.clone() : null;
+    this.filters =
+        builder.filters != null
+            ? Collections.unmodifiableList(builder.filters)
+            : Collections.emptyList();
+    this.limit = builder.limit;
+    this.aggregateInfo = builder.aggregateInfo;
+  }
+
+  /** Column indices selected by projection push-down, null means all columns. */
+  @Nullable
+  public int[] getProjectedFields() {
+    return projectedFields != null ? projectedFields.clone() : null;
+  }
+
+  /** Lance SQL filter strings accepted by filter push-down. */
+  public List<String> getFilters() {
+    return filters;
+  }
+
+  /** Maximum rows from limit push-down, null means no limit. */
+  @Nullable
+  public Long getLimit() {
+    return limit;
+  }
+
+  /** Aggregate push-down information, null means not applied. */
+  @Nullable
+  public AggregateInfo getAggregateInfo() {
+    return aggregateInfo;
+  }
+
+  /** Whether any push-down is active. */
+  public boolean hasPushDown() {
+    return projectedFields != null || !filters.isEmpty() || limit != null || aggregateInfo != null;
+  }
+
+  /** Create a new builder. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Create a new builder pre-populated with this handle's values. Useful for incremental push-down:
+   * the planner calls multiple push-down methods sequentially, each time creating a new handle with
+   * the accumulated state.
+   */
+  public Builder toBuilder() {
+    return new Builder()
+        .projectedFields(projectedFields)
+        .filters(filters)
+        .limit(limit)
+        .aggregateInfo(aggregateInfo);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    LanceSourceHandle that = (LanceSourceHandle) o;
+    return java.util.Arrays.equals(projectedFields, that.projectedFields)
+        && Objects.equals(filters, that.filters)
+        && Objects.equals(limit, that.limit)
+        && Objects.equals(aggregateInfo, that.aggregateInfo);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(filters, limit, aggregateInfo);
+    result = 31 * result + java.util.Arrays.hashCode(projectedFields);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "LanceSourceHandle{"
+        + "projectedFields="
+        + java.util.Arrays.toString(projectedFields)
+        + ", filters="
+        + filters
+        + ", limit="
+        + limit
+        + ", aggregateInfo="
+        + aggregateInfo
+        + '}';
+  }
+
+  /** Builder for {@link LanceSourceHandle}. */
+  public static class Builder {
+    private int[] projectedFields;
+    private List<String> filters;
+    private Long limit;
+    private AggregateInfo aggregateInfo;
+
+    public Builder projectedFields(@Nullable int[] projectedFields) {
+      this.projectedFields = projectedFields;
+      return this;
+    }
+
+    public Builder filters(List<String> filters) {
+      this.filters = filters;
+      return this;
+    }
+
+    public Builder limit(@Nullable Long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    public Builder aggregateInfo(@Nullable AggregateInfo aggregateInfo) {
+      this.aggregateInfo = aggregateInfo;
+      return this;
+    }
+
+    public LanceSourceHandle build() {
+      return new LanceSourceHandle(this);
+    }
+  }
+}

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceVectorSearchFunction.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceVectorSearchFunction.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.table;
 
 import org.apache.flink.connector.lance.LanceVectorSearch;
@@ -33,7 +28,6 @@ import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.table.types.inference.TypeInference;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.types.Row;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +40,7 @@ import java.util.List;
  * <p>Implements TableFunction, supports executing vector search in SQL.
  *
  * <p>Usage example:
+ *
  * <pre>{@code
  * -- Register UDF
  * CREATE TEMPORARY FUNCTION vector_search AS
@@ -59,292 +54,275 @@ import java.util.List;
  * }</pre>
  */
 @FunctionHint(
-    output = @DataTypeHint("ROW<id BIGINT, content STRING, embedding ARRAY<FLOAT>, _distance DOUBLE>")
-)
+    output =
+        @DataTypeHint("ROW<id BIGINT, content STRING, embedding ARRAY<FLOAT>, _distance DOUBLE>"))
 public class LanceVectorSearchFunction extends TableFunction<Row> {
 
-    private static final long serialVersionUID = 1L;
-    private static final Logger LOG = LoggerFactory.getLogger(LanceVectorSearchFunction.class);
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(LanceVectorSearchFunction.class);
 
-    private transient LanceVectorSearch vectorSearch;
-    private String currentDatasetPath;
-    private String currentColumnName;
+  private transient LanceVectorSearch vectorSearch;
+  private String currentDatasetPath;
+  private String currentColumnName;
 
-    @Override
-    public void open(FunctionContext context) throws Exception {
-        super.open(context);
-        LOG.info("Opening LanceVectorSearchFunction");
+  @Override
+  public void open(FunctionContext context) throws Exception {
+    super.open(context);
+    LOG.info("Opening LanceVectorSearchFunction");
+  }
+
+  @Override
+  public void close() throws Exception {
+    LOG.info("Closing LanceVectorSearchFunction");
+
+    if (vectorSearch != null) {
+      try {
+        vectorSearch.close();
+      } catch (Exception e) {
+        LOG.warn("Failed to close vector searcher", e);
+      }
+      vectorSearch = null;
     }
 
-    @Override
-    public void close() throws Exception {
-        LOG.info("Closing LanceVectorSearchFunction");
+    super.close();
+  }
+
+  /**
+   * Execute vector search
+   *
+   * @param datasetPath Dataset path
+   * @param columnName Vector column name
+   * @param queryVector Query vector
+   * @param k Number of nearest neighbors to return
+   * @param metric Distance metric type: L2, Cosine, Dot
+   */
+  public void eval(
+      String datasetPath, String columnName, Float[] queryVector, Integer k, String metric) {
+    try {
+      // Check if need to reinitialize vector searcher
+      if (vectorSearch == null
+          || !datasetPath.equals(currentDatasetPath)
+          || !columnName.equals(currentColumnName)) {
 
         if (vectorSearch != null) {
-            try {
-                vectorSearch.close();
-            } catch (Exception e) {
-                LOG.warn("Failed to close vector searcher", e);
-            }
-            vectorSearch = null;
+          vectorSearch.close();
         }
 
-        super.close();
-    }
+        LanceOptions.MetricType metricType =
+            LanceOptions.MetricType.fromValue(metric != null ? metric : "L2");
 
-    /**
-     * Execute vector search
-     *
-     * @param datasetPath Dataset path
-     * @param columnName Vector column name
-     * @param queryVector Query vector
-     * @param k Number of nearest neighbors to return
-     * @param metric Distance metric type: L2, Cosine, Dot
-     */
-    public void eval(String datasetPath, String columnName, Float[] queryVector, Integer k, String metric) {
-        try {
-            // Check if need to reinitialize vector searcher
-            if (vectorSearch == null ||
-                !datasetPath.equals(currentDatasetPath) ||
-                !columnName.equals(currentColumnName)) {
-
-                if (vectorSearch != null) {
-                    vectorSearch.close();
-                }
-
-                LanceOptions.MetricType metricType = LanceOptions.MetricType.fromValue(
-                        metric != null ? metric : "L2"
-                );
-
-                vectorSearch = LanceVectorSearch.builder()
-                        .datasetPath(datasetPath)
-                        .columnName(columnName)
-                        .metricType(metricType)
-                        .build();
-
-                vectorSearch.open();
-
-                currentDatasetPath = datasetPath;
-                currentColumnName = columnName;
-            }
-
-            // Convert query vector
-            float[] query = new float[queryVector.length];
-            for (int i = 0; i < queryVector.length; i++) {
-                query[i] = queryVector[i] != null ? queryVector[i] : 0.0f;
-            }
-
-            // Execute search
-            int topK = k != null ? k : 10;
-            List<LanceVectorSearch.SearchResult> results = vectorSearch.search(query, topK);
-
-            // Output results
-            for (LanceVectorSearch.SearchResult result : results) {
-                RowData rowData = result.getRowData();
-                double distance = result.getDistance();
-
-                // Build output Row
-                Row outputRow = convertToRow(rowData, distance);
-                if (outputRow != null) {
-                    collect(outputRow);
-                }
-            }
-
-        } catch (Exception e) {
-            LOG.error("Vector search failed", e);
-            throw new RuntimeException("Vector search failed: " + e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Simplified vector search (using default parameters)
-     *
-     * @param datasetPath Dataset path
-     * @param columnName Vector column name
-     * @param queryVector Query vector
-     * @param k Number of nearest neighbors to return
-     */
-    public void eval(String datasetPath, String columnName, Float[] queryVector, Integer k) {
-        eval(datasetPath, columnName, queryVector, k, "L2");
-    }
-
-    /**
-     * Most simplified vector search
-     *
-     * @param datasetPath Dataset path
-     * @param columnName Vector column name
-     * @param queryVector Query vector
-     */
-    public void eval(String datasetPath, String columnName, Float[] queryVector) {
-        eval(datasetPath, columnName, queryVector, 10, "L2");
-    }
-
-    // ==================== BigDecimal[] parameter overloads ====================
-    // ARRAY[0.1, 0.2, ...] in Flink SQL is parsed as BigDecimal[] type
-
-    /**
-     * Execute vector search (supports BigDecimal[] parameter)
-     *
-     * <p>ARRAY[0.1, 0.2, ...] literals in Flink SQL are parsed as DECIMAL type arrays,
-     * so this method overload is needed for support.
-     *
-     * @param datasetPath Dataset path
-     * @param columnName Vector column name
-     * @param queryVector Query vector (BigDecimal array)
-     * @param k Number of nearest neighbors to return
-     * @param metric Distance metric type: L2, Cosine, Dot
-     */
-    public void eval(String datasetPath, String columnName, BigDecimal[] queryVector, Integer k, String metric) {
-        Float[] floatVector = convertBigDecimalToFloat(queryVector);
-        eval(datasetPath, columnName, floatVector, k, metric);
-    }
-
-    /**
-     * Simplified vector search (BigDecimal[] parameter)
-     */
-    public void eval(String datasetPath, String columnName, BigDecimal[] queryVector, Integer k) {
-        eval(datasetPath, columnName, queryVector, k, "L2");
-    }
-
-    /**
-     * Most simplified vector search (BigDecimal[] parameter)
-     */
-    public void eval(String datasetPath, String columnName, BigDecimal[] queryVector) {
-        eval(datasetPath, columnName, queryVector, 10, "L2");
-    }
-
-    // ==================== Double[] parameter overloads ====================
-    // In some cases parameters may be parsed as Double[] type
-
-    /**
-     * Execute vector search (supports Double[] parameter)
-     */
-    public void eval(String datasetPath, String columnName, Double[] queryVector, Integer k, String metric) {
-        Float[] floatVector = convertDoubleToFloat(queryVector);
-        eval(datasetPath, columnName, floatVector, k, metric);
-    }
-
-    /**
-     * Simplified vector search (Double[] parameter)
-     */
-    public void eval(String datasetPath, String columnName, Double[] queryVector, Integer k) {
-        eval(datasetPath, columnName, queryVector, k, "L2");
-    }
-
-    /**
-     * Most simplified vector search (Double[] parameter)
-     */
-    public void eval(String datasetPath, String columnName, Double[] queryVector) {
-        eval(datasetPath, columnName, queryVector, 10, "L2");
-    }
-
-    // ==================== float[] primitive array parameter overloads ====================
-
-    /**
-     * Execute vector search (supports float[] primitive array parameter)
-     */
-    public void eval(String datasetPath, String columnName, float[] queryVector, Integer k, String metric) {
-        Float[] floatVector = new Float[queryVector.length];
-        for (int i = 0; i < queryVector.length; i++) {
-            floatVector[i] = queryVector[i];
-        }
-        eval(datasetPath, columnName, floatVector, k, metric);
-    }
-
-    /**
-     * Convert BigDecimal array to Float array
-     */
-    private Float[] convertBigDecimalToFloat(BigDecimal[] decimals) {
-        if (decimals == null) {
-            return new Float[0];
-        }
-        Float[] result = new Float[decimals.length];
-        for (int i = 0; i < decimals.length; i++) {
-            result[i] = decimals[i] != null ? decimals[i].floatValue() : 0.0f;
-        }
-        return result;
-    }
-
-    /**
-     * Convert Double array to Float array
-     */
-    private Float[] convertDoubleToFloat(Double[] doubles) {
-        if (doubles == null) {
-            return new Float[0];
-        }
-        Float[] result = new Float[doubles.length];
-        for (int i = 0; i < doubles.length; i++) {
-            result[i] = doubles[i] != null ? doubles[i].floatValue() : 0.0f;
-        }
-        return result;
-    }
-
-    /**
-     * Convert RowData to Row
-     */
-    private Row convertToRow(RowData rowData, double distance) {
-        if (rowData == null) {
-            return null;
-        }
-
-        if (rowData instanceof GenericRowData) {
-            GenericRowData genericRowData = (GenericRowData) rowData;
-            int arity = genericRowData.getArity();
-
-            // Create new Row including distance field
-            Object[] values = new Object[arity + 1];
-            for (int i = 0; i < arity; i++) {
-                Object field = genericRowData.getField(i);
-                values[i] = convertField(field);
-            }
-            values[arity] = distance;
-
-            return Row.of(values);
-        }
-
-        return null;
-    }
-
-    /**
-     * Convert field value
-     */
-    private Object convertField(Object field) {
-        if (field == null) {
-            return null;
-        }
-
-        if (field instanceof StringData) {
-            return ((StringData) field).toString();
-        }
-
-        if (field instanceof ArrayData) {
-            ArrayData arrayData = (ArrayData) field;
-            int size = arrayData.size();
-            Float[] result = new Float[size];
-            for (int i = 0; i < size; i++) {
-                if (arrayData.isNullAt(i)) {
-                    result[i] = null;
-                } else {
-                    result[i] = arrayData.getFloat(i);
-                }
-            }
-            return result;
-        }
-
-        return field;
-    }
-
-    @Override
-    public TypeInference getTypeInference(DataTypeFactory typeFactory) {
-        return TypeInference.newBuilder()
-                .outputTypeStrategy(TypeStrategies.explicit(
-                        DataTypes.ROW(
-                                DataTypes.FIELD("id", DataTypes.BIGINT()),
-                                DataTypes.FIELD("content", DataTypes.STRING()),
-                                DataTypes.FIELD("embedding", DataTypes.ARRAY(DataTypes.FLOAT())),
-                                DataTypes.FIELD("_distance", DataTypes.DOUBLE())
-                        )
-                ))
+        vectorSearch =
+            LanceVectorSearch.builder()
+                .datasetPath(datasetPath)
+                .columnName(columnName)
+                .metricType(metricType)
                 .build();
+
+        vectorSearch.open();
+
+        currentDatasetPath = datasetPath;
+        currentColumnName = columnName;
+      }
+
+      // Convert query vector
+      float[] query = new float[queryVector.length];
+      for (int i = 0; i < queryVector.length; i++) {
+        query[i] = queryVector[i] != null ? queryVector[i] : 0.0f;
+      }
+
+      // Execute search
+      int topK = k != null ? k : 10;
+      List<LanceVectorSearch.SearchResult> results = vectorSearch.search(query, topK);
+
+      // Output results
+      for (LanceVectorSearch.SearchResult result : results) {
+        RowData rowData = result.getRowData();
+        double distance = result.getDistance();
+
+        // Build output Row
+        Row outputRow = convertToRow(rowData, distance);
+        if (outputRow != null) {
+          collect(outputRow);
+        }
+      }
+
+    } catch (Exception e) {
+      LOG.error("Vector search failed", e);
+      throw new RuntimeException("Vector search failed: " + e.getMessage(), e);
     }
+  }
+
+  /**
+   * Simplified vector search (using default parameters)
+   *
+   * @param datasetPath Dataset path
+   * @param columnName Vector column name
+   * @param queryVector Query vector
+   * @param k Number of nearest neighbors to return
+   */
+  public void eval(String datasetPath, String columnName, Float[] queryVector, Integer k) {
+    eval(datasetPath, columnName, queryVector, k, "L2");
+  }
+
+  /**
+   * Most simplified vector search
+   *
+   * @param datasetPath Dataset path
+   * @param columnName Vector column name
+   * @param queryVector Query vector
+   */
+  public void eval(String datasetPath, String columnName, Float[] queryVector) {
+    eval(datasetPath, columnName, queryVector, 10, "L2");
+  }
+
+  // ==================== BigDecimal[] parameter overloads ====================
+  // ARRAY[0.1, 0.2, ...] in Flink SQL is parsed as BigDecimal[] type
+
+  /**
+   * Execute vector search (supports BigDecimal[] parameter)
+   *
+   * <p>ARRAY[0.1, 0.2, ...] literals in Flink SQL are parsed as DECIMAL type arrays, so this method
+   * overload is needed for support.
+   *
+   * @param datasetPath Dataset path
+   * @param columnName Vector column name
+   * @param queryVector Query vector (BigDecimal array)
+   * @param k Number of nearest neighbors to return
+   * @param metric Distance metric type: L2, Cosine, Dot
+   */
+  public void eval(
+      String datasetPath, String columnName, BigDecimal[] queryVector, Integer k, String metric) {
+    Float[] floatVector = convertBigDecimalToFloat(queryVector);
+    eval(datasetPath, columnName, floatVector, k, metric);
+  }
+
+  /** Simplified vector search (BigDecimal[] parameter) */
+  public void eval(String datasetPath, String columnName, BigDecimal[] queryVector, Integer k) {
+    eval(datasetPath, columnName, queryVector, k, "L2");
+  }
+
+  /** Most simplified vector search (BigDecimal[] parameter) */
+  public void eval(String datasetPath, String columnName, BigDecimal[] queryVector) {
+    eval(datasetPath, columnName, queryVector, 10, "L2");
+  }
+
+  // ==================== Double[] parameter overloads ====================
+  // In some cases parameters may be parsed as Double[] type
+
+  /** Execute vector search (supports Double[] parameter) */
+  public void eval(
+      String datasetPath, String columnName, Double[] queryVector, Integer k, String metric) {
+    Float[] floatVector = convertDoubleToFloat(queryVector);
+    eval(datasetPath, columnName, floatVector, k, metric);
+  }
+
+  /** Simplified vector search (Double[] parameter) */
+  public void eval(String datasetPath, String columnName, Double[] queryVector, Integer k) {
+    eval(datasetPath, columnName, queryVector, k, "L2");
+  }
+
+  /** Most simplified vector search (Double[] parameter) */
+  public void eval(String datasetPath, String columnName, Double[] queryVector) {
+    eval(datasetPath, columnName, queryVector, 10, "L2");
+  }
+
+  // ==================== float[] primitive array parameter overloads ====================
+
+  /** Execute vector search (supports float[] primitive array parameter) */
+  public void eval(
+      String datasetPath, String columnName, float[] queryVector, Integer k, String metric) {
+    Float[] floatVector = new Float[queryVector.length];
+    for (int i = 0; i < queryVector.length; i++) {
+      floatVector[i] = queryVector[i];
+    }
+    eval(datasetPath, columnName, floatVector, k, metric);
+  }
+
+  /** Convert BigDecimal array to Float array */
+  private Float[] convertBigDecimalToFloat(BigDecimal[] decimals) {
+    if (decimals == null) {
+      return new Float[0];
+    }
+    Float[] result = new Float[decimals.length];
+    for (int i = 0; i < decimals.length; i++) {
+      result[i] = decimals[i] != null ? decimals[i].floatValue() : 0.0f;
+    }
+    return result;
+  }
+
+  /** Convert Double array to Float array */
+  private Float[] convertDoubleToFloat(Double[] doubles) {
+    if (doubles == null) {
+      return new Float[0];
+    }
+    Float[] result = new Float[doubles.length];
+    for (int i = 0; i < doubles.length; i++) {
+      result[i] = doubles[i] != null ? doubles[i].floatValue() : 0.0f;
+    }
+    return result;
+  }
+
+  /** Convert RowData to Row */
+  private Row convertToRow(RowData rowData, double distance) {
+    if (rowData == null) {
+      return null;
+    }
+
+    if (rowData instanceof GenericRowData) {
+      GenericRowData genericRowData = (GenericRowData) rowData;
+      int arity = genericRowData.getArity();
+
+      // Create new Row including distance field
+      Object[] values = new Object[arity + 1];
+      for (int i = 0; i < arity; i++) {
+        Object field = genericRowData.getField(i);
+        values[i] = convertField(field);
+      }
+      values[arity] = distance;
+
+      return Row.of(values);
+    }
+
+    return null;
+  }
+
+  /** Convert field value */
+  private Object convertField(Object field) {
+    if (field == null) {
+      return null;
+    }
+
+    if (field instanceof StringData) {
+      return ((StringData) field).toString();
+    }
+
+    if (field instanceof ArrayData) {
+      ArrayData arrayData = (ArrayData) field;
+      int size = arrayData.size();
+      Float[] result = new Float[size];
+      for (int i = 0; i < size; i++) {
+        if (arrayData.isNullAt(i)) {
+          result[i] = null;
+        } else {
+          result[i] = arrayData.getFloat(i);
+        }
+      }
+      return result;
+    }
+
+    return field;
+  }
+
+  @Override
+  public TypeInference getTypeInference(DataTypeFactory typeFactory) {
+    return TypeInference.newBuilder()
+        .outputTypeStrategy(
+            TypeStrategies.explicit(
+                DataTypes.ROW(
+                    DataTypes.FIELD("id", DataTypes.BIGINT()),
+                    DataTypes.FIELD("content", DataTypes.STRING()),
+                    DataTypes.FIELD("embedding", DataTypes.ARRAY(DataTypes.FLOAT())),
+                    DataTypes.FIELD("_distance", DataTypes.DOUBLE()))))
+        .build();
+  }
 }

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceVectorSearchFunction.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceVectorSearchFunction.java
@@ -25,40 +25,33 @@ import org.apache.flink.table.annotation.FunctionHint;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.catalog.DataTypeFactory;
 import org.apache.flink.table.data.ArrayData;
-import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.TableFunction;
-import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.inference.TypeInference;
 import org.apache.flink.table.types.inference.TypeStrategies;
-import org.apache.flink.table.types.logical.ArrayType;
-import org.apache.flink.table.types.logical.DoubleType;
-import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.Row;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Lance vector search UDF.
- * 
+ *
  * <p>Implements TableFunction, supports executing vector search in SQL.
- * 
+ *
  * <p>Usage example:
  * <pre>{@code
  * -- Register UDF
- * CREATE TEMPORARY FUNCTION vector_search AS 
+ * CREATE TEMPORARY FUNCTION vector_search AS
  *     'org.apache.flink.connector.lance.table.LanceVectorSearchFunction'
  *     LANGUAGE JAVA USING JAR '/path/to/flink-connector-lance.jar';
- * 
+ *
  * -- Use UDF for vector search
  * SELECT * FROM TABLE(
  *     vector_search('/path/to/dataset', 'embedding', ARRAY[0.1, 0.2, 0.3], 10, 'L2')
@@ -86,7 +79,7 @@ public class LanceVectorSearchFunction extends TableFunction<Row> {
     @Override
     public void close() throws Exception {
         LOG.info("Closing LanceVectorSearchFunction");
-        
+
         if (vectorSearch != null) {
             try {
                 vectorSearch.close();
@@ -95,7 +88,7 @@ public class LanceVectorSearchFunction extends TableFunction<Row> {
             }
             vectorSearch = null;
         }
-        
+
         super.close();
     }
 
@@ -111,52 +104,52 @@ public class LanceVectorSearchFunction extends TableFunction<Row> {
     public void eval(String datasetPath, String columnName, Float[] queryVector, Integer k, String metric) {
         try {
             // Check if need to reinitialize vector searcher
-            if (vectorSearch == null || 
-                !datasetPath.equals(currentDatasetPath) || 
+            if (vectorSearch == null ||
+                !datasetPath.equals(currentDatasetPath) ||
                 !columnName.equals(currentColumnName)) {
-                
+
                 if (vectorSearch != null) {
                     vectorSearch.close();
                 }
-                
+
                 LanceOptions.MetricType metricType = LanceOptions.MetricType.fromValue(
                         metric != null ? metric : "L2"
                 );
-                
+
                 vectorSearch = LanceVectorSearch.builder()
                         .datasetPath(datasetPath)
                         .columnName(columnName)
                         .metricType(metricType)
                         .build();
-                
+
                 vectorSearch.open();
-                
+
                 currentDatasetPath = datasetPath;
                 currentColumnName = columnName;
             }
-            
+
             // Convert query vector
             float[] query = new float[queryVector.length];
             for (int i = 0; i < queryVector.length; i++) {
                 query[i] = queryVector[i] != null ? queryVector[i] : 0.0f;
             }
-            
+
             // Execute search
             int topK = k != null ? k : 10;
             List<LanceVectorSearch.SearchResult> results = vectorSearch.search(query, topK);
-            
+
             // Output results
             for (LanceVectorSearch.SearchResult result : results) {
                 RowData rowData = result.getRowData();
                 double distance = result.getDistance();
-                
+
                 // Build output Row
                 Row outputRow = convertToRow(rowData, distance);
                 if (outputRow != null) {
                     collect(outputRow);
                 }
             }
-            
+
         } catch (Exception e) {
             LOG.error("Vector search failed", e);
             throw new RuntimeException("Vector search failed: " + e.getMessage(), e);
@@ -191,7 +184,7 @@ public class LanceVectorSearchFunction extends TableFunction<Row> {
 
     /**
      * Execute vector search (supports BigDecimal[] parameter)
-     * 
+     *
      * <p>ARRAY[0.1, 0.2, ...] literals in Flink SQL are parsed as DECIMAL type arrays,
      * so this method overload is needed for support.
      *
@@ -293,11 +286,11 @@ public class LanceVectorSearchFunction extends TableFunction<Row> {
         if (rowData == null) {
             return null;
         }
-        
+
         if (rowData instanceof GenericRowData) {
             GenericRowData genericRowData = (GenericRowData) rowData;
             int arity = genericRowData.getArity();
-            
+
             // Create new Row including distance field
             Object[] values = new Object[arity + 1];
             for (int i = 0; i < arity; i++) {
@@ -305,10 +298,10 @@ public class LanceVectorSearchFunction extends TableFunction<Row> {
                 values[i] = convertField(field);
             }
             values[arity] = distance;
-            
+
             return Row.of(values);
         }
-        
+
         return null;
     }
 
@@ -319,11 +312,11 @@ public class LanceVectorSearchFunction extends TableFunction<Row> {
         if (field == null) {
             return null;
         }
-        
+
         if (field instanceof StringData) {
             return ((StringData) field).toString();
         }
-        
+
         if (field instanceof ArrayData) {
             ArrayData arrayData = (ArrayData) field;
             int size = arrayData.size();
@@ -337,7 +330,7 @@ public class LanceVectorSearchFunction extends TableFunction<Row> {
             }
             return result;
         }
-        
+
         return field;
     }
 

--- a/src/test/java/org/apache/flink/connector/lance/LanceConnectorITCase.java
+++ b/src/test/java/org/apache/flink/connector/lance/LanceConnectorITCase.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance;
 
 import org.apache.flink.connector.lance.config.LanceOptions;
@@ -39,7 +34,6 @@ import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -52,364 +46,353 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Lance Connector end-to-end integration tests.
- */
+/** Lance Connector end-to-end integration tests. */
 class LanceConnectorITCase {
 
-    @TempDir
-    Path tempDir;
+  @TempDir Path tempDir;
 
-    private String datasetPath;
-    private String warehousePath;
-    private RowType rowType;
-    private DataType dataType;
+  private String datasetPath;
+  private String warehousePath;
+  private RowType rowType;
+  private DataType dataType;
 
-    @BeforeEach
-    void setUp() {
-        datasetPath = tempDir.resolve("test_e2e_dataset").toString();
-        warehousePath = tempDir.resolve("test_e2e_warehouse").toString();
+  @BeforeEach
+  void setUp() {
+    datasetPath = tempDir.resolve("test_e2e_dataset").toString();
+    warehousePath = tempDir.resolve("test_e2e_warehouse").toString();
 
-        // Create test Schema
-        List<RowType.RowField> fields = new ArrayList<>();
-        fields.add(new RowType.RowField("id", new BigIntType()));
-        fields.add(new RowType.RowField("content", new VarCharType()));
-        fields.add(new RowType.RowField("embedding", new ArrayType(new FloatType())));
-        rowType = new RowType(fields);
+    // Create test Schema
+    List<RowType.RowField> fields = new ArrayList<>();
+    fields.add(new RowType.RowField("id", new BigIntType()));
+    fields.add(new RowType.RowField("content", new VarCharType()));
+    fields.add(new RowType.RowField("embedding", new ArrayType(new FloatType())));
+    rowType = new RowType(fields);
 
-        dataType = DataTypes.ROW(
-                DataTypes.FIELD("id", DataTypes.BIGINT()),
-                DataTypes.FIELD("content", DataTypes.STRING()),
-                DataTypes.FIELD("embedding", DataTypes.ARRAY(DataTypes.FLOAT()))
-        );
+    dataType =
+        DataTypes.ROW(
+            DataTypes.FIELD("id", DataTypes.BIGINT()),
+            DataTypes.FIELD("content", DataTypes.STRING()),
+            DataTypes.FIELD("embedding", DataTypes.ARRAY(DataTypes.FLOAT())));
+  }
+
+  @Test
+  @DisplayName("Test complete configuration options workflow")
+  void testCompleteOptionsWorkflow() {
+    // Build complete configuration
+    LanceOptions options =
+        LanceOptions.builder()
+            .path(datasetPath)
+            // Source configuration
+            .readBatchSize(512)
+            .readColumns(Arrays.asList("id", "content", "embedding"))
+            .readFilter("id > 0")
+            // Sink configuration
+            .writeBatchSize(256)
+            .writeMode(WriteMode.APPEND)
+            .writeMaxRowsPerFile(100000)
+            // Index configuration
+            .indexType(IndexType.IVF_PQ)
+            .indexColumn("embedding")
+            .indexNumPartitions(128)
+            .indexNumSubVectors(16)
+            .indexNumBits(8)
+            // Vector search configuration
+            .vectorColumn("embedding")
+            .vectorMetric(MetricType.L2)
+            .vectorNprobes(20)
+            .vectorEf(100)
+            // Catalog configuration
+            .defaultDatabase("default")
+            .warehouse(warehousePath)
+            .build();
+
+    // Verify all configurations
+    assertThat(options.getPath()).isEqualTo(datasetPath);
+    assertThat(options.getReadBatchSize()).isEqualTo(512);
+    assertThat(options.getReadColumns()).containsExactly("id", "content", "embedding");
+    assertThat(options.getReadFilter()).isEqualTo("id > 0");
+    assertThat(options.getWriteBatchSize()).isEqualTo(256);
+    assertThat(options.getWriteMode()).isEqualTo(WriteMode.APPEND);
+    assertThat(options.getWriteMaxRowsPerFile()).isEqualTo(100000);
+    assertThat(options.getIndexType()).isEqualTo(IndexType.IVF_PQ);
+    assertThat(options.getIndexColumn()).isEqualTo("embedding");
+    assertThat(options.getIndexNumPartitions()).isEqualTo(128);
+    assertThat(options.getIndexNumSubVectors()).isEqualTo(16);
+    assertThat(options.getIndexNumBits()).isEqualTo(8);
+    assertThat(options.getVectorColumn()).isEqualTo("embedding");
+    assertThat(options.getVectorMetric()).isEqualTo(MetricType.L2);
+    assertThat(options.getVectorNprobes()).isEqualTo(20);
+    assertThat(options.getVectorEf()).isEqualTo(100);
+    assertThat(options.getDefaultDatabase()).isEqualTo("default");
+    assertThat(options.getWarehouse()).isEqualTo(warehousePath);
+  }
+
+  @Test
+  @DisplayName("Test RowDataConverter data conversion workflow")
+  void testRowDataConverterWorkflow() {
+    RowDataConverter converter = new RowDataConverter(rowType);
+
+    // Create test data
+    List<RowData> testData = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      GenericRowData row = new GenericRowData(3);
+      row.setField(0, (long) i);
+      row.setField(1, StringData.fromString("Content " + i));
+
+      // Create vector data
+      Float[] vector = new Float[128];
+      for (int j = 0; j < 128; j++) {
+        vector[j] = (float) (i * 0.1 + j * 0.01);
+      }
+      row.setField(2, new GenericArrayData(vector));
+
+      testData.add(row);
     }
 
-    @Test
-    @DisplayName("Test complete configuration options workflow")
-    void testCompleteOptionsWorkflow() {
-        // Build complete configuration
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                // Source configuration
-                .readBatchSize(512)
-                .readColumns(Arrays.asList("id", "content", "embedding"))
-                .readFilter("id > 0")
-                // Sink configuration
-                .writeBatchSize(256)
-                .writeMode(WriteMode.APPEND)
-                .writeMaxRowsPerFile(100000)
-                // Index configuration
-                .indexType(IndexType.IVF_PQ)
-                .indexColumn("embedding")
-                .indexNumPartitions(128)
-                .indexNumSubVectors(16)
-                .indexNumBits(8)
-                // Vector search configuration
-                .vectorColumn("embedding")
-                .vectorMetric(MetricType.L2)
-                .vectorNprobes(20)
-                .vectorEf(100)
-                // Catalog configuration
-                .defaultDatabase("default")
-                .warehouse(warehousePath)
-                .build();
+    // Verify data creation succeeded
+    assertThat(testData).hasSize(10);
+    assertThat(converter.getRowType()).isEqualTo(rowType);
+    assertThat(converter.getFieldNames()).containsExactly("id", "content", "embedding");
+  }
 
-        // Verify all configurations
-        assertThat(options.getPath()).isEqualTo(datasetPath);
-        assertThat(options.getReadBatchSize()).isEqualTo(512);
-        assertThat(options.getReadColumns()).containsExactly("id", "content", "embedding");
-        assertThat(options.getReadFilter()).isEqualTo("id > 0");
-        assertThat(options.getWriteBatchSize()).isEqualTo(256);
-        assertThat(options.getWriteMode()).isEqualTo(WriteMode.APPEND);
-        assertThat(options.getWriteMaxRowsPerFile()).isEqualTo(100000);
-        assertThat(options.getIndexType()).isEqualTo(IndexType.IVF_PQ);
-        assertThat(options.getIndexColumn()).isEqualTo("embedding");
-        assertThat(options.getIndexNumPartitions()).isEqualTo(128);
-        assertThat(options.getIndexNumSubVectors()).isEqualTo(16);
-        assertThat(options.getIndexNumBits()).isEqualTo(8);
-        assertThat(options.getVectorColumn()).isEqualTo("embedding");
-        assertThat(options.getVectorMetric()).isEqualTo(MetricType.L2);
-        assertThat(options.getVectorNprobes()).isEqualTo(20);
-        assertThat(options.getVectorEf()).isEqualTo(100);
-        assertThat(options.getDefaultDatabase()).isEqualTo("default");
-        assertThat(options.getWarehouse()).isEqualTo(warehousePath);
-    }
+  @Test
+  @DisplayName("Test LanceSource builder pattern")
+  void testLanceSourceBuilder() {
+    LanceSource source =
+        LanceSource.builder()
+            .path(datasetPath)
+            .batchSize(256)
+            .columns(Arrays.asList("id", "embedding"))
+            .filter("id < 1000")
+            .rowType(rowType)
+            .build();
 
-    @Test
-    @DisplayName("Test RowDataConverter data conversion workflow")
-    void testRowDataConverterWorkflow() {
-        RowDataConverter converter = new RowDataConverter(rowType);
+    assertThat(source.getOptions().getPath()).isEqualTo(datasetPath);
+    assertThat(source.getOptions().getReadBatchSize()).isEqualTo(256);
+    assertThat(source.getSelectedColumns()).containsExactly("id", "embedding");
+    assertThat(source.getRowType()).isEqualTo(rowType);
+  }
 
-        // Create test data
-        List<RowData> testData = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
-            GenericRowData row = new GenericRowData(3);
-            row.setField(0, (long) i);
-            row.setField(1, StringData.fromString("Content " + i));
+  @Test
+  @DisplayName("Test LanceSink builder pattern")
+  void testLanceSinkBuilder() {
+    LanceSink sink =
+        LanceSink.builder()
+            .path(datasetPath)
+            .batchSize(128)
+            .writeMode(WriteMode.OVERWRITE)
+            .maxRowsPerFile(50000)
+            .rowType(rowType)
+            .build();
 
-            // Create vector data
-            Float[] vector = new Float[128];
-            for (int j = 0; j < 128; j++) {
-                vector[j] = (float) (i * 0.1 + j * 0.01);
-            }
-            row.setField(2, new GenericArrayData(vector));
+    assertThat(sink.getOptions().getPath()).isEqualTo(datasetPath);
+    assertThat(sink.getOptions().getWriteBatchSize()).isEqualTo(128);
+    assertThat(sink.getOptions().getWriteMode()).isEqualTo(WriteMode.OVERWRITE);
+    assertThat(sink.getOptions().getWriteMaxRowsPerFile()).isEqualTo(50000);
+    assertThat(sink.getRowType()).isEqualTo(rowType);
+  }
 
-            testData.add(row);
-        }
+  @Test
+  @DisplayName("Test LanceIndexBuilder builder pattern")
+  void testLanceIndexBuilder() {
+    LanceIndexBuilder builder =
+        LanceIndexBuilder.builder()
+            .datasetPath(datasetPath)
+            .columnName("embedding")
+            .indexType(IndexType.IVF_HNSW)
+            .metricType(MetricType.COSINE)
+            .numPartitions(64)
+            .maxLevel(5)
+            .maxEdges(24)
+            .efConstruction(200)
+            .replace(true)
+            .build();
 
-        // Verify data creation succeeded
-        assertThat(testData).hasSize(10);
-        assertThat(converter.getRowType()).isEqualTo(rowType);
-        assertThat(converter.getFieldNames()).containsExactly("id", "content", "embedding");
-    }
+    assertThat(builder).isNotNull();
+  }
 
-    @Test
-    @DisplayName("Test LanceSource builder pattern")
-    void testLanceSourceBuilder() {
-        LanceSource source = LanceSource.builder()
-                .path(datasetPath)
-                .batchSize(256)
-                .columns(Arrays.asList("id", "embedding"))
-                .filter("id < 1000")
-                .rowType(rowType)
-                .build();
+  @Test
+  @DisplayName("Test LanceVectorSearch builder pattern")
+  void testLanceVectorSearchBuilder() {
+    LanceVectorSearch search =
+        LanceVectorSearch.builder()
+            .datasetPath(datasetPath)
+            .columnName("embedding")
+            .metricType(MetricType.DOT)
+            .nprobes(30)
+            .ef(150)
+            .refineFactor(5)
+            .build();
 
-        assertThat(source.getOptions().getPath()).isEqualTo(datasetPath);
-        assertThat(source.getOptions().getReadBatchSize()).isEqualTo(256);
-        assertThat(source.getSelectedColumns()).containsExactly("id", "embedding");
-        assertThat(source.getRowType()).isEqualTo(rowType);
-    }
+    assertThat(search).isNotNull();
+  }
 
-    @Test
-    @DisplayName("Test LanceSink builder pattern")
-    void testLanceSinkBuilder() {
-        LanceSink sink = LanceSink.builder()
-                .path(datasetPath)
-                .batchSize(128)
-                .writeMode(WriteMode.OVERWRITE)
-                .maxRowsPerFile(50000)
-                .rowType(rowType)
-                .build();
+  @Test
+  @DisplayName("Test Table API component creation")
+  void testTableApiComponents() {
+    LanceOptions options = LanceOptions.builder().path(datasetPath).build();
 
-        assertThat(sink.getOptions().getPath()).isEqualTo(datasetPath);
-        assertThat(sink.getOptions().getWriteBatchSize()).isEqualTo(128);
-        assertThat(sink.getOptions().getWriteMode()).isEqualTo(WriteMode.OVERWRITE);
-        assertThat(sink.getOptions().getWriteMaxRowsPerFile()).isEqualTo(50000);
-        assertThat(sink.getRowType()).isEqualTo(rowType);
-    }
+    // Create DynamicTableSource
+    LanceDynamicTableSource source = new LanceDynamicTableSource(options, dataType);
+    assertThat(source.asSummaryString()).isEqualTo("Lance Table Source");
 
-    @Test
-    @DisplayName("Test LanceIndexBuilder builder pattern")
-    void testLanceIndexBuilder() {
-        LanceIndexBuilder builder = LanceIndexBuilder.builder()
-                .datasetPath(datasetPath)
-                .columnName("embedding")
-                .indexType(IndexType.IVF_HNSW)
-                .metricType(MetricType.COSINE)
-                .numPartitions(64)
-                .maxLevel(5)
-                .maxEdges(24)
-                .efConstruction(200)
-                .replace(true)
-                .build();
+    // Create DynamicTableSink
+    LanceDynamicTableSink sink = new LanceDynamicTableSink(options, dataType);
+    assertThat(sink.asSummaryString()).isEqualTo("Lance Table Sink");
 
-        assertThat(builder).isNotNull();
-    }
+    // Create Factory
+    LanceDynamicTableFactory factory = new LanceDynamicTableFactory();
+    assertThat(factory.factoryIdentifier()).isEqualTo("lance");
+  }
 
-    @Test
-    @DisplayName("Test LanceVectorSearch builder pattern")
-    void testLanceVectorSearchBuilder() {
-        LanceVectorSearch search = LanceVectorSearch.builder()
-                .datasetPath(datasetPath)
-                .columnName("embedding")
-                .metricType(MetricType.DOT)
-                .nprobes(30)
-                .ef(150)
-                .refineFactor(5)
-                .build();
+  @Test
+  @DisplayName("Test Catalog lifecycle")
+  void testCatalogLifecycle() throws Exception {
+    LanceCatalog catalog = new LanceCatalog("test_catalog", "default", warehousePath);
 
-        assertThat(search).isNotNull();
-    }
+    // Open Catalog
+    catalog.open();
+    assertThat(catalog.getDefaultDatabase()).isEqualTo("default");
+    assertThat(catalog.getWarehouse()).isEqualTo(warehousePath);
 
-    @Test
-    @DisplayName("Test Table API component creation")
-    void testTableApiComponents() {
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .build();
+    // Verify default database exists
+    assertThat(catalog.databaseExists("default")).isTrue();
 
-        // Create DynamicTableSource
-        LanceDynamicTableSource source = new LanceDynamicTableSource(options, dataType);
-        assertThat(source.asSummaryString()).isEqualTo("Lance Table Source");
+    // Create test database
+    catalog.createDatabase("test_db", null, true);
+    assertThat(catalog.databaseExists("test_db")).isTrue();
+    assertThat(catalog.listDatabases()).contains("default", "test_db");
 
-        // Create DynamicTableSink
-        LanceDynamicTableSink sink = new LanceDynamicTableSink(options, dataType);
-        assertThat(sink.asSummaryString()).isEqualTo("Lance Table Sink");
+    // List empty tables
+    assertThat(catalog.listTables("test_db")).isEmpty();
 
-        // Create Factory
-        LanceDynamicTableFactory factory = new LanceDynamicTableFactory();
-        assertThat(factory.factoryIdentifier()).isEqualTo("lance");
-    }
+    // Drop test database
+    catalog.dropDatabase("test_db", true, true);
+    assertThat(catalog.databaseExists("test_db")).isFalse();
 
-    @Test
-    @DisplayName("Test Catalog lifecycle")
-    void testCatalogLifecycle() throws Exception {
-        LanceCatalog catalog = new LanceCatalog("test_catalog", "default", warehousePath);
+    // Close Catalog
+    catalog.close();
+  }
 
-        // Open Catalog
-        catalog.open();
-        assertThat(catalog.getDefaultDatabase()).isEqualTo("default");
-        assertThat(catalog.getWarehouse()).isEqualTo(warehousePath);
+  @Test
+  @DisplayName("Test type conversion bidirectional consistency")
+  void testTypeConversionConsistency() {
+    // Flink RowType -> Arrow Schema -> Flink RowType
+    org.apache.arrow.vector.types.pojo.Schema arrowSchema =
+        LanceTypeConverter.toArrowSchema(rowType);
+    RowType convertedRowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
 
-        // Verify default database exists
-        assertThat(catalog.databaseExists("default")).isTrue();
+    // Verify field count
+    assertThat(convertedRowType.getFieldCount()).isEqualTo(rowType.getFieldCount());
 
-        // Create test database
-        catalog.createDatabase("test_db", null, true);
-        assertThat(catalog.databaseExists("test_db")).isTrue();
-        assertThat(catalog.listDatabases()).contains("default", "test_db");
+    // Verify field names
+    assertThat(convertedRowType.getFieldNames()).isEqualTo(rowType.getFieldNames());
+  }
 
-        // List empty tables
-        assertThat(catalog.listTables("test_db")).isEmpty();
+  @Test
+  @DisplayName("Test vector data conversion")
+  void testVectorDataConversion() {
+    // Create float array
+    float[] originalVector = new float[] {0.1f, 0.2f, 0.3f, 0.4f, 0.5f};
 
-        // Drop test database
-        catalog.dropDatabase("test_db", true, true);
-        assertThat(catalog.databaseExists("test_db")).isFalse();
+    // Convert to ArrayData
+    org.apache.flink.table.data.ArrayData arrayData = RowDataConverter.toArrayData(originalVector);
 
-        // Close Catalog
-        catalog.close();
-    }
+    // Convert back to float array
+    float[] convertedVector = RowDataConverter.toFloatArray(arrayData);
 
-    @Test
-    @DisplayName("Test type conversion bidirectional consistency")
-    void testTypeConversionConsistency() {
-        // Flink RowType -> Arrow Schema -> Flink RowType
-        org.apache.arrow.vector.types.pojo.Schema arrowSchema =
-                LanceTypeConverter.toArrowSchema(rowType);
-        RowType convertedRowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
+    // Verify consistency
+    assertThat(convertedVector).containsExactly(originalVector);
+  }
 
-        // Verify field count
-        assertThat(convertedRowType.getFieldCount()).isEqualTo(rowType.getFieldCount());
+  @Test
+  @DisplayName("Test double vector data conversion")
+  void testDoubleVectorDataConversion() {
+    // Create double array
+    double[] originalVector = new double[] {0.1, 0.2, 0.3, 0.4, 0.5};
 
-        // Verify field names
-        assertThat(convertedRowType.getFieldNames()).isEqualTo(rowType.getFieldNames());
-    }
+    // Convert to ArrayData
+    org.apache.flink.table.data.ArrayData arrayData = RowDataConverter.toArrayData(originalVector);
 
-    @Test
-    @DisplayName("Test vector data conversion")
-    void testVectorDataConversion() {
-        // Create float array
-        float[] originalVector = new float[] {0.1f, 0.2f, 0.3f, 0.4f, 0.5f};
+    // Convert back to double array
+    double[] convertedVector = RowDataConverter.toDoubleArray(arrayData);
 
-        // Convert to ArrayData
-        org.apache.flink.table.data.ArrayData arrayData =
-                RowDataConverter.toArrayData(originalVector);
+    // Verify consistency
+    assertThat(convertedVector).containsExactly(originalVector);
+  }
 
-        // Convert back to float array
-        float[] convertedVector = RowDataConverter.toFloatArray(arrayData);
+  @Test
+  @DisplayName("Test LanceSplit serialization compatibility")
+  void testLanceSplitSerialization() {
+    LanceSplit split1 = new LanceSplit(0, 1, datasetPath, 10000);
+    LanceSplit split2 = new LanceSplit(0, 1, datasetPath, 10000);
+    LanceSplit split3 = new LanceSplit(1, 2, datasetPath, 20000);
 
-        // Verify consistency
-        assertThat(convertedVector).containsExactly(originalVector);
-    }
+    // Equality test
+    assertThat(split1).isEqualTo(split2);
+    assertThat(split1.hashCode()).isEqualTo(split2.hashCode());
+    assertThat(split1).isNotEqualTo(split3);
 
-    @Test
-    @DisplayName("Test double vector data conversion")
-    void testDoubleVectorDataConversion() {
-        // Create double array
-        double[] originalVector = new double[] {0.1, 0.2, 0.3, 0.4, 0.5};
+    // toString test
+    String str = split1.toString();
+    assertThat(str).contains("LanceSplit");
+    assertThat(str).contains("fragmentId=1");
+    assertThat(str).contains("rowCount=10000");
+  }
 
-        // Convert to ArrayData
-        org.apache.flink.table.data.ArrayData arrayData =
-                RowDataConverter.toArrayData(originalVector);
+  @Test
+  @DisplayName("Test search result similarity calculation")
+  void testSearchResultSimilarityCalculation() {
+    // Perfect match (distance=0)
+    LanceVectorSearch.SearchResult perfectMatch = new LanceVectorSearch.SearchResult(null, 0.0);
+    assertThat(perfectMatch.getSimilarity()).isEqualTo(1.0);
 
-        // Convert back to double array
-        double[] convertedVector = RowDataConverter.toDoubleArray(arrayData);
+    // Normal match (distance=1)
+    LanceVectorSearch.SearchResult normalMatch = new LanceVectorSearch.SearchResult(null, 1.0);
+    assertThat(normalMatch.getSimilarity()).isEqualTo(0.5);
 
-        // Verify consistency
-        assertThat(convertedVector).containsExactly(originalVector);
-    }
+    // Far match (distance=9)
+    LanceVectorSearch.SearchResult farMatch = new LanceVectorSearch.SearchResult(null, 9.0);
+    assertThat(farMatch.getSimilarity()).isEqualTo(0.1);
+  }
 
-    @Test
-    @DisplayName("Test LanceSplit serialization compatibility")
-    void testLanceSplitSerialization() {
-        LanceSplit split1 = new LanceSplit(0, 1, datasetPath, 10000);
-        LanceSplit split2 = new LanceSplit(0, 1, datasetPath, 10000);
-        LanceSplit split3 = new LanceSplit(1, 2, datasetPath, 20000);
+  @Test
+  @DisplayName("Test options toString and hashCode")
+  void testOptionsToStringAndHashCode() {
+    LanceOptions options1 = LanceOptions.builder().path(datasetPath).readBatchSize(512).build();
 
-        // Equality test
-        assertThat(split1).isEqualTo(split2);
-        assertThat(split1.hashCode()).isEqualTo(split2.hashCode());
-        assertThat(split1).isNotEqualTo(split3);
+    LanceOptions options2 = LanceOptions.builder().path(datasetPath).readBatchSize(512).build();
 
-        // toString test
-        String str = split1.toString();
-        assertThat(str).contains("LanceSplit");
-        assertThat(str).contains("fragmentId=1");
-        assertThat(str).contains("rowCount=10000");
-    }
+    // hashCode equals
+    assertThat(options1.hashCode()).isEqualTo(options2.hashCode());
 
-    @Test
-    @DisplayName("Test search result similarity calculation")
-    void testSearchResultSimilarityCalculation() {
-        // Perfect match (distance=0)
-        LanceVectorSearch.SearchResult perfectMatch =
-                new LanceVectorSearch.SearchResult(null, 0.0);
-        assertThat(perfectMatch.getSimilarity()).isEqualTo(1.0);
+    // equals
+    assertThat(options1).isEqualTo(options2);
 
-        // Normal match (distance=1)
-        LanceVectorSearch.SearchResult normalMatch =
-                new LanceVectorSearch.SearchResult(null, 1.0);
-        assertThat(normalMatch.getSimilarity()).isEqualTo(0.5);
+    // toString contains key info
+    String str = options1.toString();
+    assertThat(str).contains("LanceOptions");
+    assertThat(str).contains("readBatchSize=512");
+  }
 
-        // Far match (distance=9)
-        LanceVectorSearch.SearchResult farMatch =
-                new LanceVectorSearch.SearchResult(null, 9.0);
-        assertThat(farMatch.getSimilarity()).isEqualTo(0.1);
-    }
+  @Test
+  @DisplayName("Test all enum types")
+  void testAllEnumTypes() {
+    // WriteMode
+    assertThat(WriteMode.values()).hasSize(2);
+    assertThat(WriteMode.APPEND.getValue()).isEqualTo("append");
+    assertThat(WriteMode.OVERWRITE.getValue()).isEqualTo("overwrite");
 
-    @Test
-    @DisplayName("Test options toString and hashCode")
-    void testOptionsToStringAndHashCode() {
-        LanceOptions options1 = LanceOptions.builder()
-                .path(datasetPath)
-                .readBatchSize(512)
-                .build();
+    // IndexType
+    assertThat(IndexType.values()).hasSize(3);
+    assertThat(IndexType.IVF_PQ.getValue()).isEqualTo("IVF_PQ");
+    assertThat(IndexType.IVF_HNSW.getValue()).isEqualTo("IVF_HNSW");
+    assertThat(IndexType.IVF_FLAT.getValue()).isEqualTo("IVF_FLAT");
 
-        LanceOptions options2 = LanceOptions.builder()
-                .path(datasetPath)
-                .readBatchSize(512)
-                .build();
-
-        // hashCode equals
-        assertThat(options1.hashCode()).isEqualTo(options2.hashCode());
-
-        // equals
-        assertThat(options1).isEqualTo(options2);
-
-        // toString contains key info
-        String str = options1.toString();
-        assertThat(str).contains("LanceOptions");
-        assertThat(str).contains("readBatchSize=512");
-    }
-
-    @Test
-    @DisplayName("Test all enum types")
-    void testAllEnumTypes() {
-        // WriteMode
-        assertThat(WriteMode.values()).hasSize(2);
-        assertThat(WriteMode.APPEND.getValue()).isEqualTo("append");
-        assertThat(WriteMode.OVERWRITE.getValue()).isEqualTo("overwrite");
-
-        // IndexType
-        assertThat(IndexType.values()).hasSize(3);
-        assertThat(IndexType.IVF_PQ.getValue()).isEqualTo("IVF_PQ");
-        assertThat(IndexType.IVF_HNSW.getValue()).isEqualTo("IVF_HNSW");
-        assertThat(IndexType.IVF_FLAT.getValue()).isEqualTo("IVF_FLAT");
-
-        // MetricType
-        assertThat(MetricType.values()).hasSize(3);
-        assertThat(MetricType.L2.getValue()).isEqualTo("L2");
-        assertThat(MetricType.COSINE.getValue()).isEqualTo("Cosine");
-        assertThat(MetricType.DOT.getValue()).isEqualTo("Dot");
-    }
+    // MetricType
+    assertThat(MetricType.values()).hasSize(3);
+    assertThat(MetricType.L2.getValue()).isEqualTo("L2");
+    assertThat(MetricType.COSINE.getValue()).isEqualTo("Cosine");
+    assertThat(MetricType.DOT.getValue()).isEqualTo("Dot");
+  }
 }

--- a/src/test/java/org/apache/flink/connector/lance/LanceConnectorITCase.java
+++ b/src/test/java/org/apache/flink/connector/lance/LanceConnectorITCase.java
@@ -208,7 +208,7 @@ class LanceConnectorITCase {
                 .metricType(MetricType.COSINE)
                 .numPartitions(64)
                 .maxLevel(5)
-                .m(24)
+                .maxEdges(24)
                 .efConstruction(200)
                 .replace(true)
                 .build();
@@ -284,7 +284,7 @@ class LanceConnectorITCase {
     @DisplayName("Test type conversion bidirectional consistency")
     void testTypeConversionConsistency() {
         // Flink RowType -> Arrow Schema -> Flink RowType
-        org.apache.arrow.vector.types.pojo.Schema arrowSchema = 
+        org.apache.arrow.vector.types.pojo.Schema arrowSchema =
                 LanceTypeConverter.toArrowSchema(rowType);
         RowType convertedRowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
 
@@ -302,7 +302,7 @@ class LanceConnectorITCase {
         float[] originalVector = new float[] {0.1f, 0.2f, 0.3f, 0.4f, 0.5f};
 
         // Convert to ArrayData
-        org.apache.flink.table.data.ArrayData arrayData = 
+        org.apache.flink.table.data.ArrayData arrayData =
                 RowDataConverter.toArrayData(originalVector);
 
         // Convert back to float array
@@ -319,7 +319,7 @@ class LanceConnectorITCase {
         double[] originalVector = new double[] {0.1, 0.2, 0.3, 0.4, 0.5};
 
         // Convert to ArrayData
-        org.apache.flink.table.data.ArrayData arrayData = 
+        org.apache.flink.table.data.ArrayData arrayData =
                 RowDataConverter.toArrayData(originalVector);
 
         // Convert back to double array
@@ -352,17 +352,17 @@ class LanceConnectorITCase {
     @DisplayName("Test search result similarity calculation")
     void testSearchResultSimilarityCalculation() {
         // Perfect match (distance=0)
-        LanceVectorSearch.SearchResult perfectMatch = 
+        LanceVectorSearch.SearchResult perfectMatch =
                 new LanceVectorSearch.SearchResult(null, 0.0);
         assertThat(perfectMatch.getSimilarity()).isEqualTo(1.0);
 
         // Normal match (distance=1)
-        LanceVectorSearch.SearchResult normalMatch = 
+        LanceVectorSearch.SearchResult normalMatch =
                 new LanceVectorSearch.SearchResult(null, 1.0);
         assertThat(normalMatch.getSimilarity()).isEqualTo(0.5);
 
         // Far match (distance=9)
-        LanceVectorSearch.SearchResult farMatch = 
+        LanceVectorSearch.SearchResult farMatch =
                 new LanceVectorSearch.SearchResult(null, 9.0);
         assertThat(farMatch.getSimilarity()).isEqualTo(0.1);
     }

--- a/src/test/java/org/apache/flink/connector/lance/LanceIndexBuilderTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/LanceIndexBuilderTest.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,13 +11,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance;
 
 import org.apache.flink.connector.lance.config.LanceOptions;
 import org.apache.flink.connector.lance.config.LanceOptions.IndexType;
 import org.apache.flink.connector.lance.config.LanceOptions.MetricType;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -32,258 +26,260 @@ import java.nio.file.Path;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/**
- * LanceIndexBuilder unit tests.
- */
+/** LanceIndexBuilder unit tests. */
 class LanceIndexBuilderTest {
 
-    @TempDir
-    Path tempDir;
+  @TempDir Path tempDir;
 
-    private String datasetPath;
+  private String datasetPath;
 
-    @BeforeEach
-    void setUp() {
-        datasetPath = tempDir.resolve("test_index_dataset").toString();
-    }
+  @BeforeEach
+  void setUp() {
+    datasetPath = tempDir.resolve("test_index_dataset").toString();
+  }
 
-    @Test
-    @DisplayName("Test IVF_PQ index configuration build")
-    void testIvfPqIndexConfiguration() {
-        LanceIndexBuilder builder = LanceIndexBuilder.builder()
-                .datasetPath(datasetPath)
-                .columnName("embedding")
-                .indexType(IndexType.IVF_PQ)
-                .numPartitions(128)
-                .numSubVectors(16)
-                .numBits(8)
-                .metricType(MetricType.L2)
-                .build();
+  @Test
+  @DisplayName("Test IVF_PQ index configuration build")
+  void testIvfPqIndexConfiguration() {
+    LanceIndexBuilder builder =
+        LanceIndexBuilder.builder()
+            .datasetPath(datasetPath)
+            .columnName("embedding")
+            .indexType(IndexType.IVF_PQ)
+            .numPartitions(128)
+            .numSubVectors(16)
+            .numBits(8)
+            .metricType(MetricType.L2)
+            .build();
 
-        // Verify configuration - by successful build
-        assertThat(builder).isNotNull();
-    }
+    // Verify configuration - by successful build
+    assertThat(builder).isNotNull();
+  }
 
-    @Test
-    @DisplayName("Test IVF_HNSW index configuration build")
-    void testIvfHnswIndexConfiguration() {
-        LanceIndexBuilder builder = LanceIndexBuilder.builder()
-                .datasetPath(datasetPath)
-                .columnName("embedding")
-                .indexType(IndexType.IVF_HNSW)
-                .numPartitions(64)
-                .maxLevel(5)
-                .maxEdges(24)
-                .efConstruction(200)
-                .metricType(MetricType.COSINE)
-                .build();
+  @Test
+  @DisplayName("Test IVF_HNSW index configuration build")
+  void testIvfHnswIndexConfiguration() {
+    LanceIndexBuilder builder =
+        LanceIndexBuilder.builder()
+            .datasetPath(datasetPath)
+            .columnName("embedding")
+            .indexType(IndexType.IVF_HNSW)
+            .numPartitions(64)
+            .maxLevel(5)
+            .maxEdges(24)
+            .efConstruction(200)
+            .metricType(MetricType.COSINE)
+            .build();
 
-        assertThat(builder).isNotNull();
-    }
+    assertThat(builder).isNotNull();
+  }
 
-    @Test
-    @DisplayName("Test IVF_FLAT index configuration build")
-    void testIvfFlatIndexConfiguration() {
-        LanceIndexBuilder builder = LanceIndexBuilder.builder()
-                .datasetPath(datasetPath)
-                .columnName("embedding")
-                .indexType(IndexType.IVF_FLAT)
-                .numPartitions(256)
-                .metricType(MetricType.DOT)
-                .build();
+  @Test
+  @DisplayName("Test IVF_FLAT index configuration build")
+  void testIvfFlatIndexConfiguration() {
+    LanceIndexBuilder builder =
+        LanceIndexBuilder.builder()
+            .datasetPath(datasetPath)
+            .columnName("embedding")
+            .indexType(IndexType.IVF_FLAT)
+            .numPartitions(256)
+            .metricType(MetricType.DOT)
+            .build();
 
-        assertThat(builder).isNotNull();
-    }
+    assertThat(builder).isNotNull();
+  }
 
-    @Test
-    @DisplayName("Test index type enum")
-    void testIndexTypeEnum() {
-        assertThat(IndexType.fromValue("IVF_PQ")).isEqualTo(IndexType.IVF_PQ);
-        assertThat(IndexType.fromValue("ivf_pq")).isEqualTo(IndexType.IVF_PQ);
-        assertThat(IndexType.fromValue("IVF_HNSW")).isEqualTo(IndexType.IVF_HNSW);
-        assertThat(IndexType.fromValue("IVF_FLAT")).isEqualTo(IndexType.IVF_FLAT);
+  @Test
+  @DisplayName("Test index type enum")
+  void testIndexTypeEnum() {
+    assertThat(IndexType.fromValue("IVF_PQ")).isEqualTo(IndexType.IVF_PQ);
+    assertThat(IndexType.fromValue("ivf_pq")).isEqualTo(IndexType.IVF_PQ);
+    assertThat(IndexType.fromValue("IVF_HNSW")).isEqualTo(IndexType.IVF_HNSW);
+    assertThat(IndexType.fromValue("IVF_FLAT")).isEqualTo(IndexType.IVF_FLAT);
 
-        assertThat(IndexType.IVF_PQ.getValue()).isEqualTo("IVF_PQ");
-        assertThat(IndexType.IVF_HNSW.getValue()).isEqualTo("IVF_HNSW");
-        assertThat(IndexType.IVF_FLAT.getValue()).isEqualTo("IVF_FLAT");
-    }
+    assertThat(IndexType.IVF_PQ.getValue()).isEqualTo("IVF_PQ");
+    assertThat(IndexType.IVF_HNSW.getValue()).isEqualTo("IVF_HNSW");
+    assertThat(IndexType.IVF_FLAT.getValue()).isEqualTo("IVF_FLAT");
+  }
 
-    @Test
-    @DisplayName("Test invalid index type")
-    void testInvalidIndexType() {
-        assertThatThrownBy(() -> IndexType.fromValue("INVALID"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Unsupported index type");
-    }
+  @Test
+  @DisplayName("Test invalid index type")
+  void testInvalidIndexType() {
+    assertThatThrownBy(() -> IndexType.fromValue("INVALID"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unsupported index type");
+  }
 
-    @Test
-    @DisplayName("Test metric type enum")
-    void testMetricTypeEnum() {
-        assertThat(MetricType.fromValue("L2")).isEqualTo(MetricType.L2);
-        assertThat(MetricType.fromValue("l2")).isEqualTo(MetricType.L2);
-        assertThat(MetricType.fromValue("Cosine")).isEqualTo(MetricType.COSINE);
-        assertThat(MetricType.fromValue("cosine")).isEqualTo(MetricType.COSINE);
-        assertThat(MetricType.fromValue("Dot")).isEqualTo(MetricType.DOT);
-        assertThat(MetricType.fromValue("dot")).isEqualTo(MetricType.DOT);
+  @Test
+  @DisplayName("Test metric type enum")
+  void testMetricTypeEnum() {
+    assertThat(MetricType.fromValue("L2")).isEqualTo(MetricType.L2);
+    assertThat(MetricType.fromValue("l2")).isEqualTo(MetricType.L2);
+    assertThat(MetricType.fromValue("Cosine")).isEqualTo(MetricType.COSINE);
+    assertThat(MetricType.fromValue("cosine")).isEqualTo(MetricType.COSINE);
+    assertThat(MetricType.fromValue("Dot")).isEqualTo(MetricType.DOT);
+    assertThat(MetricType.fromValue("dot")).isEqualTo(MetricType.DOT);
 
-        assertThat(MetricType.L2.getValue()).isEqualTo("L2");
-        assertThat(MetricType.COSINE.getValue()).isEqualTo("Cosine");
-        assertThat(MetricType.DOT.getValue()).isEqualTo("Dot");
-    }
+    assertThat(MetricType.L2.getValue()).isEqualTo("L2");
+    assertThat(MetricType.COSINE.getValue()).isEqualTo("Cosine");
+    assertThat(MetricType.DOT.getValue()).isEqualTo("Dot");
+  }
 
-    @Test
-    @DisplayName("Test invalid metric type")
-    void testInvalidMetricType() {
-        assertThatThrownBy(() -> MetricType.fromValue("INVALID"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Unsupported metric type");
-    }
+  @Test
+  @DisplayName("Test invalid metric type")
+  void testInvalidMetricType() {
+    assertThatThrownBy(() -> MetricType.fromValue("INVALID"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unsupported metric type");
+  }
 
-    @Test
-    @DisplayName("Test exception when missing dataset path")
-    void testMissingDatasetPath() {
-        assertThatThrownBy(() -> LanceIndexBuilder.builder()
-                .columnName("embedding")
-                .indexType(IndexType.IVF_PQ)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Dataset path cannot be empty");
-    }
+  @Test
+  @DisplayName("Test exception when missing dataset path")
+  void testMissingDatasetPath() {
+    assertThatThrownBy(
+            () ->
+                LanceIndexBuilder.builder()
+                    .columnName("embedding")
+                    .indexType(IndexType.IVF_PQ)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Dataset path cannot be empty");
+  }
 
-    @Test
-    @DisplayName("Test exception when missing column name")
-    void testMissingColumnName() {
-        assertThatThrownBy(() -> LanceIndexBuilder.builder()
-                .datasetPath(datasetPath)
-                .indexType(IndexType.IVF_PQ)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Column name cannot be empty");
-    }
+  @Test
+  @DisplayName("Test exception when missing column name")
+  void testMissingColumnName() {
+    assertThatThrownBy(
+            () ->
+                LanceIndexBuilder.builder()
+                    .datasetPath(datasetPath)
+                    .indexType(IndexType.IVF_PQ)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Column name cannot be empty");
+  }
 
-    @Test
-    @DisplayName("Test invalid number of partitions")
-    void testInvalidNumPartitions() {
-        assertThatThrownBy(() -> LanceIndexBuilder.builder()
-                .datasetPath(datasetPath)
-                .columnName("embedding")
-                .numPartitions(0)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Number of partitions must be greater than 0");
-    }
+  @Test
+  @DisplayName("Test invalid number of partitions")
+  void testInvalidNumPartitions() {
+    assertThatThrownBy(
+            () ->
+                LanceIndexBuilder.builder()
+                    .datasetPath(datasetPath)
+                    .columnName("embedding")
+                    .numPartitions(0)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Number of partitions must be greater than 0");
+  }
 
-    @Test
-    @DisplayName("Test invalid number of sub-vectors")
-    void testInvalidNumSubVectors() {
-        assertThatThrownBy(() -> LanceIndexBuilder.builder()
-                .datasetPath(datasetPath)
-                .columnName("embedding")
-                .numSubVectors(-1)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Number of sub-vectors must be greater than 0");
-    }
+  @Test
+  @DisplayName("Test invalid number of sub-vectors")
+  void testInvalidNumSubVectors() {
+    assertThatThrownBy(
+            () ->
+                LanceIndexBuilder.builder()
+                    .datasetPath(datasetPath)
+                    .columnName("embedding")
+                    .numSubVectors(-1)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Number of sub-vectors must be greater than 0");
+  }
 
-    @Test
-    @DisplayName("Test invalid number of quantization bits")
-    void testInvalidNumBits() {
-        assertThatThrownBy(() -> LanceIndexBuilder.builder()
-                .datasetPath(datasetPath)
-                .columnName("embedding")
-                .numBits(0)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Quantization bits must be between 1 and 16");
+  @Test
+  @DisplayName("Test invalid number of quantization bits")
+  void testInvalidNumBits() {
+    assertThatThrownBy(
+            () ->
+                LanceIndexBuilder.builder()
+                    .datasetPath(datasetPath)
+                    .columnName("embedding")
+                    .numBits(0)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Quantization bits must be between 1 and 16");
 
-        assertThatThrownBy(() -> LanceIndexBuilder.builder()
-                .datasetPath(datasetPath)
-                .columnName("embedding")
-                .numBits(17)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Quantization bits must be between 1 and 16");
-    }
+    assertThatThrownBy(
+            () ->
+                LanceIndexBuilder.builder()
+                    .datasetPath(datasetPath)
+                    .columnName("embedding")
+                    .numBits(17)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Quantization bits must be between 1 and 16");
+  }
 
-    @Test
-    @DisplayName("Test default index configuration values")
-    void testDefaultIndexConfiguration() {
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .indexColumn("embedding")
-                .build();
+  @Test
+  @DisplayName("Test default index configuration values")
+  void testDefaultIndexConfiguration() {
+    LanceOptions options =
+        LanceOptions.builder().path(datasetPath).indexColumn("embedding").build();
 
-        // Verify default values
-        assertThat(options.getIndexType()).isEqualTo(IndexType.IVF_PQ);
-        assertThat(options.getIndexNumPartitions()).isEqualTo(256);
-        assertThat(options.getIndexNumBits()).isEqualTo(8);
-        assertThat(options.getIndexMaxLevel()).isEqualTo(7);
-        assertThat(options.getIndexM()).isEqualTo(16);
-        assertThat(options.getIndexEfConstruction()).isEqualTo(100);
-    }
+    // Verify default values
+    assertThat(options.getIndexType()).isEqualTo(IndexType.IVF_PQ);
+    assertThat(options.getIndexNumPartitions()).isEqualTo(256);
+    assertThat(options.getIndexNumBits()).isEqualTo(8);
+    assertThat(options.getIndexMaxLevel()).isEqualTo(7);
+    assertThat(options.getIndexM()).isEqualTo(16);
+    assertThat(options.getIndexEfConstruction()).isEqualTo(100);
+  }
 
-    @Test
-    @DisplayName("Test creating index builder from LanceOptions")
-    void testFromOptions() {
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .indexColumn("embedding")
-                .indexType(IndexType.IVF_HNSW)
-                .indexNumPartitions(64)
-                .vectorMetric(MetricType.COSINE)
-                .build();
+  @Test
+  @DisplayName("Test creating index builder from LanceOptions")
+  void testFromOptions() {
+    LanceOptions options =
+        LanceOptions.builder()
+            .path(datasetPath)
+            .indexColumn("embedding")
+            .indexType(IndexType.IVF_HNSW)
+            .indexNumPartitions(64)
+            .vectorMetric(MetricType.COSINE)
+            .build();
 
-        LanceIndexBuilder builder = LanceIndexBuilder.fromOptions(options);
+    LanceIndexBuilder builder = LanceIndexBuilder.fromOptions(options);
 
-        assertThat(builder).isNotNull();
-    }
+    assertThat(builder).isNotNull();
+  }
 
-    @Test
-    @DisplayName("Test index build result")
-    void testIndexBuildResult() {
-        LanceIndexBuilder.IndexBuildResult result = new LanceIndexBuilder.IndexBuildResult(
-                true,
-                IndexType.IVF_PQ,
-                "embedding",
-                datasetPath,
-                1000,
-                null
-        );
+  @Test
+  @DisplayName("Test index build result")
+  void testIndexBuildResult() {
+    LanceIndexBuilder.IndexBuildResult result =
+        new LanceIndexBuilder.IndexBuildResult(
+            true, IndexType.IVF_PQ, "embedding", datasetPath, 1000, null);
 
-        assertThat(result.isSuccess()).isTrue();
-        assertThat(result.getIndexType()).isEqualTo(IndexType.IVF_PQ);
-        assertThat(result.getColumnName()).isEqualTo("embedding");
-        assertThat(result.getDatasetPath()).isEqualTo(datasetPath);
-        assertThat(result.getDurationMillis()).isEqualTo(1000);
-        assertThat(result.getErrorMessage()).isNull();
-    }
+    assertThat(result.isSuccess()).isTrue();
+    assertThat(result.getIndexType()).isEqualTo(IndexType.IVF_PQ);
+    assertThat(result.getColumnName()).isEqualTo("embedding");
+    assertThat(result.getDatasetPath()).isEqualTo(datasetPath);
+    assertThat(result.getDurationMillis()).isEqualTo(1000);
+    assertThat(result.getErrorMessage()).isNull();
+  }
 
-    @Test
-    @DisplayName("Test index build failure result")
-    void testIndexBuildFailureResult() {
-        LanceIndexBuilder.IndexBuildResult result = new LanceIndexBuilder.IndexBuildResult(
-                false,
-                IndexType.IVF_PQ,
-                "embedding",
-                datasetPath,
-                500,
-                "Column does not exist"
-        );
+  @Test
+  @DisplayName("Test index build failure result")
+  void testIndexBuildFailureResult() {
+    LanceIndexBuilder.IndexBuildResult result =
+        new LanceIndexBuilder.IndexBuildResult(
+            false, IndexType.IVF_PQ, "embedding", datasetPath, 500, "Column does not exist");
 
-        assertThat(result.isSuccess()).isFalse();
-        assertThat(result.getErrorMessage()).isEqualTo("Column does not exist");
-    }
+    assertThat(result.isSuccess()).isFalse();
+    assertThat(result.getErrorMessage()).isEqualTo("Column does not exist");
+  }
 
-    @Test
-    @DisplayName("Test replace index option")
-    void testReplaceIndexOption() {
-        LanceIndexBuilder builder = LanceIndexBuilder.builder()
-                .datasetPath(datasetPath)
-                .columnName("embedding")
-                .indexType(IndexType.IVF_PQ)
-                .replace(true)
-                .build();
+  @Test
+  @DisplayName("Test replace index option")
+  void testReplaceIndexOption() {
+    LanceIndexBuilder builder =
+        LanceIndexBuilder.builder()
+            .datasetPath(datasetPath)
+            .columnName("embedding")
+            .indexType(IndexType.IVF_PQ)
+            .replace(true)
+            .build();
 
-        assertThat(builder).isNotNull();
-    }
+    assertThat(builder).isNotNull();
+  }
 }

--- a/src/test/java/org/apache/flink/connector/lance/LanceIndexBuilderTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/LanceIndexBuilderTest.java
@@ -73,7 +73,7 @@ class LanceIndexBuilderTest {
                 .indexType(IndexType.IVF_HNSW)
                 .numPartitions(64)
                 .maxLevel(5)
-                .m(24)
+                .maxEdges(24)
                 .efConstruction(200)
                 .metricType(MetricType.COSINE)
                 .build();

--- a/src/test/java/org/apache/flink/connector/lance/LanceSinkTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/LanceSinkTest.java
@@ -51,7 +51,7 @@ class LanceSinkTest {
     @BeforeEach
     void setUp() {
         datasetPath = tempDir.resolve("test_sink_dataset").toString();
-        
+
         // Create test RowType
         List<RowType.RowField> fields = new ArrayList<>();
         fields.add(new RowType.RowField("id", new BigIntType()));

--- a/src/test/java/org/apache/flink/connector/lance/LanceSinkTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/LanceSinkTest.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance;
 
 import org.apache.flink.connector.lance.config.LanceOptions;
@@ -24,7 +19,6 @@ import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,177 +31,159 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/**
- * LanceSink unit tests.
- */
+/** LanceSink unit tests. */
 class LanceSinkTest {
 
-    @TempDir
-    Path tempDir;
+  @TempDir Path tempDir;
 
-    private String datasetPath;
-    private RowType rowType;
+  private String datasetPath;
+  private RowType rowType;
 
-    @BeforeEach
-    void setUp() {
-        datasetPath = tempDir.resolve("test_sink_dataset").toString();
+  @BeforeEach
+  void setUp() {
+    datasetPath = tempDir.resolve("test_sink_dataset").toString();
 
-        // Create test RowType
-        List<RowType.RowField> fields = new ArrayList<>();
-        fields.add(new RowType.RowField("id", new BigIntType()));
-        fields.add(new RowType.RowField("content", new VarCharType()));
-        fields.add(new RowType.RowField("embedding", new ArrayType(new FloatType())));
-        rowType = new RowType(fields);
-    }
+    // Create test RowType
+    List<RowType.RowField> fields = new ArrayList<>();
+    fields.add(new RowType.RowField("id", new BigIntType()));
+    fields.add(new RowType.RowField("content", new VarCharType()));
+    fields.add(new RowType.RowField("embedding", new ArrayType(new FloatType())));
+    rowType = new RowType(fields);
+  }
 
-    @Test
-    @DisplayName("Test LanceSink configuration build")
-    void testSinkConfiguration() {
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .writeBatchSize(512)
-                .writeMode(LanceOptions.WriteMode.APPEND)
-                .writeMaxRowsPerFile(500000)
-                .build();
+  @Test
+  @DisplayName("Test LanceSink configuration build")
+  void testSinkConfiguration() {
+    LanceOptions options =
+        LanceOptions.builder()
+            .path(datasetPath)
+            .writeBatchSize(512)
+            .writeMode(LanceOptions.WriteMode.APPEND)
+            .writeMaxRowsPerFile(500000)
+            .build();
 
-        LanceSink sink = new LanceSink(options, rowType);
+    LanceSink sink = new LanceSink(options, rowType);
 
-        assertThat(sink.getOptions().getPath()).isEqualTo(datasetPath);
-        assertThat(sink.getOptions().getWriteBatchSize()).isEqualTo(512);
-        assertThat(sink.getOptions().getWriteMode()).isEqualTo(LanceOptions.WriteMode.APPEND);
-        assertThat(sink.getOptions().getWriteMaxRowsPerFile()).isEqualTo(500000);
-        assertThat(sink.getRowType()).isEqualTo(rowType);
-    }
+    assertThat(sink.getOptions().getPath()).isEqualTo(datasetPath);
+    assertThat(sink.getOptions().getWriteBatchSize()).isEqualTo(512);
+    assertThat(sink.getOptions().getWriteMode()).isEqualTo(LanceOptions.WriteMode.APPEND);
+    assertThat(sink.getOptions().getWriteMaxRowsPerFile()).isEqualTo(500000);
+    assertThat(sink.getRowType()).isEqualTo(rowType);
+  }
 
-    @Test
-    @DisplayName("Test LanceSink Builder pattern")
-    void testSinkBuilder() {
-        LanceSink sink = LanceSink.builder()
-                .path(datasetPath)
-                .batchSize(256)
-                .writeMode(LanceOptions.WriteMode.OVERWRITE)
-                .maxRowsPerFile(100000)
-                .rowType(rowType)
-                .build();
+  @Test
+  @DisplayName("Test LanceSink Builder pattern")
+  void testSinkBuilder() {
+    LanceSink sink =
+        LanceSink.builder()
+            .path(datasetPath)
+            .batchSize(256)
+            .writeMode(LanceOptions.WriteMode.OVERWRITE)
+            .maxRowsPerFile(100000)
+            .rowType(rowType)
+            .build();
 
-        assertThat(sink.getOptions().getPath()).isEqualTo(datasetPath);
-        assertThat(sink.getOptions().getWriteBatchSize()).isEqualTo(256);
-        assertThat(sink.getOptions().getWriteMode()).isEqualTo(LanceOptions.WriteMode.OVERWRITE);
-        assertThat(sink.getOptions().getWriteMaxRowsPerFile()).isEqualTo(100000);
-    }
+    assertThat(sink.getOptions().getPath()).isEqualTo(datasetPath);
+    assertThat(sink.getOptions().getWriteBatchSize()).isEqualTo(256);
+    assertThat(sink.getOptions().getWriteMode()).isEqualTo(LanceOptions.WriteMode.OVERWRITE);
+    assertThat(sink.getOptions().getWriteMaxRowsPerFile()).isEqualTo(100000);
+  }
 
-    @Test
-    @DisplayName("Test LanceSink Builder throws exception when missing path")
-    void testSinkBuilderMissingPath() {
-        assertThatThrownBy(() -> LanceSink.builder()
-                .rowType(rowType)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Dataset path cannot be empty");
-    }
+  @Test
+  @DisplayName("Test LanceSink Builder throws exception when missing path")
+  void testSinkBuilderMissingPath() {
+    assertThatThrownBy(() -> LanceSink.builder().rowType(rowType).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Dataset path cannot be empty");
+  }
 
-    @Test
-    @DisplayName("Test LanceSink Builder throws exception when missing RowType")
-    void testSinkBuilderMissingRowType() {
-        assertThatThrownBy(() -> LanceSink.builder()
-                .path(datasetPath)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("RowType");
-    }
+  @Test
+  @DisplayName("Test LanceSink Builder throws exception when missing RowType")
+  void testSinkBuilderMissingRowType() {
+    assertThatThrownBy(() -> LanceSink.builder().path(datasetPath).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("RowType");
+  }
 
-    @Test
-    @DisplayName("Test default Sink configuration values")
-    void testDefaultSinkConfiguration() {
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .build();
+  @Test
+  @DisplayName("Test default Sink configuration values")
+  void testDefaultSinkConfiguration() {
+    LanceOptions options = LanceOptions.builder().path(datasetPath).build();
 
-        // Verify default values
-        assertThat(options.getWriteBatchSize()).isEqualTo(1024);
-        assertThat(options.getWriteMode()).isEqualTo(LanceOptions.WriteMode.APPEND);
-        assertThat(options.getWriteMaxRowsPerFile()).isEqualTo(1000000);
-    }
+    // Verify default values
+    assertThat(options.getWriteBatchSize()).isEqualTo(1024);
+    assertThat(options.getWriteMode()).isEqualTo(LanceOptions.WriteMode.APPEND);
+    assertThat(options.getWriteMaxRowsPerFile()).isEqualTo(1000000);
+  }
 
-    @Test
-    @DisplayName("Test write mode enum")
-    void testWriteMode() {
-        assertThat(LanceOptions.WriteMode.fromValue("append"))
-                .isEqualTo(LanceOptions.WriteMode.APPEND);
-        assertThat(LanceOptions.WriteMode.fromValue("APPEND"))
-                .isEqualTo(LanceOptions.WriteMode.APPEND);
-        assertThat(LanceOptions.WriteMode.fromValue("overwrite"))
-                .isEqualTo(LanceOptions.WriteMode.OVERWRITE);
-        assertThat(LanceOptions.WriteMode.fromValue("OVERWRITE"))
-                .isEqualTo(LanceOptions.WriteMode.OVERWRITE);
-    }
+  @Test
+  @DisplayName("Test write mode enum")
+  void testWriteMode() {
+    assertThat(LanceOptions.WriteMode.fromValue("append")).isEqualTo(LanceOptions.WriteMode.APPEND);
+    assertThat(LanceOptions.WriteMode.fromValue("APPEND")).isEqualTo(LanceOptions.WriteMode.APPEND);
+    assertThat(LanceOptions.WriteMode.fromValue("overwrite"))
+        .isEqualTo(LanceOptions.WriteMode.OVERWRITE);
+    assertThat(LanceOptions.WriteMode.fromValue("OVERWRITE"))
+        .isEqualTo(LanceOptions.WriteMode.OVERWRITE);
+  }
 
-    @Test
-    @DisplayName("Test invalid write mode")
-    void testInvalidWriteMode() {
-        assertThatThrownBy(() -> LanceOptions.WriteMode.fromValue("invalid"))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Unsupported write mode");
-    }
+  @Test
+  @DisplayName("Test invalid write mode")
+  void testInvalidWriteMode() {
+    assertThatThrownBy(() -> LanceOptions.WriteMode.fromValue("invalid"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unsupported write mode");
+  }
 
-    @Test
-    @DisplayName("Test configuration validation - invalid write batch size")
-    void testInvalidWriteBatchSize() {
-        assertThatThrownBy(() -> LanceOptions.builder()
-                .path(datasetPath)
-                .writeBatchSize(0)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("batch-size");
-    }
+  @Test
+  @DisplayName("Test configuration validation - invalid write batch size")
+  void testInvalidWriteBatchSize() {
+    assertThatThrownBy(() -> LanceOptions.builder().path(datasetPath).writeBatchSize(0).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("batch-size");
+  }
 
-    @Test
-    @DisplayName("Test configuration validation - invalid max rows per file")
-    void testInvalidMaxRowsPerFile() {
-        assertThatThrownBy(() -> LanceOptions.builder()
-                .path(datasetPath)
-                .writeMaxRowsPerFile(-1)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("max-rows-per-file");
-    }
+  @Test
+  @DisplayName("Test configuration validation - invalid max rows per file")
+  void testInvalidMaxRowsPerFile() {
+    assertThatThrownBy(
+            () -> LanceOptions.builder().path(datasetPath).writeMaxRowsPerFile(-1).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("max-rows-per-file");
+  }
 
-    @Test
-    @DisplayName("Test vector type write configuration")
-    void testVectorWriteConfiguration() {
-        List<RowType.RowField> fields = new ArrayList<>();
-        fields.add(new RowType.RowField("id", new BigIntType()));
-        fields.add(new RowType.RowField("embedding", new ArrayType(new FloatType())));
-        RowType vectorRowType = new RowType(fields);
+  @Test
+  @DisplayName("Test vector type write configuration")
+  void testVectorWriteConfiguration() {
+    List<RowType.RowField> fields = new ArrayList<>();
+    fields.add(new RowType.RowField("id", new BigIntType()));
+    fields.add(new RowType.RowField("embedding", new ArrayType(new FloatType())));
+    RowType vectorRowType = new RowType(fields);
 
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .writeBatchSize(100)
-                .build();
+    LanceOptions options = LanceOptions.builder().path(datasetPath).writeBatchSize(100).build();
 
-        LanceSink sink = new LanceSink(options, vectorRowType);
+    LanceSink sink = new LanceSink(options, vectorRowType);
 
-        assertThat(sink.getRowType().getFieldCount()).isEqualTo(2);
-        assertThat(sink.getRowType().getTypeAt(1)).isInstanceOf(ArrayType.class);
-    }
+    assertThat(sink.getRowType().getFieldCount()).isEqualTo(2);
+    assertThat(sink.getRowType().getTypeAt(1)).isInstanceOf(ArrayType.class);
+  }
 
-    @Test
-    @DisplayName("Test APPEND and OVERWRITE mode configuration")
-    void testWriteModeConfiguration() {
-        // APPEND mode
-        LanceOptions appendOptions = LanceOptions.builder()
-                .path(datasetPath)
-                .writeMode(LanceOptions.WriteMode.APPEND)
-                .build();
-        assertThat(appendOptions.getWriteMode()).isEqualTo(LanceOptions.WriteMode.APPEND);
-        assertThat(appendOptions.getWriteMode().getValue()).isEqualTo("append");
+  @Test
+  @DisplayName("Test APPEND and OVERWRITE mode configuration")
+  void testWriteModeConfiguration() {
+    // APPEND mode
+    LanceOptions appendOptions =
+        LanceOptions.builder().path(datasetPath).writeMode(LanceOptions.WriteMode.APPEND).build();
+    assertThat(appendOptions.getWriteMode()).isEqualTo(LanceOptions.WriteMode.APPEND);
+    assertThat(appendOptions.getWriteMode().getValue()).isEqualTo("append");
 
-        // OVERWRITE mode
-        LanceOptions overwriteOptions = LanceOptions.builder()
-                .path(datasetPath)
-                .writeMode(LanceOptions.WriteMode.OVERWRITE)
-                .build();
-        assertThat(overwriteOptions.getWriteMode()).isEqualTo(LanceOptions.WriteMode.OVERWRITE);
-        assertThat(overwriteOptions.getWriteMode().getValue()).isEqualTo("overwrite");
-    }
+    // OVERWRITE mode
+    LanceOptions overwriteOptions =
+        LanceOptions.builder()
+            .path(datasetPath)
+            .writeMode(LanceOptions.WriteMode.OVERWRITE)
+            .build();
+    assertThat(overwriteOptions.getWriteMode()).isEqualTo(LanceOptions.WriteMode.OVERWRITE);
+    assertThat(overwriteOptions.getWriteMode().getValue()).isEqualTo("overwrite");
+  }
 }

--- a/src/test/java/org/apache/flink/connector/lance/LanceSourceTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/LanceSourceTest.java
@@ -52,7 +52,7 @@ class LanceSourceTest {
     @BeforeEach
     void setUp() {
         datasetPath = tempDir.resolve("test_dataset").toString();
-        
+
         // Create test RowType
         List<RowType.RowField> fields = new ArrayList<>();
         fields.add(new RowType.RowField("id", new BigIntType()));

--- a/src/test/java/org/apache/flink/connector/lance/LanceSourceTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/LanceSourceTest.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance;
 
 import org.apache.flink.connector.lance.config.LanceOptions;
@@ -24,7 +19,6 @@ import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,151 +32,138 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/**
- * LanceSource unit tests.
- */
+/** LanceSource unit tests. */
 class LanceSourceTest {
 
-    @TempDir
-    Path tempDir;
+  @TempDir Path tempDir;
 
-    private String datasetPath;
-    private RowType rowType;
+  private String datasetPath;
+  private RowType rowType;
 
-    @BeforeEach
-    void setUp() {
-        datasetPath = tempDir.resolve("test_dataset").toString();
+  @BeforeEach
+  void setUp() {
+    datasetPath = tempDir.resolve("test_dataset").toString();
 
-        // Create test RowType
-        List<RowType.RowField> fields = new ArrayList<>();
-        fields.add(new RowType.RowField("id", new BigIntType()));
-        fields.add(new RowType.RowField("content", new VarCharType()));
-        fields.add(new RowType.RowField("embedding", new ArrayType(new FloatType())));
-        rowType = new RowType(fields);
-    }
+    // Create test RowType
+    List<RowType.RowField> fields = new ArrayList<>();
+    fields.add(new RowType.RowField("id", new BigIntType()));
+    fields.add(new RowType.RowField("content", new VarCharType()));
+    fields.add(new RowType.RowField("embedding", new ArrayType(new FloatType())));
+    rowType = new RowType(fields);
+  }
 
-    @Test
-    @DisplayName("Test LanceSource configuration build")
-    void testSourceConfiguration() {
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .readBatchSize(512)
-                .readColumns(Arrays.asList("id", "content"))
-                .readFilter("id > 10")
-                .build();
+  @Test
+  @DisplayName("Test LanceSource configuration build")
+  void testSourceConfiguration() {
+    LanceOptions options =
+        LanceOptions.builder()
+            .path(datasetPath)
+            .readBatchSize(512)
+            .readColumns(Arrays.asList("id", "content"))
+            .readFilter("id > 10")
+            .build();
 
-        LanceSource source = new LanceSource(options, rowType);
+    LanceSource source = new LanceSource(options, rowType);
 
-        assertThat(source.getOptions().getPath()).isEqualTo(datasetPath);
-        assertThat(source.getOptions().getReadBatchSize()).isEqualTo(512);
-        assertThat(source.getOptions().getReadColumns()).containsExactly("id", "content");
-        assertThat(source.getOptions().getReadFilter()).isEqualTo("id > 10");
-        assertThat(source.getRowType()).isEqualTo(rowType);
-    }
+    assertThat(source.getOptions().getPath()).isEqualTo(datasetPath);
+    assertThat(source.getOptions().getReadBatchSize()).isEqualTo(512);
+    assertThat(source.getOptions().getReadColumns()).containsExactly("id", "content");
+    assertThat(source.getOptions().getReadFilter()).isEqualTo("id > 10");
+    assertThat(source.getRowType()).isEqualTo(rowType);
+  }
 
-    @Test
-    @DisplayName("Test LanceSource Builder pattern")
-    void testSourceBuilder() {
-        LanceSource source = LanceSource.builder()
-                .path(datasetPath)
-                .batchSize(256)
-                .columns(Arrays.asList("id"))
-                .filter("id < 100")
-                .rowType(rowType)
-                .build();
+  @Test
+  @DisplayName("Test LanceSource Builder pattern")
+  void testSourceBuilder() {
+    LanceSource source =
+        LanceSource.builder()
+            .path(datasetPath)
+            .batchSize(256)
+            .columns(Arrays.asList("id"))
+            .filter("id < 100")
+            .rowType(rowType)
+            .build();
 
-        assertThat(source.getOptions().getPath()).isEqualTo(datasetPath);
-        assertThat(source.getOptions().getReadBatchSize()).isEqualTo(256);
-        assertThat(source.getSelectedColumns()).containsExactly("id");
-    }
+    assertThat(source.getOptions().getPath()).isEqualTo(datasetPath);
+    assertThat(source.getOptions().getReadBatchSize()).isEqualTo(256);
+    assertThat(source.getSelectedColumns()).containsExactly("id");
+  }
 
-    @Test
-    @DisplayName("Test LanceSource Builder throws exception when missing path")
-    void testSourceBuilderMissingPath() {
-        assertThatThrownBy(() -> LanceSource.builder()
-                .rowType(rowType)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Dataset path cannot be empty");
-    }
+  @Test
+  @DisplayName("Test LanceSource Builder throws exception when missing path")
+  void testSourceBuilderMissingPath() {
+    assertThatThrownBy(() -> LanceSource.builder().rowType(rowType).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Dataset path cannot be empty");
+  }
 
-    @Test
-    @DisplayName("Test LanceSplit creation")
-    void testLanceSplit() {
-        LanceSplit split = new LanceSplit(0, 1, datasetPath, 1000);
+  @Test
+  @DisplayName("Test LanceSplit creation")
+  void testLanceSplit() {
+    LanceSplit split = new LanceSplit(0, 1, datasetPath, 1000);
 
-        assertThat(split.getSplitNumber()).isEqualTo(0);
-        assertThat(split.getFragmentId()).isEqualTo(1);
-        assertThat(split.getDatasetPath()).isEqualTo(datasetPath);
-        assertThat(split.getRowCount()).isEqualTo(1000);
-    }
+    assertThat(split.getSplitNumber()).isEqualTo(0);
+    assertThat(split.getFragmentId()).isEqualTo(1);
+    assertThat(split.getDatasetPath()).isEqualTo(datasetPath);
+    assertThat(split.getRowCount()).isEqualTo(1000);
+  }
 
-    @Test
-    @DisplayName("Test LanceSplit equality")
-    void testLanceSplitEquality() {
-        LanceSplit split1 = new LanceSplit(0, 1, datasetPath, 1000);
-        LanceSplit split2 = new LanceSplit(0, 1, datasetPath, 1000);
-        LanceSplit split3 = new LanceSplit(1, 2, datasetPath, 2000);
+  @Test
+  @DisplayName("Test LanceSplit equality")
+  void testLanceSplitEquality() {
+    LanceSplit split1 = new LanceSplit(0, 1, datasetPath, 1000);
+    LanceSplit split2 = new LanceSplit(0, 1, datasetPath, 1000);
+    LanceSplit split3 = new LanceSplit(1, 2, datasetPath, 2000);
 
-        assertThat(split1).isEqualTo(split2);
-        assertThat(split1.hashCode()).isEqualTo(split2.hashCode());
-        assertThat(split1).isNotEqualTo(split3);
-    }
+    assertThat(split1).isEqualTo(split2);
+    assertThat(split1.hashCode()).isEqualTo(split2.hashCode());
+    assertThat(split1).isNotEqualTo(split3);
+  }
 
-    @Test
-    @DisplayName("Test LanceInputFormat configuration")
-    void testInputFormatConfiguration() {
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .readBatchSize(128)
-                .build();
+  @Test
+  @DisplayName("Test LanceInputFormat configuration")
+  void testInputFormatConfiguration() {
+    LanceOptions options = LanceOptions.builder().path(datasetPath).readBatchSize(128).build();
 
-        LanceInputFormat inputFormat = new LanceInputFormat(options, rowType);
+    LanceInputFormat inputFormat = new LanceInputFormat(options, rowType);
 
-        assertThat(inputFormat.getOptions().getPath()).isEqualTo(datasetPath);
-        assertThat(inputFormat.getOptions().getReadBatchSize()).isEqualTo(128);
-        assertThat(inputFormat.getRowType()).isEqualTo(rowType);
-    }
+    assertThat(inputFormat.getOptions().getPath()).isEqualTo(datasetPath);
+    assertThat(inputFormat.getOptions().getReadBatchSize()).isEqualTo(128);
+    assertThat(inputFormat.getRowType()).isEqualTo(rowType);
+  }
 
-    @Test
-    @DisplayName("Test default configuration values")
-    void testDefaultConfiguration() {
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .build();
+  @Test
+  @DisplayName("Test default configuration values")
+  void testDefaultConfiguration() {
+    LanceOptions options = LanceOptions.builder().path(datasetPath).build();
 
-        // Verify default values
-        assertThat(options.getReadBatchSize()).isEqualTo(1024);
-        assertThat(options.getReadColumns()).isEmpty();
-        assertThat(options.getReadFilter()).isNull();
-    }
+    // Verify default values
+    assertThat(options.getReadBatchSize()).isEqualTo(1024);
+    assertThat(options.getReadColumns()).isEmpty();
+    assertThat(options.getReadFilter()).isNull();
+  }
 
-    @Test
-    @DisplayName("Test configuration validation - invalid batch size")
-    void testInvalidBatchSize() {
-        assertThatThrownBy(() -> LanceOptions.builder()
-                .path(datasetPath)
-                .readBatchSize(0)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("batch-size");
-    }
+  @Test
+  @DisplayName("Test configuration validation - invalid batch size")
+  void testInvalidBatchSize() {
+    assertThatThrownBy(() -> LanceOptions.builder().path(datasetPath).readBatchSize(0).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("batch-size");
+  }
 
-    @Test
-    @DisplayName("Test vector type RowType")
-    void testVectorRowType() {
-        List<RowType.RowField> fields = new ArrayList<>();
-        fields.add(new RowType.RowField("id", new BigIntType()));
-        fields.add(new RowType.RowField("embedding", new ArrayType(new FloatType())));
-        RowType vectorRowType = new RowType(fields);
+  @Test
+  @DisplayName("Test vector type RowType")
+  void testVectorRowType() {
+    List<RowType.RowField> fields = new ArrayList<>();
+    fields.add(new RowType.RowField("id", new BigIntType()));
+    fields.add(new RowType.RowField("embedding", new ArrayType(new FloatType())));
+    RowType vectorRowType = new RowType(fields);
 
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .build();
+    LanceOptions options = LanceOptions.builder().path(datasetPath).build();
 
-        LanceSource source = new LanceSource(options, vectorRowType);
+    LanceSource source = new LanceSource(options, vectorRowType);
 
-        assertThat(source.getRowType().getFieldCount()).isEqualTo(2);
-        assertThat(source.getRowType().getTypeAt(1)).isInstanceOf(ArrayType.class);
-    }
+    assertThat(source.getRowType().getFieldCount()).isEqualTo(2);
+    assertThat(source.getRowType().getTypeAt(1)).isInstanceOf(ArrayType.class);
+  }
 }

--- a/src/test/java/org/apache/flink/connector/lance/LanceTypeConverterTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/LanceTypeConverterTest.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,9 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance;
 
+import org.apache.arrow.vector.types.DateUnit;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.flink.connector.lance.converter.LanceTypeConverter;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
@@ -33,14 +35,6 @@ import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.TinyIntType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
-
-import org.apache.arrow.vector.types.DateUnit;
-import org.apache.arrow.vector.types.FloatingPointPrecision;
-import org.apache.arrow.vector.types.TimeUnit;
-import org.apache.arrow.vector.types.pojo.ArrowType;
-import org.apache.arrow.vector.types.pojo.Field;
-import org.apache.arrow.vector.types.pojo.FieldType;
-import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -51,266 +45,279 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/**
- * LanceTypeConverter unit tests.
- */
+/** LanceTypeConverter unit tests. */
 class LanceTypeConverterTest {
 
-    @Test
-    @DisplayName("Test Arrow Int type to Flink type mapping")
-    void testArrowIntToFlinkType() {
-        // Int8 -> TINYINT
-        Field int8Field = new Field("int8", FieldType.nullable(new ArrowType.Int(8, true)), null);
-        LogicalType int8Type = LanceTypeConverter.arrowTypeToFlinkType(int8Field);
-        assertThat(int8Type).isInstanceOf(TinyIntType.class);
+  @Test
+  @DisplayName("Test Arrow Int type to Flink type mapping")
+  void testArrowIntToFlinkType() {
+    // Int8 -> TINYINT
+    Field int8Field = new Field("int8", FieldType.nullable(new ArrowType.Int(8, true)), null);
+    LogicalType int8Type = LanceTypeConverter.arrowTypeToFlinkType(int8Field);
+    assertThat(int8Type).isInstanceOf(TinyIntType.class);
 
-        // Int16 -> SMALLINT
-        Field int16Field = new Field("int16", FieldType.nullable(new ArrowType.Int(16, true)), null);
-        LogicalType int16Type = LanceTypeConverter.arrowTypeToFlinkType(int16Field);
-        assertThat(int16Type).isInstanceOf(SmallIntType.class);
+    // Int16 -> SMALLINT
+    Field int16Field = new Field("int16", FieldType.nullable(new ArrowType.Int(16, true)), null);
+    LogicalType int16Type = LanceTypeConverter.arrowTypeToFlinkType(int16Field);
+    assertThat(int16Type).isInstanceOf(SmallIntType.class);
 
-        // Int32 -> INT
-        Field int32Field = new Field("int32", FieldType.nullable(new ArrowType.Int(32, true)), null);
-        LogicalType int32Type = LanceTypeConverter.arrowTypeToFlinkType(int32Field);
-        assertThat(int32Type).isInstanceOf(IntType.class);
+    // Int32 -> INT
+    Field int32Field = new Field("int32", FieldType.nullable(new ArrowType.Int(32, true)), null);
+    LogicalType int32Type = LanceTypeConverter.arrowTypeToFlinkType(int32Field);
+    assertThat(int32Type).isInstanceOf(IntType.class);
 
-        // Int64 -> BIGINT
-        Field int64Field = new Field("int64", FieldType.nullable(new ArrowType.Int(64, true)), null);
-        LogicalType int64Type = LanceTypeConverter.arrowTypeToFlinkType(int64Field);
-        assertThat(int64Type).isInstanceOf(BigIntType.class);
+    // Int64 -> BIGINT
+    Field int64Field = new Field("int64", FieldType.nullable(new ArrowType.Int(64, true)), null);
+    LogicalType int64Type = LanceTypeConverter.arrowTypeToFlinkType(int64Field);
+    assertThat(int64Type).isInstanceOf(BigIntType.class);
+  }
+
+  @Test
+  @DisplayName("Test Arrow floating point type to Flink type mapping")
+  void testArrowFloatToFlinkType() {
+    // Float32 -> FLOAT
+    Field float32Field =
+        new Field(
+            "float32",
+            FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)),
+            null);
+    LogicalType float32Type = LanceTypeConverter.arrowTypeToFlinkType(float32Field);
+    assertThat(float32Type).isInstanceOf(FloatType.class);
+
+    // Float64 -> DOUBLE
+    Field float64Field =
+        new Field(
+            "float64",
+            FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+            null);
+    LogicalType float64Type = LanceTypeConverter.arrowTypeToFlinkType(float64Field);
+    assertThat(float64Type).isInstanceOf(DoubleType.class);
+  }
+
+  @Test
+  @DisplayName("Test Arrow string type to Flink type mapping")
+  void testArrowStringToFlinkType() {
+    // String -> STRING
+    Field stringField = new Field("str", FieldType.nullable(ArrowType.Utf8.INSTANCE), null);
+    LogicalType stringType = LanceTypeConverter.arrowTypeToFlinkType(stringField);
+    assertThat(stringType).isInstanceOf(VarCharType.class);
+
+    // LargeString -> STRING
+    Field largeStringField =
+        new Field("large_str", FieldType.nullable(ArrowType.LargeUtf8.INSTANCE), null);
+    LogicalType largeStringType = LanceTypeConverter.arrowTypeToFlinkType(largeStringField);
+    assertThat(largeStringType).isInstanceOf(VarCharType.class);
+  }
+
+  @Test
+  @DisplayName("Test Arrow Boolean type to Flink type mapping")
+  void testArrowBoolToFlinkType() {
+    Field boolField = new Field("bool", FieldType.nullable(ArrowType.Bool.INSTANCE), null);
+    LogicalType boolType = LanceTypeConverter.arrowTypeToFlinkType(boolField);
+    assertThat(boolType).isInstanceOf(BooleanType.class);
+  }
+
+  @Test
+  @DisplayName("Test Arrow Binary type to Flink type mapping")
+  void testArrowBinaryToFlinkType() {
+    Field binaryField = new Field("binary", FieldType.nullable(ArrowType.Binary.INSTANCE), null);
+    LogicalType binaryType = LanceTypeConverter.arrowTypeToFlinkType(binaryField);
+    assertThat(binaryType).isInstanceOf(VarBinaryType.class);
+  }
+
+  @Test
+  @DisplayName("Test Arrow Date type to Flink type mapping")
+  void testArrowDateToFlinkType() {
+    Field dateField = new Field("date", FieldType.nullable(new ArrowType.Date(DateUnit.DAY)), null);
+    LogicalType dateType = LanceTypeConverter.arrowTypeToFlinkType(dateField);
+    assertThat(dateType).isInstanceOf(DateType.class);
+  }
+
+  @Test
+  @DisplayName("Test Arrow Timestamp type to Flink type mapping")
+  void testArrowTimestampToFlinkType() {
+    // Millisecond precision
+    Field tsMilliField =
+        new Field(
+            "ts_milli",
+            FieldType.nullable(new ArrowType.Timestamp(TimeUnit.MILLISECOND, null)),
+            null);
+    LogicalType tsMilliType = LanceTypeConverter.arrowTypeToFlinkType(tsMilliField);
+    assertThat(tsMilliType).isInstanceOf(TimestampType.class);
+    assertThat(((TimestampType) tsMilliType).getPrecision()).isEqualTo(3);
+
+    // Microsecond precision
+    Field tsMicroField =
+        new Field(
+            "ts_micro",
+            FieldType.nullable(new ArrowType.Timestamp(TimeUnit.MICROSECOND, null)),
+            null);
+    LogicalType tsMicroType = LanceTypeConverter.arrowTypeToFlinkType(tsMicroField);
+    assertThat(tsMicroType).isInstanceOf(TimestampType.class);
+    assertThat(((TimestampType) tsMicroType).getPrecision()).isEqualTo(6);
+  }
+
+  @Test
+  @DisplayName("Test Arrow FixedSizeList (vector) type to Flink type mapping")
+  void testArrowVectorToFlinkType() {
+    // FixedSizeList<Float32> -> ARRAY<FLOAT>
+    ArrowType elementType = new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE);
+    Field elementField = new Field("item", FieldType.notNullable(elementType), null);
+    List<Field> children = Arrays.asList(elementField);
+
+    Field vectorField =
+        new Field("embedding", FieldType.nullable(new ArrowType.FixedSizeList(128)), children);
+
+    LogicalType vectorType = LanceTypeConverter.arrowTypeToFlinkType(vectorField);
+    assertThat(vectorType).isInstanceOf(ArrayType.class);
+    assertThat(((ArrayType) vectorType).getElementType()).isInstanceOf(FloatType.class);
+  }
+
+  @Test
+  @DisplayName("Test Flink type to Arrow type mapping")
+  void testFlinkTypeToArrowType() {
+    // TINYINT -> Int8
+    Field tinyIntField = LanceTypeConverter.flinkTypeToArrowField("tinyint", new TinyIntType());
+    assertThat(tinyIntField.getType()).isInstanceOf(ArrowType.Int.class);
+    assertThat(((ArrowType.Int) tinyIntField.getType()).getBitWidth()).isEqualTo(8);
+
+    // INT -> Int32
+    Field intField = LanceTypeConverter.flinkTypeToArrowField("int", new IntType());
+    assertThat(intField.getType()).isInstanceOf(ArrowType.Int.class);
+    assertThat(((ArrowType.Int) intField.getType()).getBitWidth()).isEqualTo(32);
+
+    // BIGINT -> Int64
+    Field bigIntField = LanceTypeConverter.flinkTypeToArrowField("bigint", new BigIntType());
+    assertThat(bigIntField.getType()).isInstanceOf(ArrowType.Int.class);
+    assertThat(((ArrowType.Int) bigIntField.getType()).getBitWidth()).isEqualTo(64);
+
+    // FLOAT -> Float32
+    Field floatField = LanceTypeConverter.flinkTypeToArrowField("float", new FloatType());
+    assertThat(floatField.getType()).isInstanceOf(ArrowType.FloatingPoint.class);
+    assertThat(((ArrowType.FloatingPoint) floatField.getType()).getPrecision())
+        .isEqualTo(FloatingPointPrecision.SINGLE);
+
+    // DOUBLE -> Float64
+    Field doubleField = LanceTypeConverter.flinkTypeToArrowField("double", new DoubleType());
+    assertThat(doubleField.getType()).isInstanceOf(ArrowType.FloatingPoint.class);
+    assertThat(((ArrowType.FloatingPoint) doubleField.getType()).getPrecision())
+        .isEqualTo(FloatingPointPrecision.DOUBLE);
+
+    // STRING -> Utf8
+    Field stringField = LanceTypeConverter.flinkTypeToArrowField("string", new VarCharType());
+    assertThat(stringField.getType()).isInstanceOf(ArrowType.Utf8.class);
+
+    // BOOLEAN -> Bool
+    Field boolField = LanceTypeConverter.flinkTypeToArrowField("bool", new BooleanType());
+    assertThat(boolField.getType()).isInstanceOf(ArrowType.Bool.class);
+  }
+
+  @Test
+  @DisplayName("Test Arrow Schema to Flink RowType conversion")
+  void testArrowSchemaToFlinkRowType() {
+    List<Field> fields = new ArrayList<>();
+    fields.add(new Field("id", FieldType.notNullable(new ArrowType.Int(64, true)), null));
+    fields.add(new Field("name", FieldType.nullable(ArrowType.Utf8.INSTANCE), null));
+    fields.add(
+        new Field(
+            "score",
+            FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)),
+            null));
+
+    Schema arrowSchema = new Schema(fields);
+    RowType rowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
+
+    assertThat(rowType.getFieldCount()).isEqualTo(3);
+    assertThat(rowType.getFieldNames()).containsExactly("id", "name", "score");
+    assertThat(rowType.getTypeAt(0)).isInstanceOf(BigIntType.class);
+    assertThat(rowType.getTypeAt(1)).isInstanceOf(VarCharType.class);
+    assertThat(rowType.getTypeAt(2)).isInstanceOf(DoubleType.class);
+  }
+
+  @Test
+  @DisplayName("Test Flink RowType to Arrow Schema conversion")
+  void testFlinkRowTypeToArrowSchema() {
+    List<RowType.RowField> fields = new ArrayList<>();
+    fields.add(new RowType.RowField("id", new BigIntType(false)));
+    fields.add(new RowType.RowField("content", new VarCharType()));
+    fields.add(new RowType.RowField("embedding", new ArrayType(new FloatType())));
+
+    RowType rowType = new RowType(fields);
+    Schema arrowSchema = LanceTypeConverter.toArrowSchema(rowType);
+
+    assertThat(arrowSchema.getFields()).hasSize(3);
+    assertThat(arrowSchema.getFields().get(0).getName()).isEqualTo("id");
+    assertThat(arrowSchema.getFields().get(1).getName()).isEqualTo("content");
+    assertThat(arrowSchema.getFields().get(2).getName()).isEqualTo("embedding");
+  }
+
+  @Test
+  @DisplayName("Test vector field creation")
+  void testCreateVectorField() {
+    // Float32 vector
+    Field float32Vector = LanceTypeConverter.createVectorField("embedding", 128, false);
+    assertThat(float32Vector.getName()).isEqualTo("embedding");
+    assertThat(float32Vector.getType()).isInstanceOf(ArrowType.FixedSizeList.class);
+    assertThat(((ArrowType.FixedSizeList) float32Vector.getType()).getListSize()).isEqualTo(128);
+    assertThat(float32Vector.isNullable()).isFalse();
+
+    // Float64 vector
+    Field float64Vector = LanceTypeConverter.createFloat64VectorField("embedding64", 256, true);
+    assertThat(float64Vector.getName()).isEqualTo("embedding64");
+    assertThat(((ArrowType.FixedSizeList) float64Vector.getType()).getListSize()).isEqualTo(256);
+    assertThat(float64Vector.isNullable()).isTrue();
+  }
+
+  @Test
+  @DisplayName("Test vector field detection")
+  void testIsVectorField() {
+    // Create vector field
+    Field vectorField = LanceTypeConverter.createVectorField("embedding", 128, false);
+    assertThat(LanceTypeConverter.isVectorField(vectorField)).isTrue();
+    assertThat(LanceTypeConverter.getVectorDimension(vectorField)).isEqualTo(128);
+
+    // Non-vector field
+    Field intField = new Field("id", FieldType.notNullable(new ArrowType.Int(64, true)), null);
+    assertThat(LanceTypeConverter.isVectorField(intField)).isFalse();
+    assertThat(LanceTypeConverter.getVectorDimension(intField)).isEqualTo(-1);
+  }
+
+  @Test
+  @DisplayName("Test unsupported type exception")
+  void testUnsupportedTypeException() {
+    // Unsupported Arrow type
+    Field unsupportedField =
+        new Field("unsupported", FieldType.nullable(new ArrowType.Duration(TimeUnit.SECOND)), null);
+
+    assertThatThrownBy(() -> LanceTypeConverter.arrowTypeToFlinkType(unsupportedField))
+        .isInstanceOf(LanceTypeConverter.UnsupportedTypeException.class)
+        .hasMessageContaining("Unsupported Arrow type");
+  }
+
+  @Test
+  @DisplayName("Test round-trip conversion consistency")
+  void testRoundTripConversion() {
+    // Create Flink RowType
+    List<RowType.RowField> fields = new ArrayList<>();
+    fields.add(new RowType.RowField("id", new BigIntType(false)));
+    fields.add(new RowType.RowField("name", new VarCharType()));
+    fields.add(new RowType.RowField("score", new DoubleType()));
+    fields.add(new RowType.RowField("active", new BooleanType()));
+
+    RowType originalRowType = new RowType(fields);
+
+    // Flink -> Arrow -> Flink
+    Schema arrowSchema = LanceTypeConverter.toArrowSchema(originalRowType);
+    RowType convertedRowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
+
+    // Verify field count and names
+    assertThat(convertedRowType.getFieldCount()).isEqualTo(originalRowType.getFieldCount());
+    assertThat(convertedRowType.getFieldNames()).isEqualTo(originalRowType.getFieldNames());
+
+    // Verify types (type classes should match)
+    for (int i = 0; i < originalRowType.getFieldCount(); i++) {
+      assertThat(convertedRowType.getTypeAt(i).getClass())
+          .isEqualTo(originalRowType.getTypeAt(i).getClass());
     }
-
-    @Test
-    @DisplayName("Test Arrow floating point type to Flink type mapping")
-    void testArrowFloatToFlinkType() {
-        // Float32 -> FLOAT
-        Field float32Field = new Field("float32",
-                FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)), null);
-        LogicalType float32Type = LanceTypeConverter.arrowTypeToFlinkType(float32Field);
-        assertThat(float32Type).isInstanceOf(FloatType.class);
-
-        // Float64 -> DOUBLE
-        Field float64Field = new Field("float64",
-                FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)), null);
-        LogicalType float64Type = LanceTypeConverter.arrowTypeToFlinkType(float64Field);
-        assertThat(float64Type).isInstanceOf(DoubleType.class);
-    }
-
-    @Test
-    @DisplayName("Test Arrow string type to Flink type mapping")
-    void testArrowStringToFlinkType() {
-        // String -> STRING
-        Field stringField = new Field("str", FieldType.nullable(ArrowType.Utf8.INSTANCE), null);
-        LogicalType stringType = LanceTypeConverter.arrowTypeToFlinkType(stringField);
-        assertThat(stringType).isInstanceOf(VarCharType.class);
-
-        // LargeString -> STRING
-        Field largeStringField = new Field("large_str", FieldType.nullable(ArrowType.LargeUtf8.INSTANCE), null);
-        LogicalType largeStringType = LanceTypeConverter.arrowTypeToFlinkType(largeStringField);
-        assertThat(largeStringType).isInstanceOf(VarCharType.class);
-    }
-
-    @Test
-    @DisplayName("Test Arrow Boolean type to Flink type mapping")
-    void testArrowBoolToFlinkType() {
-        Field boolField = new Field("bool", FieldType.nullable(ArrowType.Bool.INSTANCE), null);
-        LogicalType boolType = LanceTypeConverter.arrowTypeToFlinkType(boolField);
-        assertThat(boolType).isInstanceOf(BooleanType.class);
-    }
-
-    @Test
-    @DisplayName("Test Arrow Binary type to Flink type mapping")
-    void testArrowBinaryToFlinkType() {
-        Field binaryField = new Field("binary", FieldType.nullable(ArrowType.Binary.INSTANCE), null);
-        LogicalType binaryType = LanceTypeConverter.arrowTypeToFlinkType(binaryField);
-        assertThat(binaryType).isInstanceOf(VarBinaryType.class);
-    }
-
-    @Test
-    @DisplayName("Test Arrow Date type to Flink type mapping")
-    void testArrowDateToFlinkType() {
-        Field dateField = new Field("date",
-                FieldType.nullable(new ArrowType.Date(DateUnit.DAY)), null);
-        LogicalType dateType = LanceTypeConverter.arrowTypeToFlinkType(dateField);
-        assertThat(dateType).isInstanceOf(DateType.class);
-    }
-
-    @Test
-    @DisplayName("Test Arrow Timestamp type to Flink type mapping")
-    void testArrowTimestampToFlinkType() {
-        // Millisecond precision
-        Field tsMilliField = new Field("ts_milli",
-                FieldType.nullable(new ArrowType.Timestamp(TimeUnit.MILLISECOND, null)), null);
-        LogicalType tsMilliType = LanceTypeConverter.arrowTypeToFlinkType(tsMilliField);
-        assertThat(tsMilliType).isInstanceOf(TimestampType.class);
-        assertThat(((TimestampType) tsMilliType).getPrecision()).isEqualTo(3);
-
-        // Microsecond precision
-        Field tsMicroField = new Field("ts_micro",
-                FieldType.nullable(new ArrowType.Timestamp(TimeUnit.MICROSECOND, null)), null);
-        LogicalType tsMicroType = LanceTypeConverter.arrowTypeToFlinkType(tsMicroField);
-        assertThat(tsMicroType).isInstanceOf(TimestampType.class);
-        assertThat(((TimestampType) tsMicroType).getPrecision()).isEqualTo(6);
-    }
-
-    @Test
-    @DisplayName("Test Arrow FixedSizeList (vector) type to Flink type mapping")
-    void testArrowVectorToFlinkType() {
-        // FixedSizeList<Float32> -> ARRAY<FLOAT>
-        ArrowType elementType = new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE);
-        Field elementField = new Field("item", FieldType.notNullable(elementType), null);
-        List<Field> children = Arrays.asList(elementField);
-
-        Field vectorField = new Field("embedding",
-                FieldType.nullable(new ArrowType.FixedSizeList(128)), children);
-
-        LogicalType vectorType = LanceTypeConverter.arrowTypeToFlinkType(vectorField);
-        assertThat(vectorType).isInstanceOf(ArrayType.class);
-        assertThat(((ArrayType) vectorType).getElementType()).isInstanceOf(FloatType.class);
-    }
-
-    @Test
-    @DisplayName("Test Flink type to Arrow type mapping")
-    void testFlinkTypeToArrowType() {
-        // TINYINT -> Int8
-        Field tinyIntField = LanceTypeConverter.flinkTypeToArrowField("tinyint", new TinyIntType());
-        assertThat(tinyIntField.getType()).isInstanceOf(ArrowType.Int.class);
-        assertThat(((ArrowType.Int) tinyIntField.getType()).getBitWidth()).isEqualTo(8);
-
-        // INT -> Int32
-        Field intField = LanceTypeConverter.flinkTypeToArrowField("int", new IntType());
-        assertThat(intField.getType()).isInstanceOf(ArrowType.Int.class);
-        assertThat(((ArrowType.Int) intField.getType()).getBitWidth()).isEqualTo(32);
-
-        // BIGINT -> Int64
-        Field bigIntField = LanceTypeConverter.flinkTypeToArrowField("bigint", new BigIntType());
-        assertThat(bigIntField.getType()).isInstanceOf(ArrowType.Int.class);
-        assertThat(((ArrowType.Int) bigIntField.getType()).getBitWidth()).isEqualTo(64);
-
-        // FLOAT -> Float32
-        Field floatField = LanceTypeConverter.flinkTypeToArrowField("float", new FloatType());
-        assertThat(floatField.getType()).isInstanceOf(ArrowType.FloatingPoint.class);
-        assertThat(((ArrowType.FloatingPoint) floatField.getType()).getPrecision())
-                .isEqualTo(FloatingPointPrecision.SINGLE);
-
-        // DOUBLE -> Float64
-        Field doubleField = LanceTypeConverter.flinkTypeToArrowField("double", new DoubleType());
-        assertThat(doubleField.getType()).isInstanceOf(ArrowType.FloatingPoint.class);
-        assertThat(((ArrowType.FloatingPoint) doubleField.getType()).getPrecision())
-                .isEqualTo(FloatingPointPrecision.DOUBLE);
-
-        // STRING -> Utf8
-        Field stringField = LanceTypeConverter.flinkTypeToArrowField("string", new VarCharType());
-        assertThat(stringField.getType()).isInstanceOf(ArrowType.Utf8.class);
-
-        // BOOLEAN -> Bool
-        Field boolField = LanceTypeConverter.flinkTypeToArrowField("bool", new BooleanType());
-        assertThat(boolField.getType()).isInstanceOf(ArrowType.Bool.class);
-    }
-
-    @Test
-    @DisplayName("Test Arrow Schema to Flink RowType conversion")
-    void testArrowSchemaToFlinkRowType() {
-        List<Field> fields = new ArrayList<>();
-        fields.add(new Field("id", FieldType.notNullable(new ArrowType.Int(64, true)), null));
-        fields.add(new Field("name", FieldType.nullable(ArrowType.Utf8.INSTANCE), null));
-        fields.add(new Field("score",
-                FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)), null));
-
-        Schema arrowSchema = new Schema(fields);
-        RowType rowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
-
-        assertThat(rowType.getFieldCount()).isEqualTo(3);
-        assertThat(rowType.getFieldNames()).containsExactly("id", "name", "score");
-        assertThat(rowType.getTypeAt(0)).isInstanceOf(BigIntType.class);
-        assertThat(rowType.getTypeAt(1)).isInstanceOf(VarCharType.class);
-        assertThat(rowType.getTypeAt(2)).isInstanceOf(DoubleType.class);
-    }
-
-    @Test
-    @DisplayName("Test Flink RowType to Arrow Schema conversion")
-    void testFlinkRowTypeToArrowSchema() {
-        List<RowType.RowField> fields = new ArrayList<>();
-        fields.add(new RowType.RowField("id", new BigIntType(false)));
-        fields.add(new RowType.RowField("content", new VarCharType()));
-        fields.add(new RowType.RowField("embedding", new ArrayType(new FloatType())));
-
-        RowType rowType = new RowType(fields);
-        Schema arrowSchema = LanceTypeConverter.toArrowSchema(rowType);
-
-        assertThat(arrowSchema.getFields()).hasSize(3);
-        assertThat(arrowSchema.getFields().get(0).getName()).isEqualTo("id");
-        assertThat(arrowSchema.getFields().get(1).getName()).isEqualTo("content");
-        assertThat(arrowSchema.getFields().get(2).getName()).isEqualTo("embedding");
-    }
-
-    @Test
-    @DisplayName("Test vector field creation")
-    void testCreateVectorField() {
-        // Float32 vector
-        Field float32Vector = LanceTypeConverter.createVectorField("embedding", 128, false);
-        assertThat(float32Vector.getName()).isEqualTo("embedding");
-        assertThat(float32Vector.getType()).isInstanceOf(ArrowType.FixedSizeList.class);
-        assertThat(((ArrowType.FixedSizeList) float32Vector.getType()).getListSize()).isEqualTo(128);
-        assertThat(float32Vector.isNullable()).isFalse();
-
-        // Float64 vector
-        Field float64Vector = LanceTypeConverter.createFloat64VectorField("embedding64", 256, true);
-        assertThat(float64Vector.getName()).isEqualTo("embedding64");
-        assertThat(((ArrowType.FixedSizeList) float64Vector.getType()).getListSize()).isEqualTo(256);
-        assertThat(float64Vector.isNullable()).isTrue();
-    }
-
-    @Test
-    @DisplayName("Test vector field detection")
-    void testIsVectorField() {
-        // Create vector field
-        Field vectorField = LanceTypeConverter.createVectorField("embedding", 128, false);
-        assertThat(LanceTypeConverter.isVectorField(vectorField)).isTrue();
-        assertThat(LanceTypeConverter.getVectorDimension(vectorField)).isEqualTo(128);
-
-        // Non-vector field
-        Field intField = new Field("id", FieldType.notNullable(new ArrowType.Int(64, true)), null);
-        assertThat(LanceTypeConverter.isVectorField(intField)).isFalse();
-        assertThat(LanceTypeConverter.getVectorDimension(intField)).isEqualTo(-1);
-    }
-
-    @Test
-    @DisplayName("Test unsupported type exception")
-    void testUnsupportedTypeException() {
-        // Unsupported Arrow type
-        Field unsupportedField = new Field("unsupported",
-                FieldType.nullable(new ArrowType.Duration(TimeUnit.SECOND)), null);
-
-        assertThatThrownBy(() -> LanceTypeConverter.arrowTypeToFlinkType(unsupportedField))
-                .isInstanceOf(LanceTypeConverter.UnsupportedTypeException.class)
-                .hasMessageContaining("Unsupported Arrow type");
-    }
-
-    @Test
-    @DisplayName("Test round-trip conversion consistency")
-    void testRoundTripConversion() {
-        // Create Flink RowType
-        List<RowType.RowField> fields = new ArrayList<>();
-        fields.add(new RowType.RowField("id", new BigIntType(false)));
-        fields.add(new RowType.RowField("name", new VarCharType()));
-        fields.add(new RowType.RowField("score", new DoubleType()));
-        fields.add(new RowType.RowField("active", new BooleanType()));
-
-        RowType originalRowType = new RowType(fields);
-
-        // Flink -> Arrow -> Flink
-        Schema arrowSchema = LanceTypeConverter.toArrowSchema(originalRowType);
-        RowType convertedRowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
-
-        // Verify field count and names
-        assertThat(convertedRowType.getFieldCount()).isEqualTo(originalRowType.getFieldCount());
-        assertThat(convertedRowType.getFieldNames()).isEqualTo(originalRowType.getFieldNames());
-
-        // Verify types (type classes should match)
-        for (int i = 0; i < originalRowType.getFieldCount(); i++) {
-            assertThat(convertedRowType.getTypeAt(i).getClass())
-                    .isEqualTo(originalRowType.getTypeAt(i).getClass());
-        }
-    }
+  }
 }

--- a/src/test/java/org/apache/flink/connector/lance/LanceTypeConverterTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/LanceTypeConverterTest.java
@@ -84,13 +84,13 @@ class LanceTypeConverterTest {
     @DisplayName("Test Arrow floating point type to Flink type mapping")
     void testArrowFloatToFlinkType() {
         // Float32 -> FLOAT
-        Field float32Field = new Field("float32", 
+        Field float32Field = new Field("float32",
                 FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)), null);
         LogicalType float32Type = LanceTypeConverter.arrowTypeToFlinkType(float32Field);
         assertThat(float32Type).isInstanceOf(FloatType.class);
 
         // Float64 -> DOUBLE
-        Field float64Field = new Field("float64", 
+        Field float64Field = new Field("float64",
                 FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)), null);
         LogicalType float64Type = LanceTypeConverter.arrowTypeToFlinkType(float64Field);
         assertThat(float64Type).isInstanceOf(DoubleType.class);
@@ -129,7 +129,7 @@ class LanceTypeConverterTest {
     @Test
     @DisplayName("Test Arrow Date type to Flink type mapping")
     void testArrowDateToFlinkType() {
-        Field dateField = new Field("date", 
+        Field dateField = new Field("date",
                 FieldType.nullable(new ArrowType.Date(DateUnit.DAY)), null);
         LogicalType dateType = LanceTypeConverter.arrowTypeToFlinkType(dateField);
         assertThat(dateType).isInstanceOf(DateType.class);
@@ -139,14 +139,14 @@ class LanceTypeConverterTest {
     @DisplayName("Test Arrow Timestamp type to Flink type mapping")
     void testArrowTimestampToFlinkType() {
         // Millisecond precision
-        Field tsMilliField = new Field("ts_milli", 
+        Field tsMilliField = new Field("ts_milli",
                 FieldType.nullable(new ArrowType.Timestamp(TimeUnit.MILLISECOND, null)), null);
         LogicalType tsMilliType = LanceTypeConverter.arrowTypeToFlinkType(tsMilliField);
         assertThat(tsMilliType).isInstanceOf(TimestampType.class);
         assertThat(((TimestampType) tsMilliType).getPrecision()).isEqualTo(3);
 
         // Microsecond precision
-        Field tsMicroField = new Field("ts_micro", 
+        Field tsMicroField = new Field("ts_micro",
                 FieldType.nullable(new ArrowType.Timestamp(TimeUnit.MICROSECOND, null)), null);
         LogicalType tsMicroType = LanceTypeConverter.arrowTypeToFlinkType(tsMicroField);
         assertThat(tsMicroType).isInstanceOf(TimestampType.class);
@@ -160,10 +160,10 @@ class LanceTypeConverterTest {
         ArrowType elementType = new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE);
         Field elementField = new Field("item", FieldType.notNullable(elementType), null);
         List<Field> children = Arrays.asList(elementField);
-        
-        Field vectorField = new Field("embedding", 
+
+        Field vectorField = new Field("embedding",
                 FieldType.nullable(new ArrowType.FixedSizeList(128)), children);
-        
+
         LogicalType vectorType = LanceTypeConverter.arrowTypeToFlinkType(vectorField);
         assertThat(vectorType).isInstanceOf(ArrayType.class);
         assertThat(((ArrayType) vectorType).getElementType()).isInstanceOf(FloatType.class);
@@ -214,9 +214,9 @@ class LanceTypeConverterTest {
         List<Field> fields = new ArrayList<>();
         fields.add(new Field("id", FieldType.notNullable(new ArrowType.Int(64, true)), null));
         fields.add(new Field("name", FieldType.nullable(ArrowType.Utf8.INSTANCE), null));
-        fields.add(new Field("score", 
+        fields.add(new Field("score",
                 FieldType.nullable(new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE)), null));
-        
+
         Schema arrowSchema = new Schema(fields);
         RowType rowType = LanceTypeConverter.toFlinkRowType(arrowSchema);
 
@@ -234,7 +234,7 @@ class LanceTypeConverterTest {
         fields.add(new RowType.RowField("id", new BigIntType(false)));
         fields.add(new RowType.RowField("content", new VarCharType()));
         fields.add(new RowType.RowField("embedding", new ArrayType(new FloatType())));
-        
+
         RowType rowType = new RowType(fields);
         Schema arrowSchema = LanceTypeConverter.toArrowSchema(rowType);
 
@@ -279,9 +279,9 @@ class LanceTypeConverterTest {
     @DisplayName("Test unsupported type exception")
     void testUnsupportedTypeException() {
         // Unsupported Arrow type
-        Field unsupportedField = new Field("unsupported", 
+        Field unsupportedField = new Field("unsupported",
                 FieldType.nullable(new ArrowType.Duration(TimeUnit.SECOND)), null);
-        
+
         assertThatThrownBy(() -> LanceTypeConverter.arrowTypeToFlinkType(unsupportedField))
                 .isInstanceOf(LanceTypeConverter.UnsupportedTypeException.class)
                 .hasMessageContaining("Unsupported Arrow type");
@@ -296,7 +296,7 @@ class LanceTypeConverterTest {
         fields.add(new RowType.RowField("name", new VarCharType()));
         fields.add(new RowType.RowField("score", new DoubleType()));
         fields.add(new RowType.RowField("active", new BooleanType()));
-        
+
         RowType originalRowType = new RowType(fields);
 
         // Flink -> Arrow -> Flink

--- a/src/test/java/org/apache/flink/connector/lance/LanceVectorSearchTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/LanceVectorSearchTest.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,12 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance;
 
 import org.apache.flink.connector.lance.config.LanceOptions;
 import org.apache.flink.connector.lance.config.LanceOptions.MetricType;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,212 +25,224 @@ import java.nio.file.Path;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/**
- * LanceVectorSearch unit tests.
- */
+/** LanceVectorSearch unit tests. */
 class LanceVectorSearchTest {
 
-    @TempDir
-    Path tempDir;
+  @TempDir Path tempDir;
 
-    private String datasetPath;
+  private String datasetPath;
 
-    @BeforeEach
-    void setUp() {
-        datasetPath = tempDir.resolve("test_search_dataset").toString();
-    }
+  @BeforeEach
+  void setUp() {
+    datasetPath = tempDir.resolve("test_search_dataset").toString();
+  }
 
-    @Test
-    @DisplayName("Test vector search configuration build")
-    void testVectorSearchConfiguration() {
-        LanceVectorSearch search = LanceVectorSearch.builder()
-                .datasetPath(datasetPath)
-                .columnName("embedding")
-                .metricType(MetricType.L2)
-                .nprobes(20)
-                .ef(100)
-                .refineFactor(10)
-                .build();
+  @Test
+  @DisplayName("Test vector search configuration build")
+  void testVectorSearchConfiguration() {
+    LanceVectorSearch search =
+        LanceVectorSearch.builder()
+            .datasetPath(datasetPath)
+            .columnName("embedding")
+            .metricType(MetricType.L2)
+            .nprobes(20)
+            .ef(100)
+            .refineFactor(10)
+            .build();
 
-        assertThat(search).isNotNull();
-    }
+    assertThat(search).isNotNull();
+  }
 
-    @Test
-    @DisplayName("Test different metric types")
-    void testDifferentMetricTypes() {
-        // L2 distance
-        LanceVectorSearch l2Search = LanceVectorSearch.builder()
-                .datasetPath(datasetPath)
-                .columnName("embedding")
-                .metricType(MetricType.L2)
-                .build();
-        assertThat(l2Search).isNotNull();
+  @Test
+  @DisplayName("Test different metric types")
+  void testDifferentMetricTypes() {
+    // L2 distance
+    LanceVectorSearch l2Search =
+        LanceVectorSearch.builder()
+            .datasetPath(datasetPath)
+            .columnName("embedding")
+            .metricType(MetricType.L2)
+            .build();
+    assertThat(l2Search).isNotNull();
 
-        // Cosine similarity
-        LanceVectorSearch cosineSearch = LanceVectorSearch.builder()
-                .datasetPath(datasetPath)
-                .columnName("embedding")
-                .metricType(MetricType.COSINE)
-                .build();
-        assertThat(cosineSearch).isNotNull();
+    // Cosine similarity
+    LanceVectorSearch cosineSearch =
+        LanceVectorSearch.builder()
+            .datasetPath(datasetPath)
+            .columnName("embedding")
+            .metricType(MetricType.COSINE)
+            .build();
+    assertThat(cosineSearch).isNotNull();
 
-        // Dot product
-        LanceVectorSearch dotSearch = LanceVectorSearch.builder()
-                .datasetPath(datasetPath)
-                .columnName("embedding")
-                .metricType(MetricType.DOT)
-                .build();
-        assertThat(dotSearch).isNotNull();
-    }
+    // Dot product
+    LanceVectorSearch dotSearch =
+        LanceVectorSearch.builder()
+            .datasetPath(datasetPath)
+            .columnName("embedding")
+            .metricType(MetricType.DOT)
+            .build();
+    assertThat(dotSearch).isNotNull();
+  }
 
-    @Test
-    @DisplayName("Test exception when missing dataset path")
-    void testMissingDatasetPath() {
-        assertThatThrownBy(() -> LanceVectorSearch.builder()
-                .columnName("embedding")
-                .metricType(MetricType.L2)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Dataset path cannot be empty");
-    }
+  @Test
+  @DisplayName("Test exception when missing dataset path")
+  void testMissingDatasetPath() {
+    assertThatThrownBy(
+            () ->
+                LanceVectorSearch.builder()
+                    .columnName("embedding")
+                    .metricType(MetricType.L2)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Dataset path cannot be empty");
+  }
 
-    @Test
-    @DisplayName("Test exception when missing column name")
-    void testMissingColumnName() {
-        assertThatThrownBy(() -> LanceVectorSearch.builder()
-                .datasetPath(datasetPath)
-                .metricType(MetricType.L2)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Column name cannot be empty");
-    }
+  @Test
+  @DisplayName("Test exception when missing column name")
+  void testMissingColumnName() {
+    assertThatThrownBy(
+            () ->
+                LanceVectorSearch.builder()
+                    .datasetPath(datasetPath)
+                    .metricType(MetricType.L2)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Column name cannot be empty");
+  }
 
-    @Test
-    @DisplayName("Test invalid nprobes value")
-    void testInvalidNprobes() {
-        assertThatThrownBy(() -> LanceVectorSearch.builder()
-                .datasetPath(datasetPath)
-                .columnName("embedding")
-                .nprobes(0)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("nprobes must be greater than 0");
-    }
+  @Test
+  @DisplayName("Test invalid nprobes value")
+  void testInvalidNprobes() {
+    assertThatThrownBy(
+            () ->
+                LanceVectorSearch.builder()
+                    .datasetPath(datasetPath)
+                    .columnName("embedding")
+                    .nprobes(0)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("nprobes must be greater than 0");
+  }
 
-    @Test
-    @DisplayName("Test default vector search configuration values")
-    void testDefaultVectorSearchConfiguration() {
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .vectorColumn("embedding")
-                .build();
+  @Test
+  @DisplayName("Test default vector search configuration values")
+  void testDefaultVectorSearchConfiguration() {
+    LanceOptions options =
+        LanceOptions.builder().path(datasetPath).vectorColumn("embedding").build();
 
-        // Verify default values
-        assertThat(options.getVectorMetric()).isEqualTo(MetricType.L2);
-        assertThat(options.getVectorNprobes()).isEqualTo(20);
-        assertThat(options.getVectorEf()).isEqualTo(100);
-        assertThat(options.getVectorRefineFactor()).isNull();
-    }
+    // Verify default values
+    assertThat(options.getVectorMetric()).isEqualTo(MetricType.L2);
+    assertThat(options.getVectorNprobes()).isEqualTo(20);
+    assertThat(options.getVectorEf()).isEqualTo(100);
+    assertThat(options.getVectorRefineFactor()).isNull();
+  }
 
-    @Test
-    @DisplayName("Test creating vector searcher from LanceOptions")
-    void testFromOptions() {
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .vectorColumn("embedding")
-                .vectorMetric(MetricType.COSINE)
-                .vectorNprobes(30)
-                .vectorEf(150)
-                .vectorRefineFactor(5)
-                .build();
+  @Test
+  @DisplayName("Test creating vector searcher from LanceOptions")
+  void testFromOptions() {
+    LanceOptions options =
+        LanceOptions.builder()
+            .path(datasetPath)
+            .vectorColumn("embedding")
+            .vectorMetric(MetricType.COSINE)
+            .vectorNprobes(30)
+            .vectorEf(150)
+            .vectorRefineFactor(5)
+            .build();
 
-        LanceVectorSearch search = LanceVectorSearch.fromOptions(options);
+    LanceVectorSearch search = LanceVectorSearch.fromOptions(options);
 
-        assertThat(search).isNotNull();
-    }
+    assertThat(search).isNotNull();
+  }
 
-    @Test
-    @DisplayName("Test search result")
-    void testSearchResult() {
-        // Create mock RowData
-        LanceVectorSearch.SearchResult result = new LanceVectorSearch.SearchResult(null, 0.5);
+  @Test
+  @DisplayName("Test search result")
+  void testSearchResult() {
+    // Create mock RowData
+    LanceVectorSearch.SearchResult result = new LanceVectorSearch.SearchResult(null, 0.5);
 
-        assertThat(result.getDistance()).isEqualTo(0.5);
-        assertThat(result.getSimilarity()).isGreaterThan(0);
-        assertThat(result.getSimilarity()).isLessThanOrEqualTo(1.0);
-    }
+    assertThat(result.getDistance()).isEqualTo(0.5);
+    assertThat(result.getSimilarity()).isGreaterThan(0);
+    assertThat(result.getSimilarity()).isLessThanOrEqualTo(1.0);
+  }
 
-    @Test
-    @DisplayName("Test search result similarity calculation")
-    void testSearchResultSimilarity() {
-        // Distance 0 should have similarity 1.0
-        LanceVectorSearch.SearchResult perfectMatch = new LanceVectorSearch.SearchResult(null, 0.0);
-        assertThat(perfectMatch.getSimilarity()).isEqualTo(1.0);
+  @Test
+  @DisplayName("Test search result similarity calculation")
+  void testSearchResultSimilarity() {
+    // Distance 0 should have similarity 1.0
+    LanceVectorSearch.SearchResult perfectMatch = new LanceVectorSearch.SearchResult(null, 0.0);
+    assertThat(perfectMatch.getSimilarity()).isEqualTo(1.0);
 
-        // Distance 1 should have similarity 0.5
-        LanceVectorSearch.SearchResult halfMatch = new LanceVectorSearch.SearchResult(null, 1.0);
-        assertThat(halfMatch.getSimilarity()).isEqualTo(0.5);
+    // Distance 1 should have similarity 0.5
+    LanceVectorSearch.SearchResult halfMatch = new LanceVectorSearch.SearchResult(null, 1.0);
+    assertThat(halfMatch.getSimilarity()).isEqualTo(0.5);
 
-        // Greater distance means lower similarity
-        LanceVectorSearch.SearchResult farResult = new LanceVectorSearch.SearchResult(null, 10.0);
-        assertThat(farResult.getSimilarity()).isLessThan(0.5);
-    }
+    // Greater distance means lower similarity
+    LanceVectorSearch.SearchResult farResult = new LanceVectorSearch.SearchResult(null, 10.0);
+    assertThat(farResult.getSimilarity()).isLessThan(0.5);
+  }
 
-    @Test
-    @DisplayName("Test search result equality")
-    void testSearchResultEquality() {
-        LanceVectorSearch.SearchResult result1 = new LanceVectorSearch.SearchResult(null, 0.5);
-        LanceVectorSearch.SearchResult result2 = new LanceVectorSearch.SearchResult(null, 0.5);
-        LanceVectorSearch.SearchResult result3 = new LanceVectorSearch.SearchResult(null, 1.0);
+  @Test
+  @DisplayName("Test search result equality")
+  void testSearchResultEquality() {
+    LanceVectorSearch.SearchResult result1 = new LanceVectorSearch.SearchResult(null, 0.5);
+    LanceVectorSearch.SearchResult result2 = new LanceVectorSearch.SearchResult(null, 0.5);
+    LanceVectorSearch.SearchResult result3 = new LanceVectorSearch.SearchResult(null, 1.0);
 
-        assertThat(result1).isEqualTo(result2);
-        assertThat(result1.hashCode()).isEqualTo(result2.hashCode());
-        assertThat(result1).isNotEqualTo(result3);
-    }
+    assertThat(result1).isEqualTo(result2);
+    assertThat(result1.hashCode()).isEqualTo(result2.hashCode());
+    assertThat(result1).isNotEqualTo(result3);
+  }
 
-    @Test
-    @DisplayName("Test configuration validation - invalid vector search params")
-    void testInvalidVectorSearchParams() {
-        assertThatThrownBy(() -> LanceOptions.builder()
-                .path(datasetPath)
-                .vectorColumn("embedding")
-                .vectorNprobes(0)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("nprobes");
+  @Test
+  @DisplayName("Test configuration validation - invalid vector search params")
+  void testInvalidVectorSearchParams() {
+    assertThatThrownBy(
+            () ->
+                LanceOptions.builder()
+                    .path(datasetPath)
+                    .vectorColumn("embedding")
+                    .vectorNprobes(0)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("nprobes");
 
-        assertThatThrownBy(() -> LanceOptions.builder()
-                .path(datasetPath)
-                .vectorColumn("embedding")
-                .vectorEf(0)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("ef");
+    assertThatThrownBy(
+            () ->
+                LanceOptions.builder()
+                    .path(datasetPath)
+                    .vectorColumn("embedding")
+                    .vectorEf(0)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("ef");
 
-        assertThatThrownBy(() -> LanceOptions.builder()
-                .path(datasetPath)
-                .vectorColumn("embedding")
-                .vectorRefineFactor(0)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("refine-factor");
-    }
+    assertThatThrownBy(
+            () ->
+                LanceOptions.builder()
+                    .path(datasetPath)
+                    .vectorColumn("embedding")
+                    .vectorRefineFactor(0)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("refine-factor");
+  }
 
-    @Test
-    @DisplayName("Test metric type values")
-    void testMetricTypeValues() {
-        assertThat(MetricType.L2.getValue()).isEqualTo("L2");
-        assertThat(MetricType.COSINE.getValue()).isEqualTo("Cosine");
-        assertThat(MetricType.DOT.getValue()).isEqualTo("Dot");
-    }
+  @Test
+  @DisplayName("Test metric type values")
+  void testMetricTypeValues() {
+    assertThat(MetricType.L2.getValue()).isEqualTo("L2");
+    assertThat(MetricType.COSINE.getValue()).isEqualTo("Cosine");
+    assertThat(MetricType.DOT.getValue()).isEqualTo("Dot");
+  }
 
-    @Test
-    @DisplayName("Test search result toString")
-    void testSearchResultToString() {
-        LanceVectorSearch.SearchResult result = new LanceVectorSearch.SearchResult(null, 0.5);
-        String str = result.toString();
+  @Test
+  @DisplayName("Test search result toString")
+  void testSearchResultToString() {
+    LanceVectorSearch.SearchResult result = new LanceVectorSearch.SearchResult(null, 0.5);
+    String str = result.toString();
 
-        assertThat(str).contains("SearchResult");
-        assertThat(str).contains("distance=0.5");
-    }
+    assertThat(str).contains("SearchResult");
+    assertThat(str).contains("distance=0.5");
+  }
 }

--- a/src/test/java/org/apache/flink/connector/lance/aggregate/AggregateExecutorTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/aggregate/AggregateExecutorTest.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.aggregate;
 
 import org.apache.flink.table.data.GenericRowData;
@@ -26,7 +21,6 @@ import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -37,495 +31,470 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-/**
- * AggregateExecutor unit tests
- */
+/** AggregateExecutor unit tests */
 @DisplayName("AggregateExecutor Unit Tests")
 class AggregateExecutorTest {
 
-    private RowType sourceRowType;
+  private RowType sourceRowType;
 
-    @BeforeEach
-    void setUp() {
-        // Create test RowType: (id INT, name VARCHAR, category VARCHAR, amount DOUBLE, quantity INT)
-        sourceRowType = RowType.of(
-                new IntType(),
-                new VarCharType(100),
-                new VarCharType(50),
-                new DoubleType(),
-                new IntType()
-        );
-        sourceRowType = new RowType(Arrays.asList(
+  @BeforeEach
+  void setUp() {
+    // Create test RowType: (id INT, name VARCHAR, category VARCHAR, amount DOUBLE, quantity INT)
+    sourceRowType =
+        RowType.of(
+            new IntType(),
+            new VarCharType(100),
+            new VarCharType(50),
+            new DoubleType(),
+            new IntType());
+    sourceRowType =
+        new RowType(
+            Arrays.asList(
                 new RowType.RowField("id", new IntType()),
                 new RowType.RowField("name", new VarCharType(100)),
                 new RowType.RowField("category", new VarCharType(50)),
                 new RowType.RowField("amount", new DoubleType()),
-                new RowType.RowField("quantity", new IntType())
-        ));
+                new RowType.RowField("quantity", new IntType())));
+  }
+
+  /** Create test data row */
+  private RowData createRow(int id, String name, String category, double amount, int quantity) {
+    GenericRowData row = new GenericRowData(5);
+    row.setField(0, id);
+    row.setField(1, StringData.fromString(name));
+    row.setField(2, StringData.fromString(category));
+    row.setField(3, amount);
+    row.setField(4, quantity);
+    return row;
+  }
+
+  // ==================== COUNT Aggregate Tests ====================
+
+  @Nested
+  @DisplayName("COUNT Aggregate Tests")
+  class CountAggregateTests {
+
+    @Test
+    @DisplayName("COUNT(*) should correctly count all rows")
+    void testCountStar() {
+      AggregateInfo aggInfo = AggregateInfo.builder().addCountStar("cnt").build();
+
+      AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
+      executor.init();
+
+      // Accumulate 5 rows of data
+      executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
+      executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
+      executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
+      executor.accumulate(createRow(4, "David", "B", 180.0, 18));
+      executor.accumulate(createRow(5, "Eve", "C", 220.0, 22));
+
+      List<RowData> results = executor.getResults();
+
+      assertEquals(1, results.size());
+      assertEquals(5L, results.get(0).getLong(0)); // COUNT(*)
     }
 
-    /**
-     * Create test data row
-     */
-    private RowData createRow(int id, String name, String category, double amount, int quantity) {
-        GenericRowData row = new GenericRowData(5);
-        row.setField(0, id);
-        row.setField(1, StringData.fromString(name));
-        row.setField(2, StringData.fromString(category));
-        row.setField(3, amount);
-        row.setField(4, quantity);
-        return row;
+    @Test
+    @DisplayName("COUNT(column) should correctly count non-null values")
+    void testCountColumn() {
+      AggregateInfo aggInfo = AggregateInfo.builder().addCount("name", "name_count").build();
+
+      AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
+      executor.init();
+
+      executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
+      executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
+      executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
+
+      List<RowData> results = executor.getResults();
+
+      assertEquals(1, results.size());
+      assertEquals(3L, results.get(0).getLong(0));
     }
 
-    // ==================== COUNT Aggregate Tests ====================
+    @Test
+    @DisplayName("COUNT(*) on empty dataset should return 0")
+    void testCountStarEmpty() {
+      AggregateInfo aggInfo = AggregateInfo.builder().addCountStar("cnt").build();
 
-    @Nested
-    @DisplayName("COUNT Aggregate Tests")
-    class CountAggregateTests {
+      AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
+      executor.init();
 
-        @Test
-        @DisplayName("COUNT(*) should correctly count all rows")
-        void testCountStar() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .build();
+      List<RowData> results = executor.getResults();
 
-            AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
-            executor.init();
+      assertEquals(1, results.size());
+      assertEquals(0L, results.get(0).getLong(0));
+    }
+  }
 
-            // Accumulate 5 rows of data
-            executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
-            executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
-            executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
-            executor.accumulate(createRow(4, "David", "B", 180.0, 18));
-            executor.accumulate(createRow(5, "Eve", "C", 220.0, 22));
+  // ==================== SUM Aggregate Tests ====================
 
-            List<RowData> results = executor.getResults();
+  @Nested
+  @DisplayName("SUM Aggregate Tests")
+  class SumAggregateTests {
 
-            assertEquals(1, results.size());
-            assertEquals(5L, results.get(0).getLong(0));  // COUNT(*)
-        }
+    @Test
+    @DisplayName("SUM should correctly sum values")
+    void testSum() {
+      AggregateInfo aggInfo = AggregateInfo.builder().addSum("amount", "total_amount").build();
 
-        @Test
-        @DisplayName("COUNT(column) should correctly count non-null values")
-        void testCountColumn() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addCount("name", "name_count")
-                    .build();
+      AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
+      executor.init();
 
-            AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
-            executor.init();
+      executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
+      executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
+      executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
 
-            executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
-            executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
-            executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
+      List<RowData> results = executor.getResults();
 
-            List<RowData> results = executor.getResults();
-
-            assertEquals(1, results.size());
-            assertEquals(3L, results.get(0).getLong(0));
-        }
-
-        @Test
-        @DisplayName("COUNT(*) on empty dataset should return 0")
-        void testCountStarEmpty() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .build();
-
-            AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
-            executor.init();
-
-            List<RowData> results = executor.getResults();
-
-            assertEquals(1, results.size());
-            assertEquals(0L, results.get(0).getLong(0));
-        }
+      assertEquals(1, results.size());
+      assertEquals(450.0, results.get(0).getDouble(0), 0.001);
     }
 
-    // ==================== SUM Aggregate Tests ====================
+    @Test
+    @DisplayName("SUM on empty dataset should return null")
+    void testSumEmpty() {
+      AggregateInfo aggInfo = AggregateInfo.builder().addSum("amount", "total_amount").build();
 
-    @Nested
-    @DisplayName("SUM Aggregate Tests")
-    class SumAggregateTests {
+      AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
+      executor.init();
 
-        @Test
-        @DisplayName("SUM should correctly sum values")
-        void testSum() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addSum("amount", "total_amount")
-                    .build();
+      List<RowData> results = executor.getResults();
 
-            AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
-            executor.init();
+      assertEquals(1, results.size());
+      assertTrue(results.get(0).isNullAt(0));
+    }
+  }
 
-            executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
-            executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
-            executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
+  // ==================== AVG Aggregate Tests ====================
 
-            List<RowData> results = executor.getResults();
+  @Nested
+  @DisplayName("AVG Aggregate Tests")
+  class AvgAggregateTests {
 
-            assertEquals(1, results.size());
-            assertEquals(450.0, results.get(0).getDouble(0), 0.001);
-        }
+    @Test
+    @DisplayName("AVG should correctly calculate average")
+    void testAvg() {
+      AggregateInfo aggInfo = AggregateInfo.builder().addAvg("amount", "avg_amount").build();
 
-        @Test
-        @DisplayName("SUM on empty dataset should return null")
-        void testSumEmpty() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addSum("amount", "total_amount")
-                    .build();
+      AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
+      executor.init();
 
-            AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
-            executor.init();
+      executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
+      executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
+      executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
 
-            List<RowData> results = executor.getResults();
+      List<RowData> results = executor.getResults();
 
-            assertEquals(1, results.size());
-            assertTrue(results.get(0).isNullAt(0));
-        }
+      assertEquals(1, results.size());
+      assertEquals(150.0, results.get(0).getDouble(0), 0.001); // (100+200+150)/3
     }
 
-    // ==================== AVG Aggregate Tests ====================
+    @Test
+    @DisplayName("AVG on empty dataset should return null")
+    void testAvgEmpty() {
+      AggregateInfo aggInfo = AggregateInfo.builder().addAvg("amount", "avg_amount").build();
 
-    @Nested
-    @DisplayName("AVG Aggregate Tests")
-    class AvgAggregateTests {
+      AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
+      executor.init();
 
-        @Test
-        @DisplayName("AVG should correctly calculate average")
-        void testAvg() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addAvg("amount", "avg_amount")
-                    .build();
+      List<RowData> results = executor.getResults();
 
-            AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
-            executor.init();
+      assertEquals(1, results.size());
+      assertTrue(results.get(0).isNullAt(0));
+    }
+  }
 
-            executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
-            executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
-            executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
+  // ==================== MIN/MAX Aggregate Tests ====================
 
-            List<RowData> results = executor.getResults();
+  @Nested
+  @DisplayName("MIN/MAX Aggregate Tests")
+  class MinMaxAggregateTests {
 
-            assertEquals(1, results.size());
-            assertEquals(150.0, results.get(0).getDouble(0), 0.001);  // (100+200+150)/3
-        }
+    @Test
+    @DisplayName("MIN should return minimum value")
+    void testMin() {
+      AggregateInfo aggInfo = AggregateInfo.builder().addMin("amount", "min_amount").build();
 
-        @Test
-        @DisplayName("AVG on empty dataset should return null")
-        void testAvgEmpty() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addAvg("amount", "avg_amount")
-                    .build();
+      AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
+      executor.init();
 
-            AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
-            executor.init();
+      executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
+      executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
+      executor.accumulate(createRow(3, "Charlie", "A", 50.0, 15));
 
-            List<RowData> results = executor.getResults();
+      List<RowData> results = executor.getResults();
 
-            assertEquals(1, results.size());
-            assertTrue(results.get(0).isNullAt(0));
-        }
+      assertEquals(1, results.size());
+      assertEquals(50.0, results.get(0).getDouble(0), 0.001);
     }
 
-    // ==================== MIN/MAX Aggregate Tests ====================
+    @Test
+    @DisplayName("MAX should return maximum value")
+    void testMax() {
+      AggregateInfo aggInfo = AggregateInfo.builder().addMax("amount", "max_amount").build();
 
-    @Nested
-    @DisplayName("MIN/MAX Aggregate Tests")
-    class MinMaxAggregateTests {
+      AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
+      executor.init();
 
-        @Test
-        @DisplayName("MIN should return minimum value")
-        void testMin() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addMin("amount", "min_amount")
-                    .build();
+      executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
+      executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
+      executor.accumulate(createRow(3, "Charlie", "A", 50.0, 15));
 
-            AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
-            executor.init();
+      List<RowData> results = executor.getResults();
 
-            executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
-            executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
-            executor.accumulate(createRow(3, "Charlie", "A", 50.0, 15));
-
-            List<RowData> results = executor.getResults();
-
-            assertEquals(1, results.size());
-            assertEquals(50.0, results.get(0).getDouble(0), 0.001);
-        }
-
-        @Test
-        @DisplayName("MAX should return maximum value")
-        void testMax() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addMax("amount", "max_amount")
-                    .build();
-
-            AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
-            executor.init();
-
-            executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
-            executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
-            executor.accumulate(createRow(3, "Charlie", "A", 50.0, 15));
-
-            List<RowData> results = executor.getResults();
-
-            assertEquals(1, results.size());
-            assertEquals(200.0, results.get(0).getDouble(0), 0.001);
-        }
-
-        @Test
-        @DisplayName("MIN/MAX on empty dataset should return null")
-        void testMinMaxEmpty() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addMin("amount", "min_amount")
-                    .addMax("amount", "max_amount")
-                    .build();
-
-            AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
-            executor.init();
-
-            List<RowData> results = executor.getResults();
-
-            assertEquals(1, results.size());
-            assertTrue(results.get(0).isNullAt(0));  // MIN
-            assertTrue(results.get(0).isNullAt(1));  // MAX
-        }
+      assertEquals(1, results.size());
+      assertEquals(200.0, results.get(0).getDouble(0), 0.001);
     }
 
-    // ==================== GROUP BY Tests ====================
+    @Test
+    @DisplayName("MIN/MAX on empty dataset should return null")
+    void testMinMaxEmpty() {
+      AggregateInfo aggInfo =
+          AggregateInfo.builder()
+              .addMin("amount", "min_amount")
+              .addMax("amount", "max_amount")
+              .build();
 
-    @Nested
-    @DisplayName("GROUP BY Aggregate Tests")
-    class GroupByAggregateTests {
+      AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
+      executor.init();
 
-        @Test
-        @DisplayName("COUNT with GROUP BY should count by group")
-        void testGroupByCount() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .groupBy("category")
-                    .build();
+      List<RowData> results = executor.getResults();
 
-            AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
-            executor.init();
+      assertEquals(1, results.size());
+      assertTrue(results.get(0).isNullAt(0)); // MIN
+      assertTrue(results.get(0).isNullAt(1)); // MAX
+    }
+  }
 
-            executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
-            executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
-            executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
-            executor.accumulate(createRow(4, "David", "B", 180.0, 18));
-            executor.accumulate(createRow(5, "Eve", "A", 220.0, 22));
+  // ==================== GROUP BY Tests ====================
 
-            List<RowData> results = executor.getResults();
+  @Nested
+  @DisplayName("GROUP BY Aggregate Tests")
+  class GroupByAggregateTests {
 
-            assertEquals(2, results.size());  // 2 groups: A and B
+    @Test
+    @DisplayName("COUNT with GROUP BY should count by group")
+    void testGroupByCount() {
+      AggregateInfo aggInfo =
+          AggregateInfo.builder().addCountStar("cnt").groupBy("category").build();
 
-            // Verify count for each group
-            long countA = 0, countB = 0;
-            for (RowData row : results) {
-                String category = row.getString(0).toString();
-                long count = row.getLong(1);
-                if ("A".equals(category)) {
-                    countA = count;
-                } else if ("B".equals(category)) {
-                    countB = count;
-                }
-            }
-            assertEquals(3, countA);  // A has 3 rows
-            assertEquals(2, countB);  // B has 2 rows
+      AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
+      executor.init();
+
+      executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
+      executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
+      executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
+      executor.accumulate(createRow(4, "David", "B", 180.0, 18));
+      executor.accumulate(createRow(5, "Eve", "A", 220.0, 22));
+
+      List<RowData> results = executor.getResults();
+
+      assertEquals(2, results.size()); // 2 groups: A and B
+
+      // Verify count for each group
+      long countA = 0, countB = 0;
+      for (RowData row : results) {
+        String category = row.getString(0).toString();
+        long count = row.getLong(1);
+        if ("A".equals(category)) {
+          countA = count;
+        } else if ("B".equals(category)) {
+          countB = count;
         }
-
-        @Test
-        @DisplayName("SUM with GROUP BY should sum by group")
-        void testGroupBySum() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addSum("amount", "total_amount")
-                    .groupBy("category")
-                    .build();
-
-            AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
-            executor.init();
-
-            executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
-            executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
-            executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
-
-            List<RowData> results = executor.getResults();
-
-            assertEquals(2, results.size());
-
-            // Verify sum for each group
-            for (RowData row : results) {
-                String category = row.getString(0).toString();
-                double sum = row.getDouble(1);
-                if ("A".equals(category)) {
-                    assertEquals(250.0, sum, 0.001);  // 100 + 150
-                } else if ("B".equals(category)) {
-                    assertEquals(200.0, sum, 0.001);  // 200
-                }
-            }
-        }
-
-        @Test
-        @DisplayName("Empty dataset with GROUP BY should return empty result")
-        void testGroupByEmpty() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .groupBy("category")
-                    .build();
-
-            AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
-            executor.init();
-
-            List<RowData> results = executor.getResults();
-
-            assertTrue(results.isEmpty());
-        }
+      }
+      assertEquals(3, countA); // A has 3 rows
+      assertEquals(2, countB); // B has 2 rows
     }
 
-    // ==================== Multiple Aggregates Tests ====================
+    @Test
+    @DisplayName("SUM with GROUP BY should sum by group")
+    void testGroupBySum() {
+      AggregateInfo aggInfo =
+          AggregateInfo.builder().addSum("amount", "total_amount").groupBy("category").build();
 
-    @Nested
-    @DisplayName("Multiple Aggregates Tests")
-    class MultipleAggregatesTests {
+      AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
+      executor.init();
 
-        @Test
-        @DisplayName("Multiple aggregate functions should work together")
-        void testMultipleAggregates() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .addSum("amount", "sum_amount")
-                    .addAvg("amount", "avg_amount")
-                    .addMin("amount", "min_amount")
-                    .addMax("amount", "max_amount")
-                    .build();
+      executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
+      executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
+      executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
 
-            AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
-            executor.init();
+      List<RowData> results = executor.getResults();
 
-            executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
-            executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
-            executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
+      assertEquals(2, results.size());
 
-            List<RowData> results = executor.getResults();
-
-            assertEquals(1, results.size());
-            RowData result = results.get(0);
-
-            assertEquals(3L, result.getLong(0));           // COUNT(*)
-            assertEquals(450.0, result.getDouble(1), 0.001); // SUM
-            assertEquals(150.0, result.getDouble(2), 0.001); // AVG
-            assertEquals(100.0, result.getDouble(3), 0.001); // MIN
-            assertEquals(200.0, result.getDouble(4), 0.001); // MAX
+      // Verify sum for each group
+      for (RowData row : results) {
+        String category = row.getString(0).toString();
+        double sum = row.getDouble(1);
+        if ("A".equals(category)) {
+          assertEquals(250.0, sum, 0.001); // 100 + 150
+        } else if ("B".equals(category)) {
+          assertEquals(200.0, sum, 0.001); // 200
         }
-
-        @Test
-        @DisplayName("Multiple aggregates with GROUP BY should work correctly")
-        void testMultipleAggregatesWithGroupBy() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .addSum("amount", "sum_amount")
-                    .addAvg("amount", "avg_amount")
-                    .groupBy("category")
-                    .build();
-
-            AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
-            executor.init();
-
-            executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
-            executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
-            executor.accumulate(createRow(3, "Charlie", "A", 200.0, 15));
-
-            List<RowData> results = executor.getResults();
-
-            assertEquals(2, results.size());
-
-            for (RowData row : results) {
-                String category = row.getString(0).toString();
-                long count = row.getLong(1);
-                double sum = row.getDouble(2);
-                double avg = row.getDouble(3);
-
-                if ("A".equals(category)) {
-                    assertEquals(2, count);
-                    assertEquals(300.0, sum, 0.001);
-                    assertEquals(150.0, avg, 0.001);
-                } else if ("B".equals(category)) {
-                    assertEquals(1, count);
-                    assertEquals(200.0, sum, 0.001);
-                    assertEquals(200.0, avg, 0.001);
-                }
-            }
-        }
+      }
     }
 
-    // ==================== Reset Tests ====================
+    @Test
+    @DisplayName("Empty dataset with GROUP BY should return empty result")
+    void testGroupByEmpty() {
+      AggregateInfo aggInfo =
+          AggregateInfo.builder().addCountStar("cnt").groupBy("category").build();
 
-    @Nested
-    @DisplayName("Reset Tests")
-    class ResetTests {
+      AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
+      executor.init();
 
-        @Test
-        @DisplayName("reset should clear aggregate state")
-        void testReset() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .build();
+      List<RowData> results = executor.getResults();
 
-            AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
-            executor.init();
+      assertTrue(results.isEmpty());
+    }
+  }
 
-            executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
-            executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
+  // ==================== Multiple Aggregates Tests ====================
 
-            // Reset
-            executor.reset();
+  @Nested
+  @DisplayName("Multiple Aggregates Tests")
+  class MultipleAggregatesTests {
 
-            // Re-initialize and accumulate new data
-            executor.init();
-            executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
+    @Test
+    @DisplayName("Multiple aggregate functions should work together")
+    void testMultipleAggregates() {
+      AggregateInfo aggInfo =
+          AggregateInfo.builder()
+              .addCountStar("cnt")
+              .addSum("amount", "sum_amount")
+              .addAvg("amount", "avg_amount")
+              .addMin("amount", "min_amount")
+              .addMax("amount", "max_amount")
+              .build();
 
-            List<RowData> results = executor.getResults();
+      AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
+      executor.init();
 
-            assertEquals(1, results.size());
-            assertEquals(1L, results.get(0).getLong(0));  // Only 1 row after reset
-        }
+      executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
+      executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
+      executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
+
+      List<RowData> results = executor.getResults();
+
+      assertEquals(1, results.size());
+      RowData result = results.get(0);
+
+      assertEquals(3L, result.getLong(0)); // COUNT(*)
+      assertEquals(450.0, result.getDouble(1), 0.001); // SUM
+      assertEquals(150.0, result.getDouble(2), 0.001); // AVG
+      assertEquals(100.0, result.getDouble(3), 0.001); // MIN
+      assertEquals(200.0, result.getDouble(4), 0.001); // MAX
     }
 
-    // ==================== Result Type Tests ====================
+    @Test
+    @DisplayName("Multiple aggregates with GROUP BY should work correctly")
+    void testMultipleAggregatesWithGroupBy() {
+      AggregateInfo aggInfo =
+          AggregateInfo.builder()
+              .addCountStar("cnt")
+              .addSum("amount", "sum_amount")
+              .addAvg("amount", "avg_amount")
+              .groupBy("category")
+              .build();
 
-    @Nested
-    @DisplayName("Result Type Tests")
-    class ResultTypeTests {
+      AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
+      executor.init();
 
-        @Test
-        @DisplayName("buildResultRowType should return correct result type")
-        void testBuildResultRowType() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .addSum("amount", "sum_amount")
-                    .groupBy("category")
-                    .build();
+      executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
+      executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
+      executor.accumulate(createRow(3, "Charlie", "A", 200.0, 15));
 
-            AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
-            executor.init();
+      List<RowData> results = executor.getResults();
 
-            RowType resultType = executor.buildResultRowType();
+      assertEquals(2, results.size());
 
-            assertNotNull(resultType);
-            assertEquals(3, resultType.getFieldCount());
+      for (RowData row : results) {
+        String category = row.getString(0).toString();
+        long count = row.getLong(1);
+        double sum = row.getDouble(2);
+        double avg = row.getDouble(3);
 
-            // First field is group column category
-            assertEquals("category", resultType.getFieldNames().get(0));
-
-            // Second field is COUNT result
-            assertEquals("cnt", resultType.getFieldNames().get(1));
-            assertTrue(resultType.getTypeAt(1) instanceof BigIntType);
-
-            // Third field is SUM result
-            assertEquals("sum_amount", resultType.getFieldNames().get(2));
-            assertTrue(resultType.getTypeAt(2) instanceof DoubleType);
+        if ("A".equals(category)) {
+          assertEquals(2, count);
+          assertEquals(300.0, sum, 0.001);
+          assertEquals(150.0, avg, 0.001);
+        } else if ("B".equals(category)) {
+          assertEquals(1, count);
+          assertEquals(200.0, sum, 0.001);
+          assertEquals(200.0, avg, 0.001);
         }
+      }
     }
+  }
+
+  // ==================== Reset Tests ====================
+
+  @Nested
+  @DisplayName("Reset Tests")
+  class ResetTests {
+
+    @Test
+    @DisplayName("reset should clear aggregate state")
+    void testReset() {
+      AggregateInfo aggInfo = AggregateInfo.builder().addCountStar("cnt").build();
+
+      AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
+      executor.init();
+
+      executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
+      executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
+
+      // Reset
+      executor.reset();
+
+      // Re-initialize and accumulate new data
+      executor.init();
+      executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
+
+      List<RowData> results = executor.getResults();
+
+      assertEquals(1, results.size());
+      assertEquals(1L, results.get(0).getLong(0)); // Only 1 row after reset
+    }
+  }
+
+  // ==================== Result Type Tests ====================
+
+  @Nested
+  @DisplayName("Result Type Tests")
+  class ResultTypeTests {
+
+    @Test
+    @DisplayName("buildResultRowType should return correct result type")
+    void testBuildResultRowType() {
+      AggregateInfo aggInfo =
+          AggregateInfo.builder()
+              .addCountStar("cnt")
+              .addSum("amount", "sum_amount")
+              .groupBy("category")
+              .build();
+
+      AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
+      executor.init();
+
+      RowType resultType = executor.buildResultRowType();
+
+      assertNotNull(resultType);
+      assertEquals(3, resultType.getFieldCount());
+
+      // First field is group column category
+      assertEquals("category", resultType.getFieldNames().get(0));
+
+      // Second field is COUNT result
+      assertEquals("cnt", resultType.getFieldNames().get(1));
+      assertTrue(resultType.getTypeAt(1) instanceof BigIntType);
+
+      // Third field is SUM result
+      assertEquals("sum_amount", resultType.getFieldNames().get(2));
+      assertTrue(resultType.getTypeAt(2) instanceof DoubleType);
+    }
+  }
 }

--- a/src/test/java/org/apache/flink/connector/lance/aggregate/AggregateExecutorTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/aggregate/AggregateExecutorTest.java
@@ -89,19 +89,19 @@ class AggregateExecutorTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addCountStar("cnt")
                     .build();
-            
+
             AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
             executor.init();
-            
+
             // Accumulate 5 rows of data
             executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
             executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
             executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
             executor.accumulate(createRow(4, "David", "B", 180.0, 18));
             executor.accumulate(createRow(5, "Eve", "C", 220.0, 22));
-            
+
             List<RowData> results = executor.getResults();
-            
+
             assertEquals(1, results.size());
             assertEquals(5L, results.get(0).getLong(0));  // COUNT(*)
         }
@@ -112,16 +112,16 @@ class AggregateExecutorTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addCount("name", "name_count")
                     .build();
-            
+
             AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
             executor.init();
-            
+
             executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
             executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
             executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
-            
+
             List<RowData> results = executor.getResults();
-            
+
             assertEquals(1, results.size());
             assertEquals(3L, results.get(0).getLong(0));
         }
@@ -132,12 +132,12 @@ class AggregateExecutorTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addCountStar("cnt")
                     .build();
-            
+
             AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
             executor.init();
-            
+
             List<RowData> results = executor.getResults();
-            
+
             assertEquals(1, results.size());
             assertEquals(0L, results.get(0).getLong(0));
         }
@@ -155,16 +155,16 @@ class AggregateExecutorTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addSum("amount", "total_amount")
                     .build();
-            
+
             AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
             executor.init();
-            
+
             executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
             executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
             executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
-            
+
             List<RowData> results = executor.getResults();
-            
+
             assertEquals(1, results.size());
             assertEquals(450.0, results.get(0).getDouble(0), 0.001);
         }
@@ -175,12 +175,12 @@ class AggregateExecutorTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addSum("amount", "total_amount")
                     .build();
-            
+
             AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
             executor.init();
-            
+
             List<RowData> results = executor.getResults();
-            
+
             assertEquals(1, results.size());
             assertTrue(results.get(0).isNullAt(0));
         }
@@ -198,16 +198,16 @@ class AggregateExecutorTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addAvg("amount", "avg_amount")
                     .build();
-            
+
             AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
             executor.init();
-            
+
             executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
             executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
             executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
-            
+
             List<RowData> results = executor.getResults();
-            
+
             assertEquals(1, results.size());
             assertEquals(150.0, results.get(0).getDouble(0), 0.001);  // (100+200+150)/3
         }
@@ -218,12 +218,12 @@ class AggregateExecutorTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addAvg("amount", "avg_amount")
                     .build();
-            
+
             AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
             executor.init();
-            
+
             List<RowData> results = executor.getResults();
-            
+
             assertEquals(1, results.size());
             assertTrue(results.get(0).isNullAt(0));
         }
@@ -241,16 +241,16 @@ class AggregateExecutorTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addMin("amount", "min_amount")
                     .build();
-            
+
             AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
             executor.init();
-            
+
             executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
             executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
             executor.accumulate(createRow(3, "Charlie", "A", 50.0, 15));
-            
+
             List<RowData> results = executor.getResults();
-            
+
             assertEquals(1, results.size());
             assertEquals(50.0, results.get(0).getDouble(0), 0.001);
         }
@@ -261,16 +261,16 @@ class AggregateExecutorTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addMax("amount", "max_amount")
                     .build();
-            
+
             AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
             executor.init();
-            
+
             executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
             executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
             executor.accumulate(createRow(3, "Charlie", "A", 50.0, 15));
-            
+
             List<RowData> results = executor.getResults();
-            
+
             assertEquals(1, results.size());
             assertEquals(200.0, results.get(0).getDouble(0), 0.001);
         }
@@ -282,12 +282,12 @@ class AggregateExecutorTest {
                     .addMin("amount", "min_amount")
                     .addMax("amount", "max_amount")
                     .build();
-            
+
             AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
             executor.init();
-            
+
             List<RowData> results = executor.getResults();
-            
+
             assertEquals(1, results.size());
             assertTrue(results.get(0).isNullAt(0));  // MIN
             assertTrue(results.get(0).isNullAt(1));  // MAX
@@ -307,20 +307,20 @@ class AggregateExecutorTest {
                     .addCountStar("cnt")
                     .groupBy("category")
                     .build();
-            
+
             AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
             executor.init();
-            
+
             executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
             executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
             executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
             executor.accumulate(createRow(4, "David", "B", 180.0, 18));
             executor.accumulate(createRow(5, "Eve", "A", 220.0, 22));
-            
+
             List<RowData> results = executor.getResults();
-            
+
             assertEquals(2, results.size());  // 2 groups: A and B
-            
+
             // Verify count for each group
             long countA = 0, countB = 0;
             for (RowData row : results) {
@@ -343,18 +343,18 @@ class AggregateExecutorTest {
                     .addSum("amount", "total_amount")
                     .groupBy("category")
                     .build();
-            
+
             AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
             executor.init();
-            
+
             executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
             executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
             executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
-            
+
             List<RowData> results = executor.getResults();
-            
+
             assertEquals(2, results.size());
-            
+
             // Verify sum for each group
             for (RowData row : results) {
                 String category = row.getString(0).toString();
@@ -374,12 +374,12 @@ class AggregateExecutorTest {
                     .addCountStar("cnt")
                     .groupBy("category")
                     .build();
-            
+
             AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
             executor.init();
-            
+
             List<RowData> results = executor.getResults();
-            
+
             assertTrue(results.isEmpty());
         }
     }
@@ -400,19 +400,19 @@ class AggregateExecutorTest {
                     .addMin("amount", "min_amount")
                     .addMax("amount", "max_amount")
                     .build();
-            
+
             AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
             executor.init();
-            
+
             executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
             executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
             executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
-            
+
             List<RowData> results = executor.getResults();
-            
+
             assertEquals(1, results.size());
             RowData result = results.get(0);
-            
+
             assertEquals(3L, result.getLong(0));           // COUNT(*)
             assertEquals(450.0, result.getDouble(1), 0.001); // SUM
             assertEquals(150.0, result.getDouble(2), 0.001); // AVG
@@ -429,24 +429,24 @@ class AggregateExecutorTest {
                     .addAvg("amount", "avg_amount")
                     .groupBy("category")
                     .build();
-            
+
             AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
             executor.init();
-            
+
             executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
             executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
             executor.accumulate(createRow(3, "Charlie", "A", 200.0, 15));
-            
+
             List<RowData> results = executor.getResults();
-            
+
             assertEquals(2, results.size());
-            
+
             for (RowData row : results) {
                 String category = row.getString(0).toString();
                 long count = row.getLong(1);
                 double sum = row.getDouble(2);
                 double avg = row.getDouble(3);
-                
+
                 if ("A".equals(category)) {
                     assertEquals(2, count);
                     assertEquals(300.0, sum, 0.001);
@@ -472,22 +472,22 @@ class AggregateExecutorTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addCountStar("cnt")
                     .build();
-            
+
             AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
             executor.init();
-            
+
             executor.accumulate(createRow(1, "Alice", "A", 100.0, 10));
             executor.accumulate(createRow(2, "Bob", "B", 200.0, 20));
-            
+
             // Reset
             executor.reset();
-            
+
             // Re-initialize and accumulate new data
             executor.init();
             executor.accumulate(createRow(3, "Charlie", "A", 150.0, 15));
-            
+
             List<RowData> results = executor.getResults();
-            
+
             assertEquals(1, results.size());
             assertEquals(1L, results.get(0).getLong(0));  // Only 1 row after reset
         }
@@ -507,22 +507,22 @@ class AggregateExecutorTest {
                     .addSum("amount", "sum_amount")
                     .groupBy("category")
                     .build();
-            
+
             AggregateExecutor executor = new AggregateExecutor(aggInfo, sourceRowType);
             executor.init();
-            
+
             RowType resultType = executor.buildResultRowType();
-            
+
             assertNotNull(resultType);
             assertEquals(3, resultType.getFieldCount());
-            
+
             // First field is group column category
             assertEquals("category", resultType.getFieldNames().get(0));
-            
+
             // Second field is COUNT result
             assertEquals("cnt", resultType.getFieldNames().get(1));
             assertTrue(resultType.getTypeAt(1) instanceof BigIntType);
-            
+
             // Third field is SUM result
             assertEquals("sum_amount", resultType.getFieldNames().get(2));
             assertTrue(resultType.getTypeAt(2) instanceof DoubleType);

--- a/src/test/java/org/apache/flink/connector/lance/aggregate/AggregateInfoTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/aggregate/AggregateInfoTest.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.aggregate;
 
 import org.junit.jupiter.api.DisplayName;
@@ -27,330 +22,320 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-/**
- * AggregateInfo unit tests
- */
+/** AggregateInfo unit tests */
 @DisplayName("AggregateInfo Unit Tests")
 class AggregateInfoTest {
 
-    // ==================== AggregateCall Tests ====================
+  // ==================== AggregateCall Tests ====================
 
-    @Nested
-    @DisplayName("AggregateCall Tests")
-    class AggregateCallTests {
+  @Nested
+  @DisplayName("AggregateCall Tests")
+  class AggregateCallTests {
 
-        @Test
-        @DisplayName("COUNT(*) should be correctly identified")
-        void testCountStar() {
-            AggregateInfo.AggregateCall call = new AggregateInfo.AggregateCall(
-                    AggregateInfo.AggregateFunction.COUNT, null, "cnt");
+    @Test
+    @DisplayName("COUNT(*) should be correctly identified")
+    void testCountStar() {
+      AggregateInfo.AggregateCall call =
+          new AggregateInfo.AggregateCall(AggregateInfo.AggregateFunction.COUNT, null, "cnt");
 
-            assertTrue(call.isCountStar());
-            assertEquals(AggregateInfo.AggregateFunction.COUNT, call.getFunction());
-            assertNull(call.getColumn());
-            assertEquals("cnt", call.getAlias());
-            assertEquals("COUNT(*)", call.toString());
-        }
-
-        @Test
-        @DisplayName("COUNT(column) should be correctly identified")
-        void testCountColumn() {
-            AggregateInfo.AggregateCall call = new AggregateInfo.AggregateCall(
-                    AggregateInfo.AggregateFunction.COUNT, "id", "id_count");
-
-            assertFalse(call.isCountStar());
-            assertEquals(AggregateInfo.AggregateFunction.COUNT, call.getFunction());
-            assertEquals("id", call.getColumn());
-            assertEquals("id_count", call.getAlias());
-            assertEquals("COUNT(id)", call.toString());
-        }
-
-        @Test
-        @DisplayName("SUM aggregate should be correctly built")
-        void testSumAggregate() {
-            AggregateInfo.AggregateCall call = new AggregateInfo.AggregateCall(
-                    AggregateInfo.AggregateFunction.SUM, "amount", "total_amount");
-
-            assertFalse(call.isCountStar());
-            assertEquals(AggregateInfo.AggregateFunction.SUM, call.getFunction());
-            assertEquals("amount", call.getColumn());
-            assertEquals("total_amount", call.getAlias());
-            assertEquals("SUM(amount)", call.toString());
-        }
-
-        @Test
-        @DisplayName("AVG aggregate should be correctly built")
-        void testAvgAggregate() {
-            AggregateInfo.AggregateCall call = new AggregateInfo.AggregateCall(
-                    AggregateInfo.AggregateFunction.AVG, "score", "avg_score");
-
-            assertEquals(AggregateInfo.AggregateFunction.AVG, call.getFunction());
-            assertEquals("score", call.getColumn());
-            assertEquals("avg_score", call.getAlias());
-            assertEquals("AVG(score)", call.toString());
-        }
-
-        @Test
-        @DisplayName("MIN aggregate should be correctly built")
-        void testMinAggregate() {
-            AggregateInfo.AggregateCall call = new AggregateInfo.AggregateCall(
-                    AggregateInfo.AggregateFunction.MIN, "price", "min_price");
-
-            assertEquals(AggregateInfo.AggregateFunction.MIN, call.getFunction());
-            assertEquals("price", call.getColumn());
-            assertEquals("min_price", call.getAlias());
-        }
-
-        @Test
-        @DisplayName("MAX aggregate should be correctly built")
-        void testMaxAggregate() {
-            AggregateInfo.AggregateCall call = new AggregateInfo.AggregateCall(
-                    AggregateInfo.AggregateFunction.MAX, "price", "max_price");
-
-            assertEquals(AggregateInfo.AggregateFunction.MAX, call.getFunction());
-            assertEquals("price", call.getColumn());
-            assertEquals("max_price", call.getAlias());
-        }
-
-        @Test
-        @DisplayName("AggregateCall equals and hashCode should work correctly")
-        void testAggregateCallEqualsAndHashCode() {
-            AggregateInfo.AggregateCall call1 = new AggregateInfo.AggregateCall(
-                    AggregateInfo.AggregateFunction.SUM, "amount", "total");
-            AggregateInfo.AggregateCall call2 = new AggregateInfo.AggregateCall(
-                    AggregateInfo.AggregateFunction.SUM, "amount", "total");
-            AggregateInfo.AggregateCall call3 = new AggregateInfo.AggregateCall(
-                    AggregateInfo.AggregateFunction.SUM, "price", "total");
-
-            assertEquals(call1, call2);
-            assertEquals(call1.hashCode(), call2.hashCode());
-            assertNotEquals(call1, call3);
-        }
+      assertTrue(call.isCountStar());
+      assertEquals(AggregateInfo.AggregateFunction.COUNT, call.getFunction());
+      assertNull(call.getColumn());
+      assertEquals("cnt", call.getAlias());
+      assertEquals("COUNT(*)", call.toString());
     }
 
-    // ==================== AggregateInfo Builder Tests ====================
+    @Test
+    @DisplayName("COUNT(column) should be correctly identified")
+    void testCountColumn() {
+      AggregateInfo.AggregateCall call =
+          new AggregateInfo.AggregateCall(AggregateInfo.AggregateFunction.COUNT, "id", "id_count");
 
-    @Nested
-    @DisplayName("AggregateInfo Builder Tests")
-    class AggregateInfoBuilderTests {
-
-        @Test
-        @DisplayName("Build simple COUNT(*) query")
-        void testBuildSimpleCountStar() {
-            AggregateInfo info = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .build();
-
-            assertNotNull(info);
-            assertEquals(1, info.getAggregateCalls().size());
-            assertTrue(info.isSimpleCountStar());
-            assertFalse(info.hasGroupBy());
-        }
-
-        @Test
-        @DisplayName("Build aggregate query with GROUP BY")
-        void testBuildAggregateWithGroupBy() {
-            AggregateInfo info = AggregateInfo.builder()
-                    .addSum("amount", "total_amount")
-                    .addAvg("score", "avg_score")
-                    .groupBy("category", "region")
-                    .build();
-
-            assertNotNull(info);
-            assertEquals(2, info.getAggregateCalls().size());
-            assertTrue(info.hasGroupBy());
-            assertEquals(Arrays.asList("category", "region"), info.getGroupByColumns());
-            assertFalse(info.isSimpleCountStar());
-        }
-
-        @Test
-        @DisplayName("Build multiple aggregates query")
-        void testBuildMultipleAggregates() {
-            AggregateInfo info = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .addSum("amount", "sum_amount")
-                    .addAvg("score", "avg_score")
-                    .addMin("price", "min_price")
-                    .addMax("price", "max_price")
-                    .build();
-
-            assertNotNull(info);
-            assertEquals(5, info.getAggregateCalls().size());
-            assertFalse(info.hasGroupBy());
-        }
-
-        @Test
-        @DisplayName("Build requires at least one aggregate function")
-        void testBuildRequiresAtLeastOneAggregate() {
-            assertThrows(IllegalArgumentException.class, () -> {
-                AggregateInfo.builder().build();
-            });
-        }
-
-        @Test
-        @DisplayName("addAggregateCall should work correctly")
-        void testAddAggregateCall() {
-            AggregateInfo.AggregateCall call = new AggregateInfo.AggregateCall(
-                    AggregateInfo.AggregateFunction.SUM, "amount", "total");
-
-            AggregateInfo info = AggregateInfo.builder()
-                    .addAggregateCall(call)
-                    .build();
-
-            assertEquals(1, info.getAggregateCalls().size());
-            assertEquals(call, info.getAggregateCalls().get(0));
-        }
-
-        @Test
-        @DisplayName("addCount should work correctly")
-        void testAddCount() {
-            AggregateInfo info = AggregateInfo.builder()
-                    .addCount("id", "id_count")
-                    .build();
-
-            AggregateInfo.AggregateCall call = info.getAggregateCalls().get(0);
-            assertEquals(AggregateInfo.AggregateFunction.COUNT, call.getFunction());
-            assertEquals("id", call.getColumn());
-            assertFalse(call.isCountStar());
-        }
-
-        @Test
-        @DisplayName("groupBy(List) should work correctly")
-        void testGroupByWithList() {
-            List<String> groupCols = Arrays.asList("col1", "col2", "col3");
-
-            AggregateInfo info = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .groupBy(groupCols)
-                    .build();
-
-            assertEquals(groupCols, info.getGroupByColumns());
-        }
-
-        @Test
-        @DisplayName("groupByFieldIndices should be correctly set")
-        void testGroupByFieldIndices() {
-            int[] indices = {0, 2, 4};
-
-            AggregateInfo info = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .groupBy("col1", "col3", "col5")
-                    .groupByFieldIndices(indices)
-                    .build();
-
-            assertArrayEquals(indices, info.getGroupByFieldIndices());
-        }
+      assertFalse(call.isCountStar());
+      assertEquals(AggregateInfo.AggregateFunction.COUNT, call.getFunction());
+      assertEquals("id", call.getColumn());
+      assertEquals("id_count", call.getAlias());
+      assertEquals("COUNT(id)", call.toString());
     }
 
-    // ==================== AggregateInfo Methods Tests ====================
+    @Test
+    @DisplayName("SUM aggregate should be correctly built")
+    void testSumAggregate() {
+      AggregateInfo.AggregateCall call =
+          new AggregateInfo.AggregateCall(
+              AggregateInfo.AggregateFunction.SUM, "amount", "total_amount");
 
-    @Nested
-    @DisplayName("AggregateInfo Methods Tests")
-    class AggregateInfoMethodTests {
-
-        @Test
-        @DisplayName("getRequiredColumns should return all required columns")
-        void testGetRequiredColumns() {
-            AggregateInfo info = AggregateInfo.builder()
-                    .addSum("amount", "sum_amount")
-                    .addAvg("score", "avg_score")
-                    .groupBy("category", "region")
-                    .build();
-
-            List<String> required = info.getRequiredColumns();
-
-            // Should contain group columns and aggregate columns
-            assertTrue(required.contains("category"));
-            assertTrue(required.contains("region"));
-            assertTrue(required.contains("amount"));
-            assertTrue(required.contains("score"));
-        }
-
-        @Test
-        @DisplayName("getRequiredColumns should deduplicate")
-        void testGetRequiredColumnsDedup() {
-            AggregateInfo info = AggregateInfo.builder()
-                    .addSum("amount", "sum_amount")
-                    .addAvg("amount", "avg_amount")  // Same column
-                    .groupBy("category")
-                    .build();
-
-            List<String> required = info.getRequiredColumns();
-
-            // amount should appear only once
-            long amountCount = required.stream().filter(c -> c.equals("amount")).count();
-            assertEquals(1, amountCount);
-        }
-
-        @Test
-        @DisplayName("COUNT(*) does not require column")
-        void testCountStarNoColumn() {
-            AggregateInfo info = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .build();
-
-            List<String> required = info.getRequiredColumns();
-            assertTrue(required.isEmpty());
-        }
-
-        @Test
-        @DisplayName("equals and hashCode should work correctly")
-        void testEqualsAndHashCode() {
-            AggregateInfo info1 = AggregateInfo.builder()
-                    .addSum("amount", "total")
-                    .groupBy("category")
-                    .build();
-
-            AggregateInfo info2 = AggregateInfo.builder()
-                    .addSum("amount", "total")
-                    .groupBy("category")
-                    .build();
-
-            AggregateInfo info3 = AggregateInfo.builder()
-                    .addAvg("amount", "avg")
-                    .groupBy("category")
-                    .build();
-
-            assertEquals(info1, info2);
-            assertEquals(info1.hashCode(), info2.hashCode());
-            assertNotEquals(info1, info3);
-        }
-
-        @Test
-        @DisplayName("toString should return meaningful string")
-        void testToString() {
-            AggregateInfo info = AggregateInfo.builder()
-                    .addSum("amount", "total")
-                    .groupBy("category")
-                    .build();
-
-            String str = info.toString();
-
-            assertTrue(str.contains("AggregateInfo"));
-            assertTrue(str.contains("SUM(amount)"));
-            assertTrue(str.contains("groupBy"));
-            assertTrue(str.contains("category"));
-        }
+      assertFalse(call.isCountStar());
+      assertEquals(AggregateInfo.AggregateFunction.SUM, call.getFunction());
+      assertEquals("amount", call.getColumn());
+      assertEquals("total_amount", call.getAlias());
+      assertEquals("SUM(amount)", call.toString());
     }
 
-    // ==================== Aggregate Function Enum Tests ====================
+    @Test
+    @DisplayName("AVG aggregate should be correctly built")
+    void testAvgAggregate() {
+      AggregateInfo.AggregateCall call =
+          new AggregateInfo.AggregateCall(
+              AggregateInfo.AggregateFunction.AVG, "score", "avg_score");
 
-    @Nested
-    @DisplayName("AggregateFunction Enum Tests")
-    class AggregateFunctionEnumTests {
-
-        @Test
-        @DisplayName("Should contain all supported aggregate functions")
-        void testAllAggregateFunctions() {
-            AggregateInfo.AggregateFunction[] functions = AggregateInfo.AggregateFunction.values();
-
-            assertEquals(6, functions.length);
-            assertTrue(Arrays.asList(functions).contains(AggregateInfo.AggregateFunction.COUNT));
-            assertTrue(Arrays.asList(functions).contains(AggregateInfo.AggregateFunction.COUNT_DISTINCT));
-            assertTrue(Arrays.asList(functions).contains(AggregateInfo.AggregateFunction.SUM));
-            assertTrue(Arrays.asList(functions).contains(AggregateInfo.AggregateFunction.AVG));
-            assertTrue(Arrays.asList(functions).contains(AggregateInfo.AggregateFunction.MIN));
-            assertTrue(Arrays.asList(functions).contains(AggregateInfo.AggregateFunction.MAX));
-        }
+      assertEquals(AggregateInfo.AggregateFunction.AVG, call.getFunction());
+      assertEquals("score", call.getColumn());
+      assertEquals("avg_score", call.getAlias());
+      assertEquals("AVG(score)", call.toString());
     }
+
+    @Test
+    @DisplayName("MIN aggregate should be correctly built")
+    void testMinAggregate() {
+      AggregateInfo.AggregateCall call =
+          new AggregateInfo.AggregateCall(
+              AggregateInfo.AggregateFunction.MIN, "price", "min_price");
+
+      assertEquals(AggregateInfo.AggregateFunction.MIN, call.getFunction());
+      assertEquals("price", call.getColumn());
+      assertEquals("min_price", call.getAlias());
+    }
+
+    @Test
+    @DisplayName("MAX aggregate should be correctly built")
+    void testMaxAggregate() {
+      AggregateInfo.AggregateCall call =
+          new AggregateInfo.AggregateCall(
+              AggregateInfo.AggregateFunction.MAX, "price", "max_price");
+
+      assertEquals(AggregateInfo.AggregateFunction.MAX, call.getFunction());
+      assertEquals("price", call.getColumn());
+      assertEquals("max_price", call.getAlias());
+    }
+
+    @Test
+    @DisplayName("AggregateCall equals and hashCode should work correctly")
+    void testAggregateCallEqualsAndHashCode() {
+      AggregateInfo.AggregateCall call1 =
+          new AggregateInfo.AggregateCall(AggregateInfo.AggregateFunction.SUM, "amount", "total");
+      AggregateInfo.AggregateCall call2 =
+          new AggregateInfo.AggregateCall(AggregateInfo.AggregateFunction.SUM, "amount", "total");
+      AggregateInfo.AggregateCall call3 =
+          new AggregateInfo.AggregateCall(AggregateInfo.AggregateFunction.SUM, "price", "total");
+
+      assertEquals(call1, call2);
+      assertEquals(call1.hashCode(), call2.hashCode());
+      assertNotEquals(call1, call3);
+    }
+  }
+
+  // ==================== AggregateInfo Builder Tests ====================
+
+  @Nested
+  @DisplayName("AggregateInfo Builder Tests")
+  class AggregateInfoBuilderTests {
+
+    @Test
+    @DisplayName("Build simple COUNT(*) query")
+    void testBuildSimpleCountStar() {
+      AggregateInfo info = AggregateInfo.builder().addCountStar("cnt").build();
+
+      assertNotNull(info);
+      assertEquals(1, info.getAggregateCalls().size());
+      assertTrue(info.isSimpleCountStar());
+      assertFalse(info.hasGroupBy());
+    }
+
+    @Test
+    @DisplayName("Build aggregate query with GROUP BY")
+    void testBuildAggregateWithGroupBy() {
+      AggregateInfo info =
+          AggregateInfo.builder()
+              .addSum("amount", "total_amount")
+              .addAvg("score", "avg_score")
+              .groupBy("category", "region")
+              .build();
+
+      assertNotNull(info);
+      assertEquals(2, info.getAggregateCalls().size());
+      assertTrue(info.hasGroupBy());
+      assertEquals(Arrays.asList("category", "region"), info.getGroupByColumns());
+      assertFalse(info.isSimpleCountStar());
+    }
+
+    @Test
+    @DisplayName("Build multiple aggregates query")
+    void testBuildMultipleAggregates() {
+      AggregateInfo info =
+          AggregateInfo.builder()
+              .addCountStar("cnt")
+              .addSum("amount", "sum_amount")
+              .addAvg("score", "avg_score")
+              .addMin("price", "min_price")
+              .addMax("price", "max_price")
+              .build();
+
+      assertNotNull(info);
+      assertEquals(5, info.getAggregateCalls().size());
+      assertFalse(info.hasGroupBy());
+    }
+
+    @Test
+    @DisplayName("Build requires at least one aggregate function")
+    void testBuildRequiresAtLeastOneAggregate() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> {
+            AggregateInfo.builder().build();
+          });
+    }
+
+    @Test
+    @DisplayName("addAggregateCall should work correctly")
+    void testAddAggregateCall() {
+      AggregateInfo.AggregateCall call =
+          new AggregateInfo.AggregateCall(AggregateInfo.AggregateFunction.SUM, "amount", "total");
+
+      AggregateInfo info = AggregateInfo.builder().addAggregateCall(call).build();
+
+      assertEquals(1, info.getAggregateCalls().size());
+      assertEquals(call, info.getAggregateCalls().get(0));
+    }
+
+    @Test
+    @DisplayName("addCount should work correctly")
+    void testAddCount() {
+      AggregateInfo info = AggregateInfo.builder().addCount("id", "id_count").build();
+
+      AggregateInfo.AggregateCall call = info.getAggregateCalls().get(0);
+      assertEquals(AggregateInfo.AggregateFunction.COUNT, call.getFunction());
+      assertEquals("id", call.getColumn());
+      assertFalse(call.isCountStar());
+    }
+
+    @Test
+    @DisplayName("groupBy(List) should work correctly")
+    void testGroupByWithList() {
+      List<String> groupCols = Arrays.asList("col1", "col2", "col3");
+
+      AggregateInfo info = AggregateInfo.builder().addCountStar("cnt").groupBy(groupCols).build();
+
+      assertEquals(groupCols, info.getGroupByColumns());
+    }
+
+    @Test
+    @DisplayName("groupByFieldIndices should be correctly set")
+    void testGroupByFieldIndices() {
+      int[] indices = {0, 2, 4};
+
+      AggregateInfo info =
+          AggregateInfo.builder()
+              .addCountStar("cnt")
+              .groupBy("col1", "col3", "col5")
+              .groupByFieldIndices(indices)
+              .build();
+
+      assertArrayEquals(indices, info.getGroupByFieldIndices());
+    }
+  }
+
+  // ==================== AggregateInfo Methods Tests ====================
+
+  @Nested
+  @DisplayName("AggregateInfo Methods Tests")
+  class AggregateInfoMethodTests {
+
+    @Test
+    @DisplayName("getRequiredColumns should return all required columns")
+    void testGetRequiredColumns() {
+      AggregateInfo info =
+          AggregateInfo.builder()
+              .addSum("amount", "sum_amount")
+              .addAvg("score", "avg_score")
+              .groupBy("category", "region")
+              .build();
+
+      List<String> required = info.getRequiredColumns();
+
+      // Should contain group columns and aggregate columns
+      assertTrue(required.contains("category"));
+      assertTrue(required.contains("region"));
+      assertTrue(required.contains("amount"));
+      assertTrue(required.contains("score"));
+    }
+
+    @Test
+    @DisplayName("getRequiredColumns should deduplicate")
+    void testGetRequiredColumnsDedup() {
+      AggregateInfo info =
+          AggregateInfo.builder()
+              .addSum("amount", "sum_amount")
+              .addAvg("amount", "avg_amount") // Same column
+              .groupBy("category")
+              .build();
+
+      List<String> required = info.getRequiredColumns();
+
+      // amount should appear only once
+      long amountCount = required.stream().filter(c -> c.equals("amount")).count();
+      assertEquals(1, amountCount);
+    }
+
+    @Test
+    @DisplayName("COUNT(*) does not require column")
+    void testCountStarNoColumn() {
+      AggregateInfo info = AggregateInfo.builder().addCountStar("cnt").build();
+
+      List<String> required = info.getRequiredColumns();
+      assertTrue(required.isEmpty());
+    }
+
+    @Test
+    @DisplayName("equals and hashCode should work correctly")
+    void testEqualsAndHashCode() {
+      AggregateInfo info1 =
+          AggregateInfo.builder().addSum("amount", "total").groupBy("category").build();
+
+      AggregateInfo info2 =
+          AggregateInfo.builder().addSum("amount", "total").groupBy("category").build();
+
+      AggregateInfo info3 =
+          AggregateInfo.builder().addAvg("amount", "avg").groupBy("category").build();
+
+      assertEquals(info1, info2);
+      assertEquals(info1.hashCode(), info2.hashCode());
+      assertNotEquals(info1, info3);
+    }
+
+    @Test
+    @DisplayName("toString should return meaningful string")
+    void testToString() {
+      AggregateInfo info =
+          AggregateInfo.builder().addSum("amount", "total").groupBy("category").build();
+
+      String str = info.toString();
+
+      assertTrue(str.contains("AggregateInfo"));
+      assertTrue(str.contains("SUM(amount)"));
+      assertTrue(str.contains("groupBy"));
+      assertTrue(str.contains("category"));
+    }
+  }
+
+  // ==================== Aggregate Function Enum Tests ====================
+
+  @Nested
+  @DisplayName("AggregateFunction Enum Tests")
+  class AggregateFunctionEnumTests {
+
+    @Test
+    @DisplayName("Should contain all supported aggregate functions")
+    void testAllAggregateFunctions() {
+      AggregateInfo.AggregateFunction[] functions = AggregateInfo.AggregateFunction.values();
+
+      assertEquals(6, functions.length);
+      assertTrue(Arrays.asList(functions).contains(AggregateInfo.AggregateFunction.COUNT));
+      assertTrue(Arrays.asList(functions).contains(AggregateInfo.AggregateFunction.COUNT_DISTINCT));
+      assertTrue(Arrays.asList(functions).contains(AggregateInfo.AggregateFunction.SUM));
+      assertTrue(Arrays.asList(functions).contains(AggregateInfo.AggregateFunction.AVG));
+      assertTrue(Arrays.asList(functions).contains(AggregateInfo.AggregateFunction.MIN));
+      assertTrue(Arrays.asList(functions).contains(AggregateInfo.AggregateFunction.MAX));
+    }
+  }
 }

--- a/src/test/java/org/apache/flink/connector/lance/aggregate/AggregateInfoTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/aggregate/AggregateInfoTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class AggregateInfoTest {
 
     // ==================== AggregateCall Tests ====================
-    
+
     @Nested
     @DisplayName("AggregateCall Tests")
     class AggregateCallTests {
@@ -44,7 +44,7 @@ class AggregateInfoTest {
         void testCountStar() {
             AggregateInfo.AggregateCall call = new AggregateInfo.AggregateCall(
                     AggregateInfo.AggregateFunction.COUNT, null, "cnt");
-            
+
             assertTrue(call.isCountStar());
             assertEquals(AggregateInfo.AggregateFunction.COUNT, call.getFunction());
             assertNull(call.getColumn());
@@ -57,7 +57,7 @@ class AggregateInfoTest {
         void testCountColumn() {
             AggregateInfo.AggregateCall call = new AggregateInfo.AggregateCall(
                     AggregateInfo.AggregateFunction.COUNT, "id", "id_count");
-            
+
             assertFalse(call.isCountStar());
             assertEquals(AggregateInfo.AggregateFunction.COUNT, call.getFunction());
             assertEquals("id", call.getColumn());
@@ -70,7 +70,7 @@ class AggregateInfoTest {
         void testSumAggregate() {
             AggregateInfo.AggregateCall call = new AggregateInfo.AggregateCall(
                     AggregateInfo.AggregateFunction.SUM, "amount", "total_amount");
-            
+
             assertFalse(call.isCountStar());
             assertEquals(AggregateInfo.AggregateFunction.SUM, call.getFunction());
             assertEquals("amount", call.getColumn());
@@ -83,7 +83,7 @@ class AggregateInfoTest {
         void testAvgAggregate() {
             AggregateInfo.AggregateCall call = new AggregateInfo.AggregateCall(
                     AggregateInfo.AggregateFunction.AVG, "score", "avg_score");
-            
+
             assertEquals(AggregateInfo.AggregateFunction.AVG, call.getFunction());
             assertEquals("score", call.getColumn());
             assertEquals("avg_score", call.getAlias());
@@ -95,7 +95,7 @@ class AggregateInfoTest {
         void testMinAggregate() {
             AggregateInfo.AggregateCall call = new AggregateInfo.AggregateCall(
                     AggregateInfo.AggregateFunction.MIN, "price", "min_price");
-            
+
             assertEquals(AggregateInfo.AggregateFunction.MIN, call.getFunction());
             assertEquals("price", call.getColumn());
             assertEquals("min_price", call.getAlias());
@@ -106,7 +106,7 @@ class AggregateInfoTest {
         void testMaxAggregate() {
             AggregateInfo.AggregateCall call = new AggregateInfo.AggregateCall(
                     AggregateInfo.AggregateFunction.MAX, "price", "max_price");
-            
+
             assertEquals(AggregateInfo.AggregateFunction.MAX, call.getFunction());
             assertEquals("price", call.getColumn());
             assertEquals("max_price", call.getAlias());
@@ -121,7 +121,7 @@ class AggregateInfoTest {
                     AggregateInfo.AggregateFunction.SUM, "amount", "total");
             AggregateInfo.AggregateCall call3 = new AggregateInfo.AggregateCall(
                     AggregateInfo.AggregateFunction.SUM, "price", "total");
-            
+
             assertEquals(call1, call2);
             assertEquals(call1.hashCode(), call2.hashCode());
             assertNotEquals(call1, call3);
@@ -129,7 +129,7 @@ class AggregateInfoTest {
     }
 
     // ==================== AggregateInfo Builder Tests ====================
-    
+
     @Nested
     @DisplayName("AggregateInfo Builder Tests")
     class AggregateInfoBuilderTests {
@@ -140,7 +140,7 @@ class AggregateInfoTest {
             AggregateInfo info = AggregateInfo.builder()
                     .addCountStar("cnt")
                     .build();
-            
+
             assertNotNull(info);
             assertEquals(1, info.getAggregateCalls().size());
             assertTrue(info.isSimpleCountStar());
@@ -155,7 +155,7 @@ class AggregateInfoTest {
                     .addAvg("score", "avg_score")
                     .groupBy("category", "region")
                     .build();
-            
+
             assertNotNull(info);
             assertEquals(2, info.getAggregateCalls().size());
             assertTrue(info.hasGroupBy());
@@ -173,7 +173,7 @@ class AggregateInfoTest {
                     .addMin("price", "min_price")
                     .addMax("price", "max_price")
                     .build();
-            
+
             assertNotNull(info);
             assertEquals(5, info.getAggregateCalls().size());
             assertFalse(info.hasGroupBy());
@@ -192,11 +192,11 @@ class AggregateInfoTest {
         void testAddAggregateCall() {
             AggregateInfo.AggregateCall call = new AggregateInfo.AggregateCall(
                     AggregateInfo.AggregateFunction.SUM, "amount", "total");
-            
+
             AggregateInfo info = AggregateInfo.builder()
                     .addAggregateCall(call)
                     .build();
-            
+
             assertEquals(1, info.getAggregateCalls().size());
             assertEquals(call, info.getAggregateCalls().get(0));
         }
@@ -207,7 +207,7 @@ class AggregateInfoTest {
             AggregateInfo info = AggregateInfo.builder()
                     .addCount("id", "id_count")
                     .build();
-            
+
             AggregateInfo.AggregateCall call = info.getAggregateCalls().get(0);
             assertEquals(AggregateInfo.AggregateFunction.COUNT, call.getFunction());
             assertEquals("id", call.getColumn());
@@ -218,12 +218,12 @@ class AggregateInfoTest {
         @DisplayName("groupBy(List) should work correctly")
         void testGroupByWithList() {
             List<String> groupCols = Arrays.asList("col1", "col2", "col3");
-            
+
             AggregateInfo info = AggregateInfo.builder()
                     .addCountStar("cnt")
                     .groupBy(groupCols)
                     .build();
-            
+
             assertEquals(groupCols, info.getGroupByColumns());
         }
 
@@ -231,19 +231,19 @@ class AggregateInfoTest {
         @DisplayName("groupByFieldIndices should be correctly set")
         void testGroupByFieldIndices() {
             int[] indices = {0, 2, 4};
-            
+
             AggregateInfo info = AggregateInfo.builder()
                     .addCountStar("cnt")
                     .groupBy("col1", "col3", "col5")
                     .groupByFieldIndices(indices)
                     .build();
-            
+
             assertArrayEquals(indices, info.getGroupByFieldIndices());
         }
     }
 
     // ==================== AggregateInfo Methods Tests ====================
-    
+
     @Nested
     @DisplayName("AggregateInfo Methods Tests")
     class AggregateInfoMethodTests {
@@ -256,9 +256,9 @@ class AggregateInfoTest {
                     .addAvg("score", "avg_score")
                     .groupBy("category", "region")
                     .build();
-            
+
             List<String> required = info.getRequiredColumns();
-            
+
             // Should contain group columns and aggregate columns
             assertTrue(required.contains("category"));
             assertTrue(required.contains("region"));
@@ -274,9 +274,9 @@ class AggregateInfoTest {
                     .addAvg("amount", "avg_amount")  // Same column
                     .groupBy("category")
                     .build();
-            
+
             List<String> required = info.getRequiredColumns();
-            
+
             // amount should appear only once
             long amountCount = required.stream().filter(c -> c.equals("amount")).count();
             assertEquals(1, amountCount);
@@ -288,7 +288,7 @@ class AggregateInfoTest {
             AggregateInfo info = AggregateInfo.builder()
                     .addCountStar("cnt")
                     .build();
-            
+
             List<String> required = info.getRequiredColumns();
             assertTrue(required.isEmpty());
         }
@@ -300,17 +300,17 @@ class AggregateInfoTest {
                     .addSum("amount", "total")
                     .groupBy("category")
                     .build();
-            
+
             AggregateInfo info2 = AggregateInfo.builder()
                     .addSum("amount", "total")
                     .groupBy("category")
                     .build();
-            
+
             AggregateInfo info3 = AggregateInfo.builder()
                     .addAvg("amount", "avg")
                     .groupBy("category")
                     .build();
-            
+
             assertEquals(info1, info2);
             assertEquals(info1.hashCode(), info2.hashCode());
             assertNotEquals(info1, info3);
@@ -323,9 +323,9 @@ class AggregateInfoTest {
                     .addSum("amount", "total")
                     .groupBy("category")
                     .build();
-            
+
             String str = info.toString();
-            
+
             assertTrue(str.contains("AggregateInfo"));
             assertTrue(str.contains("SUM(amount)"));
             assertTrue(str.contains("groupBy"));
@@ -334,7 +334,7 @@ class AggregateInfoTest {
     }
 
     // ==================== Aggregate Function Enum Tests ====================
-    
+
     @Nested
     @DisplayName("AggregateFunction Enum Tests")
     class AggregateFunctionEnumTests {
@@ -343,7 +343,7 @@ class AggregateInfoTest {
         @DisplayName("Should contain all supported aggregate functions")
         void testAllAggregateFunctions() {
             AggregateInfo.AggregateFunction[] functions = AggregateInfo.AggregateFunction.values();
-            
+
             assertEquals(6, functions.length);
             assertTrue(Arrays.asList(functions).contains(AggregateInfo.AggregateFunction.COUNT));
             assertTrue(Arrays.asList(functions).contains(AggregateInfo.AggregateFunction.COUNT_DISTINCT));

--- a/src/test/java/org/apache/flink/connector/lance/catalog/LanceCatalogPathResolverTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/catalog/LanceCatalogPathResolverTest.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.catalog;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link LanceCatalogPathResolver}. */
+class LanceCatalogPathResolverTest {
+
+  // ==================== Path Normalization ====================
+
+  @Nested
+  @DisplayName("Path Normalization")
+  class NormalizationTests {
+
+    @Test
+    @DisplayName("Remove trailing slashes")
+    void testNormalize() {
+      assertThat(LanceCatalogPathResolver.normalize("/data/warehouse/"))
+          .isEqualTo("/data/warehouse");
+    }
+
+    @Test
+    @DisplayName("Remove multiple trailing slashes")
+    void testNormalizeMultipleSlashes() {
+      assertThat(LanceCatalogPathResolver.normalize("/data///")).isEqualTo("/data");
+    }
+
+    @Test
+    @DisplayName("Null input returns null")
+    void testNormalizeNull() {
+      assertThat(LanceCatalogPathResolver.normalize(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("Root path preserved")
+    void testNormalizeRootPath() {
+      assertThat(LanceCatalogPathResolver.normalize("/")).isEqualTo("/");
+    }
+
+    @Test
+    @DisplayName("S3 path normalized correctly")
+    void testNormalizeS3Path() {
+      assertThat(LanceCatalogPathResolver.normalize("s3://bucket/path/"))
+          .isEqualTo("s3://bucket/path");
+    }
+  }
+
+  // ==================== Remote Detection ====================
+
+  @Nested
+  @DisplayName("Remote Detection")
+  class RemoteDetectionTests {
+
+    @Test
+    @DisplayName("S3 path is remote")
+    void testS3() {
+      assertThat(LanceCatalogPathResolver.detectRemote("s3://bucket/path")).isTrue();
+    }
+
+    @Test
+    @DisplayName("S3A path is remote")
+    void testS3A() {
+      assertThat(LanceCatalogPathResolver.detectRemote("s3a://bucket/path")).isTrue();
+    }
+
+    @Test
+    @DisplayName("GCS path is remote")
+    void testGcs() {
+      assertThat(LanceCatalogPathResolver.detectRemote("gs://bucket/path")).isTrue();
+    }
+
+    @Test
+    @DisplayName("Azure path is remote")
+    void testAzure() {
+      assertThat(LanceCatalogPathResolver.detectRemote("az://container/path")).isTrue();
+    }
+
+    @Test
+    @DisplayName("HTTPS path is remote")
+    void testHttps() {
+      assertThat(LanceCatalogPathResolver.detectRemote("https://example.com/path")).isTrue();
+    }
+
+    @Test
+    @DisplayName("HTTP path is remote")
+    void testHttp() {
+      assertThat(LanceCatalogPathResolver.detectRemote("http://example.com/path")).isTrue();
+    }
+
+    @Test
+    @DisplayName("Local path is not remote")
+    void testLocalPath() {
+      assertThat(LanceCatalogPathResolver.detectRemote("/tmp/local/path")).isFalse();
+    }
+
+    @Test
+    @DisplayName("Null path is not remote")
+    void testNullPath() {
+      assertThat(LanceCatalogPathResolver.detectRemote(null)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Case insensitive detection")
+    void testCaseInsensitive() {
+      assertThat(LanceCatalogPathResolver.detectRemote("S3://Bucket/Path")).isTrue();
+    }
+  }
+
+  // ==================== Path Resolution ====================
+
+  @Nested
+  @DisplayName("Path Resolution")
+  class PathResolutionTests {
+
+    @Test
+    @DisplayName("Resolve database path for local warehouse")
+    void testResolveDatabasePathLocal() {
+      LanceCatalogPathResolver resolver = new LanceCatalogPathResolver("/data/warehouse");
+      assertThat(resolver.resolveDatabasePath("mydb")).isEqualTo("/data/warehouse/mydb");
+    }
+
+    @Test
+    @DisplayName("Resolve table path for local warehouse")
+    void testResolveTablePathLocal() {
+      LanceCatalogPathResolver resolver = new LanceCatalogPathResolver("/data/warehouse");
+      assertThat(resolver.resolveTablePath("mydb", "mytable"))
+          .isEqualTo("/data/warehouse/mydb/mytable");
+    }
+
+    @Test
+    @DisplayName("Resolve database path for S3 warehouse")
+    void testResolveDatabasePathS3() {
+      LanceCatalogPathResolver resolver = new LanceCatalogPathResolver("s3://bucket/warehouse");
+      assertThat(resolver.resolveDatabasePath("mydb")).isEqualTo("s3://bucket/warehouse/mydb");
+    }
+
+    @Test
+    @DisplayName("Resolve table path for S3 warehouse")
+    void testResolveTablePathS3() {
+      LanceCatalogPathResolver resolver = new LanceCatalogPathResolver("s3://bucket/warehouse");
+      assertThat(resolver.resolveTablePath("mydb", "mytable"))
+          .isEqualTo("s3://bucket/warehouse/mydb/mytable");
+    }
+
+    @Test
+    @DisplayName("Trailing slashes removed before resolving")
+    void testTrailingSlashHandling() {
+      LanceCatalogPathResolver resolver = new LanceCatalogPathResolver("/data/warehouse///");
+      assertThat(resolver.getWarehouse()).isEqualTo("/data/warehouse");
+      assertThat(resolver.resolveDatabasePath("db")).isEqualTo("/data/warehouse/db");
+    }
+  }
+
+  // ==================== isRemote Property ====================
+
+  @Nested
+  @DisplayName("isRemote property")
+  class IsRemoteTests {
+
+    @Test
+    @DisplayName("Local path is not remote")
+    void testLocalIsNotRemote() {
+      LanceCatalogPathResolver resolver = new LanceCatalogPathResolver("/tmp/warehouse");
+      assertThat(resolver.isRemote()).isFalse();
+    }
+
+    @Test
+    @DisplayName("S3 path is remote")
+    void testS3IsRemote() {
+      LanceCatalogPathResolver resolver = new LanceCatalogPathResolver("s3://bucket/warehouse");
+      assertThat(resolver.isRemote()).isTrue();
+    }
+  }
+}

--- a/src/test/java/org/apache/flink/connector/lance/catalog/LocalStorageProviderTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/catalog/LocalStorageProviderTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.catalog;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link LocalStorageProvider}. */
+class LocalStorageProviderTest {
+
+  @TempDir Path tempDir;
+
+  private LanceCatalogPathResolver pathResolver;
+  private LocalStorageProvider provider;
+
+  @BeforeEach
+  void setup() {
+    String warehouse = tempDir.resolve("warehouse").toString();
+    pathResolver = new LanceCatalogPathResolver(warehouse);
+    provider = new LocalStorageProvider(pathResolver);
+  }
+
+  @Nested
+  @DisplayName("initializeWarehouse")
+  class InitializeTests {
+
+    @Test
+    @DisplayName("Creates warehouse and default database directories")
+    void testInitialize() throws IOException {
+      provider.initializeWarehouse("default");
+
+      Path warehousePath = Paths.get(pathResolver.getWarehouse());
+      assertThat(warehousePath).exists().isDirectory();
+      assertThat(warehousePath.resolve("default")).exists().isDirectory();
+    }
+
+    @Test
+    @DisplayName("Idempotent: calling twice does not fail")
+    void testInitializeIdempotent() throws IOException {
+      provider.initializeWarehouse("default");
+      provider.initializeWarehouse("default");
+
+      assertThat(Paths.get(pathResolver.getWarehouse(), "default")).exists();
+    }
+  }
+
+  @Nested
+  @DisplayName("Database Operations")
+  class DatabaseTests {
+
+    @BeforeEach
+    void init() throws IOException {
+      provider.initializeWarehouse("default");
+    }
+
+    @Test
+    @DisplayName("listDatabases returns existing databases")
+    void testListDatabases() throws IOException {
+      provider.createDatabase("db1");
+      provider.createDatabase("db2");
+
+      List<String> databases = provider.listDatabases();
+      assertThat(databases).contains("default", "db1", "db2");
+    }
+
+    @Test
+    @DisplayName("databaseExists returns true for existing database")
+    void testDatabaseExists() throws IOException {
+      provider.createDatabase("testdb");
+      assertThat(provider.databaseExists("testdb")).isTrue();
+    }
+
+    @Test
+    @DisplayName("databaseExists returns false for non-existing database")
+    void testDatabaseNotExists() {
+      assertThat(provider.databaseExists("nonexistent")).isFalse();
+    }
+
+    @Test
+    @DisplayName("dropDatabase removes database directory")
+    void testDropDatabase() throws IOException {
+      provider.createDatabase("toDrop");
+      assertThat(provider.databaseExists("toDrop")).isTrue();
+
+      provider.dropDatabase("toDrop", false);
+      assertThat(provider.databaseExists("toDrop")).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("Table Operations")
+  class TableTests {
+
+    @BeforeEach
+    void init() throws IOException {
+      provider.initializeWarehouse("default");
+    }
+
+    @Test
+    @DisplayName("tableExists returns false for non-existing table")
+    void testTableNotExists() {
+      assertThat(provider.tableExists("default", "nonexistent")).isFalse();
+    }
+
+    @Test
+    @DisplayName("tableExists returns true for a valid Lance dataset directory")
+    void testTableExists() throws IOException {
+      // Create a fake Lance dataset directory
+      Path tablePath = Paths.get(pathResolver.resolveTablePath("default", "mytable"));
+      Files.createDirectories(tablePath.resolve("_versions"));
+
+      assertThat(provider.tableExists("default", "mytable")).isTrue();
+    }
+
+    @Test
+    @DisplayName("listTables returns valid datasets")
+    void testListTables() throws IOException {
+      // Create valid dataset
+      Path table1 = Paths.get(pathResolver.resolveTablePath("default", "t1"));
+      Files.createDirectories(table1.resolve("_versions"));
+
+      // Create non-dataset directory (no _versions)
+      Path notATable = Paths.get(pathResolver.resolveTablePath("default", "notatable"));
+      Files.createDirectories(notATable);
+
+      List<String> tables = provider.listTables("default");
+      assertThat(tables).containsExactly("t1");
+    }
+
+    @Test
+    @DisplayName("dropTable removes table directory")
+    void testDropTable() throws IOException {
+      Path tablePath = Paths.get(pathResolver.resolveTablePath("default", "toDelete"));
+      Files.createDirectories(tablePath.resolve("_versions"));
+
+      assertThat(provider.tableExists("default", "toDelete")).isTrue();
+      provider.dropTable("default", "toDelete");
+      assertThat(provider.tableExists("default", "toDelete")).isFalse();
+    }
+
+    @Test
+    @DisplayName("renameTable moves table directory")
+    void testRenameTable() throws IOException {
+      Path oldPath = Paths.get(pathResolver.resolveTablePath("default", "oldName"));
+      Files.createDirectories(oldPath.resolve("_versions"));
+
+      provider.renameTable("default", "oldName", "newName");
+
+      assertThat(provider.tableExists("default", "oldName")).isFalse();
+      assertThat(provider.tableExists("default", "newName")).isTrue();
+    }
+  }
+
+  @Nested
+  @DisplayName("No-op Methods")
+  class NoOpTests {
+
+    @Test
+    @DisplayName("registerTable is a no-op for local storage")
+    void testRegisterTable() {
+      provider.registerTable("default", "table");
+      // No exception, no side effects
+    }
+
+    @Test
+    @DisplayName("configureEnvironment is a no-op for local storage")
+    void testConfigureEnvironment() {
+      provider.configureEnvironment();
+      // No exception
+    }
+  }
+}

--- a/src/test/java/org/apache/flink/connector/lance/catalog/RemoteStorageProviderTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/catalog/RemoteStorageProviderTest.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.catalog;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for {@link RemoteStorageProvider}. */
+class RemoteStorageProviderTest {
+
+  private LanceCatalogPathResolver pathResolver;
+  private RemoteStorageProvider provider;
+
+  @BeforeEach
+  void setup() {
+    pathResolver = new LanceCatalogPathResolver("s3://test-bucket/warehouse");
+    Map<String, String> opts = new HashMap<>();
+    opts.put("aws_access_key_id", "AKID_TEST");
+    opts.put("aws_secret_access_key", "SECRET_TEST");
+    provider = new RemoteStorageProvider(pathResolver, opts);
+  }
+
+  @Nested
+  @DisplayName("initializeWarehouse")
+  class InitializeTests {
+
+    @Test
+    @DisplayName("Registers default database")
+    void testInitialize() {
+      provider.initializeWarehouse("default");
+      assertThat(provider.getKnownDatabases()).contains("default");
+    }
+  }
+
+  @Nested
+  @DisplayName("Database Operations")
+  class DatabaseTests {
+
+    @BeforeEach
+    void init() {
+      provider.initializeWarehouse("default");
+    }
+
+    @Test
+    @DisplayName("listDatabases returns registered databases")
+    void testListDatabases() throws IOException {
+      provider.createDatabase("db1");
+      provider.createDatabase("db2");
+
+      List<String> databases = provider.listDatabases();
+      assertThat(databases).contains("default", "db1", "db2");
+    }
+
+    @Test
+    @DisplayName("databaseExists returns true for any database (remote assumption)")
+    void testDatabaseExists() {
+      // Remote storage always returns true for databaseExists
+      assertThat(provider.databaseExists("anything")).isTrue();
+    }
+
+    @Test
+    @DisplayName("createDatabase registers new database")
+    void testCreateDatabase() throws IOException {
+      provider.createDatabase("newdb");
+      assertThat(provider.getKnownDatabases()).contains("newdb");
+    }
+
+    @Test
+    @DisplayName("dropDatabase removes database and its tables when cascade")
+    void testDropDatabaseCascade() throws IOException {
+      provider.createDatabase("dropme");
+      provider.registerTable("dropme", "t1");
+      provider.registerTable("dropme", "t2");
+
+      provider.dropDatabase("dropme", true);
+
+      assertThat(provider.getKnownDatabases()).doesNotContain("dropme");
+      assertThat(provider.getKnownTables()).doesNotContain("dropme/t1", "dropme/t2");
+    }
+
+    @Test
+    @DisplayName("dropDatabase without cascade keeps tables untouched")
+    void testDropDatabaseNoCascade() throws IOException {
+      provider.createDatabase("dropme");
+      provider.registerTable("dropme", "t1");
+
+      provider.dropDatabase("dropme", false);
+
+      assertThat(provider.getKnownDatabases()).doesNotContain("dropme");
+      // Tables are still in the set (orphaned records)
+      assertThat(provider.getKnownTables()).contains("dropme/t1");
+    }
+  }
+
+  @Nested
+  @DisplayName("Table Operations")
+  class TableTests {
+
+    @BeforeEach
+    void init() {
+      provider.initializeWarehouse("default");
+    }
+
+    @Test
+    @DisplayName("registerTable and listTables")
+    void testRegisterAndListTables() throws IOException {
+      provider.registerTable("default", "t1");
+      provider.registerTable("default", "t2");
+
+      List<String> tables = provider.listTables("default");
+      assertThat(tables).containsExactlyInAnyOrder("t1", "t2");
+    }
+
+    @Test
+    @DisplayName("tableExists returns true for registered table")
+    void testTableExistsRegistered() {
+      provider.registerTable("default", "known");
+      assertThat(provider.tableExists("default", "known")).isTrue();
+    }
+
+    @Test
+    @DisplayName("tableExists returns false for unregistered table (no real dataset)")
+    void testTableExistsUnregistered() {
+      // Without a real S3 dataset, probing will fail → returns false
+      assertThat(provider.tableExists("default", "unknown")).isFalse();
+    }
+
+    @Test
+    @DisplayName("dropTable removes table record")
+    void testDropTable() {
+      provider.registerTable("default", "toDrop");
+      assertThat(provider.getKnownTables()).contains("default/toDrop");
+
+      provider.dropTable("default", "toDrop");
+      assertThat(provider.getKnownTables()).doesNotContain("default/toDrop");
+    }
+
+    @Test
+    @DisplayName("renameTable throws UnsupportedOperationException")
+    void testRenameTableUnsupported() {
+      assertThatThrownBy(() -> provider.renameTable("default", "old", "new"))
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessageContaining("does not support renaming");
+    }
+
+    @Test
+    @DisplayName("listTables only returns tables for the given database")
+    void testListTablesScoped() throws IOException {
+      provider.registerTable("default", "t1");
+      provider.registerTable("other", "t2");
+
+      assertThat(provider.listTables("default")).containsExactly("t1");
+      assertThat(provider.listTables("other")).containsExactly("t2");
+    }
+  }
+
+  @Nested
+  @DisplayName("Environment Configuration")
+  class EnvironmentTests {
+
+    @Test
+    @DisplayName("configureEnvironment sets system properties")
+    void testConfigureEnvironment() {
+      provider.configureEnvironment();
+
+      assertThat(System.getProperty("AWS_ACCESS_KEY_ID")).isEqualTo("AKID_TEST");
+      assertThat(System.getProperty("AWS_SECRET_ACCESS_KEY")).isEqualTo("SECRET_TEST");
+
+      // Cleanup
+      System.clearProperty("AWS_ACCESS_KEY_ID");
+      System.clearProperty("AWS_SECRET_ACCESS_KEY");
+    }
+  }
+
+  @Nested
+  @DisplayName("getStorageOptions")
+  class StorageOptionsTests {
+
+    @Test
+    @DisplayName("Returns the provided storage options")
+    void testGetStorageOptions() {
+      assertThat(provider.getStorageOptions()).containsEntry("aws_access_key_id", "AKID_TEST");
+    }
+  }
+
+  @Nested
+  @DisplayName("clear")
+  class ClearTests {
+
+    @Test
+    @DisplayName("Clear removes all registries")
+    void testClear() {
+      provider.initializeWarehouse("default");
+      provider.registerTable("default", "t1");
+
+      provider.clear();
+
+      assertThat(provider.getKnownDatabases()).isEmpty();
+      assertThat(provider.getKnownTables()).isEmpty();
+    }
+  }
+}

--- a/src/test/java/org/apache/flink/connector/lance/catalog/StorageEnvironmentManagerTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/catalog/StorageEnvironmentManagerTest.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.catalog;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link StorageEnvironmentManager}. */
+class StorageEnvironmentManagerTest {
+
+  @Nested
+  @DisplayName("configure")
+  class ConfigureTests {
+
+    @Test
+    @DisplayName("Setting S3 credentials sets system properties")
+    void testConfigureSetsSystemProperties() {
+      Map<String, String> opts = new HashMap<>();
+      opts.put("aws_access_key_id", "AKID_TEST");
+      opts.put("aws_secret_access_key", "SECRET_TEST");
+      opts.put("aws_region", "us-west-2");
+      opts.put("aws_endpoint", "http://localhost:9000");
+      opts.put("aws_virtual_hosted_style_request", "false");
+      opts.put("allow_http", "true");
+
+      StorageEnvironmentManager.configure(opts);
+
+      assertThat(System.getProperty("AWS_ACCESS_KEY_ID")).isEqualTo("AKID_TEST");
+      assertThat(System.getProperty("AWS_SECRET_ACCESS_KEY")).isEqualTo("SECRET_TEST");
+      assertThat(System.getProperty("AWS_DEFAULT_REGION")).isEqualTo("us-west-2");
+      assertThat(System.getProperty("AWS_ENDPOINT")).isEqualTo("http://localhost:9000");
+      assertThat(System.getProperty("AWS_VIRTUAL_HOSTED_STYLE_REQUEST")).isEqualTo("false");
+      assertThat(System.getProperty("AWS_ALLOW_HTTP")).isEqualTo("true");
+
+      // Cleanup
+      System.clearProperty("AWS_ACCESS_KEY_ID");
+      System.clearProperty("AWS_SECRET_ACCESS_KEY");
+      System.clearProperty("AWS_DEFAULT_REGION");
+      System.clearProperty("AWS_ENDPOINT");
+      System.clearProperty("AWS_VIRTUAL_HOSTED_STYLE_REQUEST");
+      System.clearProperty("AWS_ALLOW_HTTP");
+    }
+
+    @Test
+    @DisplayName("Null options map is a no-op")
+    void testConfigureNullOptions() {
+      StorageEnvironmentManager.configure(null);
+      // Should not throw
+    }
+
+    @Test
+    @DisplayName("Empty options map is a no-op")
+    void testConfigureEmptyOptions() {
+      StorageEnvironmentManager.configure(Collections.emptyMap());
+      // Should not throw
+    }
+
+    @Test
+    @DisplayName("Unknown keys are ignored")
+    void testConfigureUnknownKeys() {
+      Map<String, String> opts = new HashMap<>();
+      opts.put("unknown_key", "value");
+
+      StorageEnvironmentManager.configure(opts);
+      // Should not set any system property for unknown keys
+      assertThat(System.getProperty("unknown_key")).isNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("toTableOptions")
+  class ToTableOptionsTests {
+
+    @Test
+    @DisplayName("Convert storage options to table options")
+    void testToTableOptions() {
+      Map<String, String> storageOpts = new HashMap<>();
+      storageOpts.put("aws_access_key_id", "AKID");
+      storageOpts.put("aws_secret_access_key", "SECRET");
+      storageOpts.put("aws_region", "us-east-1");
+      storageOpts.put("aws_endpoint", "http://s3.example.com");
+
+      Map<String, String> tableOpts = StorageEnvironmentManager.toTableOptions(storageOpts);
+
+      assertThat(tableOpts).hasSize(4);
+      assertThat(tableOpts.get("s3-access-key")).isEqualTo("AKID");
+      assertThat(tableOpts.get("s3-secret-key")).isEqualTo("SECRET");
+      assertThat(tableOpts.get("s3-region")).isEqualTo("us-east-1");
+      assertThat(tableOpts.get("s3-endpoint")).isEqualTo("http://s3.example.com");
+    }
+
+    @Test
+    @DisplayName("Null options returns empty map")
+    void testToTableOptionsNull() {
+      assertThat(StorageEnvironmentManager.toTableOptions(null)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Empty options returns empty map")
+    void testToTableOptionsEmpty() {
+      assertThat(StorageEnvironmentManager.toTableOptions(Collections.emptyMap())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Partial options only map known keys")
+    void testToTableOptionsPartial() {
+      Map<String, String> storageOpts = new HashMap<>();
+      storageOpts.put("aws_access_key_id", "AKID");
+      // Only access key, no secret, region, endpoint
+
+      Map<String, String> tableOpts = StorageEnvironmentManager.toTableOptions(storageOpts);
+
+      assertThat(tableOpts).hasSize(1);
+      assertThat(tableOpts.get("s3-access-key")).isEqualTo("AKID");
+    }
+  }
+}

--- a/src/test/java/org/apache/flink/connector/lance/config/LanceDatasetFactoryTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/config/LanceDatasetFactoryTest.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.config;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for {@link LanceDatasetFactory}. */
+class LanceDatasetFactoryTest {
+
+  @TempDir Path tempDir;
+
+  // ==================== Path Validation Tests ====================
+
+  @Nested
+  @DisplayName("Path Validation")
+  class PathValidationTests {
+
+    @Test
+    @DisplayName("validatePath rejects null path")
+    void testNullPath() {
+      assertThatThrownBy(() -> LanceDatasetFactory.validatePath(null))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("must not be null or empty");
+    }
+
+    @Test
+    @DisplayName("validatePath rejects empty path")
+    void testEmptyPath() {
+      assertThatThrownBy(() -> LanceDatasetFactory.validatePath(""))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("must not be null or empty");
+    }
+
+    @Test
+    @DisplayName("validatePath accepts valid path")
+    void testValidPath() {
+      // Should not throw
+      LanceDatasetFactory.validatePath("/some/path");
+    }
+  }
+
+  // ==================== Allocator Tests ====================
+
+  @Nested
+  @DisplayName("Allocator Management")
+  class AllocatorTests {
+
+    @Test
+    @DisplayName("createAllocator returns a usable allocator")
+    void testCreateAllocator() {
+      BufferAllocator allocator = LanceDatasetFactory.createAllocator();
+      assertThat(allocator).isNotNull();
+      allocator.close();
+    }
+
+    @Test
+    @DisplayName("closeQuietly handles null allocator")
+    void testCloseQuietlyNullAllocator() {
+      // Should not throw
+      LanceDatasetFactory.closeQuietly((BufferAllocator) null);
+    }
+  }
+
+  // ==================== Dataset Open Tests ====================
+
+  @Nested
+  @DisplayName("Dataset Open")
+  class DatasetOpenTests {
+
+    @Test
+    @DisplayName("open with null path throws IllegalArgumentException")
+    void testOpenNullPath() {
+      BufferAllocator allocator = LanceDatasetFactory.createAllocator();
+      try {
+        assertThatThrownBy(() -> LanceDatasetFactory.open(null, allocator))
+            .isInstanceOf(IllegalArgumentException.class);
+      } finally {
+        allocator.close();
+      }
+    }
+
+    @Test
+    @DisplayName("open with empty path throws IllegalArgumentException")
+    void testOpenEmptyPath() {
+      BufferAllocator allocator = LanceDatasetFactory.createAllocator();
+      try {
+        assertThatThrownBy(() -> LanceDatasetFactory.open("", allocator))
+            .isInstanceOf(IllegalArgumentException.class);
+      } finally {
+        allocator.close();
+      }
+    }
+
+    @Test
+    @DisplayName("open non-existent dataset throws IOException")
+    void testOpenNonExistentDataset() {
+      BufferAllocator allocator = LanceDatasetFactory.createAllocator();
+      String fakePath = tempDir.resolve("non_existent_dataset").toString();
+      try {
+        assertThatThrownBy(() -> LanceDatasetFactory.open(fakePath, allocator))
+            .isInstanceOf(IOException.class)
+            .hasMessageContaining("Failed to open Lance dataset");
+      } finally {
+        allocator.close();
+      }
+    }
+
+    @Test
+    @DisplayName("openManaged with null path throws IllegalArgumentException")
+    void testOpenManagedNullPath() {
+      assertThatThrownBy(() -> LanceDatasetFactory.openManaged(null))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("openManaged with empty path throws IllegalArgumentException")
+    void testOpenManagedEmptyPath() {
+      assertThatThrownBy(() -> LanceDatasetFactory.openManaged(""))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("openManaged non-existent dataset throws IOException and cleans up")
+    void testOpenManagedNonExistentDataset() {
+      String fakePath = tempDir.resolve("non_existent_dataset").toString();
+      assertThatThrownBy(() -> LanceDatasetFactory.openManaged(fakePath))
+          .isInstanceOf(IOException.class)
+          .hasMessageContaining("Failed to open Lance dataset");
+      // Allocator should be cleaned up (no leak)
+    }
+  }
+
+  // ==================== closeQuietly Tests ====================
+
+  @Nested
+  @DisplayName("closeQuietly")
+  class CloseQuietlyTests {
+
+    @Test
+    @DisplayName("closeQuietly handles null dataset without exception")
+    void testCloseQuietlyNullDataset() {
+      LanceDatasetFactory.closeQuietly((com.lancedb.lance.Dataset) null);
+      // Should not throw
+    }
+  }
+}

--- a/src/test/java/org/apache/flink/connector/lance/config/LanceOptionsRefactorTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/config/LanceOptionsRefactorTest.java
@@ -1,0 +1,545 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit tests for split LanceOptions: LanceSourceOptions, LanceSinkOptions, etc. */
+class LanceOptionsRefactorTest {
+
+  // ==================== LanceSourceOptions Tests ====================
+
+  @Nested
+  @DisplayName("LanceSourceOptions")
+  class SourceOptionsTests {
+
+    @Test
+    @DisplayName("Build with all fields")
+    void testBuildAllFields() {
+      LanceSourceOptions opts =
+          LanceSourceOptions.builder()
+              .path("/data/my_dataset")
+              .batchSize(512)
+              .limit(100L)
+              .columns(Arrays.asList("id", "name"))
+              .filter("id > 10")
+              .build();
+
+      assertThat(opts.getPath()).isEqualTo("/data/my_dataset");
+      assertThat(opts.getBatchSize()).isEqualTo(512);
+      assertThat(opts.getLimit()).isEqualTo(100L);
+      assertThat(opts.getColumns()).containsExactly("id", "name");
+      assertThat(opts.getFilter()).isEqualTo("id > 10");
+    }
+
+    @Test
+    @DisplayName("Default values are correct")
+    void testDefaults() {
+      LanceSourceOptions opts = LanceSourceOptions.builder().path("/data").build();
+
+      assertThat(opts.getBatchSize()).isEqualTo(1024);
+      assertThat(opts.getLimit()).isNull();
+      assertThat(opts.getColumns()).isEmpty();
+      assertThat(opts.getFilter()).isNull();
+    }
+
+    @Test
+    @DisplayName("Columns list is unmodifiable")
+    void testColumnsImmutable() {
+      LanceSourceOptions opts =
+          LanceSourceOptions.builder().path("/data").columns(Arrays.asList("a", "b")).build();
+
+      assertThatThrownBy(() -> opts.getColumns().add("c"))
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @DisplayName("toBuilder creates a modified copy")
+    void testToBuilder() {
+      LanceSourceOptions original =
+          LanceSourceOptions.builder().path("/data").batchSize(256).filter("id > 5").build();
+
+      LanceSourceOptions modified = original.toBuilder().limit(50L).build();
+
+      // Original is unchanged
+      assertThat(original.getLimit()).isNull();
+      // Modified has new limit but retains other fields
+      assertThat(modified.getLimit()).isEqualTo(50L);
+      assertThat(modified.getPath()).isEqualTo("/data");
+      assertThat(modified.getBatchSize()).isEqualTo(256);
+      assertThat(modified.getFilter()).isEqualTo("id > 5");
+    }
+
+    @Test
+    @DisplayName("Validation rejects invalid batch size")
+    void testInvalidBatchSize() {
+      assertThatThrownBy(() -> LanceSourceOptions.builder().path("/data").batchSize(0).build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("batch-size");
+    }
+
+    @Test
+    @DisplayName("Validation rejects negative limit")
+    void testNegativeLimit() {
+      assertThatThrownBy(() -> LanceSourceOptions.builder().path("/data").limit(-1L).build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("limit");
+    }
+
+    @Test
+    @DisplayName("Null columns defaults to empty list")
+    void testNullColumns() {
+      LanceSourceOptions opts = LanceSourceOptions.builder().path("/data").columns(null).build();
+      assertThat(opts.getColumns()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("equals and hashCode")
+    void testEqualsHashCode() {
+      LanceSourceOptions a =
+          LanceSourceOptions.builder()
+              .path("/data")
+              .batchSize(512)
+              .limit(10L)
+              .columns(Arrays.asList("x"))
+              .filter("x > 1")
+              .build();
+      LanceSourceOptions b =
+          LanceSourceOptions.builder()
+              .path("/data")
+              .batchSize(512)
+              .limit(10L)
+              .columns(Arrays.asList("x"))
+              .filter("x > 1")
+              .build();
+      LanceSourceOptions c = LanceSourceOptions.builder().path("/other").build();
+
+      assertThat(a).isEqualTo(b);
+      assertThat(a.hashCode()).isEqualTo(b.hashCode());
+      assertThat(a).isNotEqualTo(c);
+    }
+
+    @Test
+    @DisplayName("toString contains key fields")
+    void testToString() {
+      LanceSourceOptions opts = LanceSourceOptions.builder().path("/data").batchSize(256).build();
+      assertThat(opts.toString()).contains("/data").contains("256");
+    }
+  }
+
+  // ==================== LanceSinkOptions Tests ====================
+
+  @Nested
+  @DisplayName("LanceSinkOptions")
+  class SinkOptionsTests {
+
+    @Test
+    @DisplayName("Build with all fields")
+    void testBuildAllFields() {
+      LanceSinkOptions opts =
+          LanceSinkOptions.builder()
+              .path("/data/sink")
+              .batchSize(512)
+              .writeMode(LanceOptions.WriteMode.OVERWRITE)
+              .maxRowsPerFile(500000)
+              .build();
+
+      assertThat(opts.getPath()).isEqualTo("/data/sink");
+      assertThat(opts.getBatchSize()).isEqualTo(512);
+      assertThat(opts.getWriteMode()).isEqualTo(LanceOptions.WriteMode.OVERWRITE);
+      assertThat(opts.getMaxRowsPerFile()).isEqualTo(500000);
+    }
+
+    @Test
+    @DisplayName("Default values are correct")
+    void testDefaults() {
+      LanceSinkOptions opts = LanceSinkOptions.builder().path("/data").build();
+
+      assertThat(opts.getBatchSize()).isEqualTo(1024);
+      assertThat(opts.getWriteMode()).isEqualTo(LanceOptions.WriteMode.APPEND);
+      assertThat(opts.getMaxRowsPerFile()).isEqualTo(1000000);
+    }
+
+    @Test
+    @DisplayName("Validation rejects invalid batch size")
+    void testInvalidBatchSize() {
+      assertThatThrownBy(() -> LanceSinkOptions.builder().path("/data").batchSize(-1).build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("batch-size");
+    }
+
+    @Test
+    @DisplayName("Validation rejects invalid max rows per file")
+    void testInvalidMaxRows() {
+      assertThatThrownBy(() -> LanceSinkOptions.builder().path("/data").maxRowsPerFile(0).build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("max-rows-per-file");
+    }
+
+    @Test
+    @DisplayName("toBuilder creates a modified copy")
+    void testToBuilder() {
+      LanceSinkOptions original =
+          LanceSinkOptions.builder()
+              .path("/data")
+              .batchSize(256)
+              .writeMode(LanceOptions.WriteMode.APPEND)
+              .build();
+
+      LanceSinkOptions modified =
+          original.toBuilder().writeMode(LanceOptions.WriteMode.OVERWRITE).build();
+
+      assertThat(original.getWriteMode()).isEqualTo(LanceOptions.WriteMode.APPEND);
+      assertThat(modified.getWriteMode()).isEqualTo(LanceOptions.WriteMode.OVERWRITE);
+      assertThat(modified.getPath()).isEqualTo("/data");
+      assertThat(modified.getBatchSize()).isEqualTo(256);
+    }
+
+    @Test
+    @DisplayName("equals and hashCode")
+    void testEqualsHashCode() {
+      LanceSinkOptions a =
+          LanceSinkOptions.builder()
+              .path("/data")
+              .batchSize(512)
+              .writeMode(LanceOptions.WriteMode.OVERWRITE)
+              .maxRowsPerFile(100)
+              .build();
+      LanceSinkOptions b =
+          LanceSinkOptions.builder()
+              .path("/data")
+              .batchSize(512)
+              .writeMode(LanceOptions.WriteMode.OVERWRITE)
+              .maxRowsPerFile(100)
+              .build();
+
+      assertThat(a).isEqualTo(b);
+      assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+  }
+
+  // ==================== LanceIndexOptions Tests ====================
+
+  @Nested
+  @DisplayName("LanceIndexOptions")
+  class IndexOptionsTests {
+
+    @Test
+    @DisplayName("Build with all fields")
+    void testBuildAllFields() {
+      LanceIndexOptions opts =
+          LanceIndexOptions.builder()
+              .columnName("embedding")
+              .indexType(LanceOptions.IndexType.IVF_HNSW)
+              .metricType(LanceOptions.MetricType.COSINE)
+              .numPartitions(128)
+              .numSubVectors(32)
+              .numBits(4)
+              .maxLevel(5)
+              .maxEdges(32)
+              .efConstruction(200)
+              .build();
+
+      assertThat(opts.getColumnName()).isEqualTo("embedding");
+      assertThat(opts.getIndexType()).isEqualTo(LanceOptions.IndexType.IVF_HNSW);
+      assertThat(opts.getMetricType()).isEqualTo(LanceOptions.MetricType.COSINE);
+      assertThat(opts.getNumPartitions()).isEqualTo(128);
+      assertThat(opts.getNumSubVectors()).isEqualTo(32);
+      assertThat(opts.getNumBits()).isEqualTo(4);
+      assertThat(opts.getMaxLevel()).isEqualTo(5);
+      assertThat(opts.getM()).isEqualTo(32);
+      assertThat(opts.getEfConstruction()).isEqualTo(200);
+    }
+
+    @Test
+    @DisplayName("Default values are correct")
+    void testDefaults() {
+      LanceIndexOptions opts = LanceIndexOptions.builder().build();
+
+      assertThat(opts.getIndexType()).isEqualTo(LanceOptions.IndexType.IVF_PQ);
+      assertThat(opts.getMetricType()).isEqualTo(LanceOptions.MetricType.L2);
+      assertThat(opts.getNumPartitions()).isEqualTo(256);
+      assertThat(opts.getNumSubVectors()).isNull();
+      assertThat(opts.getNumBits()).isEqualTo(8);
+      assertThat(opts.getMaxLevel()).isEqualTo(7);
+      assertThat(opts.getM()).isEqualTo(16);
+      assertThat(opts.getEfConstruction()).isEqualTo(100);
+    }
+
+    @Test
+    @DisplayName("Validation rejects invalid num partitions")
+    void testInvalidNumPartitions() {
+      assertThatThrownBy(() -> LanceIndexOptions.builder().numPartitions(0).build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("num-partitions");
+    }
+
+    @Test
+    @DisplayName("Validation rejects invalid num bits")
+    void testInvalidNumBits() {
+      assertThatThrownBy(() -> LanceIndexOptions.builder().numBits(17).build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("num-bits");
+    }
+
+    @Test
+    @DisplayName("Validation rejects invalid M")
+    void testInvalidM() {
+      assertThatThrownBy(() -> LanceIndexOptions.builder().maxEdges(0).build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("index.m");
+    }
+
+    @Test
+    @DisplayName("equals and hashCode")
+    void testEqualsHashCode() {
+      LanceIndexOptions a =
+          LanceIndexOptions.builder()
+              .columnName("vec")
+              .indexType(LanceOptions.IndexType.IVF_FLAT)
+              .numPartitions(64)
+              .build();
+      LanceIndexOptions b =
+          LanceIndexOptions.builder()
+              .columnName("vec")
+              .indexType(LanceOptions.IndexType.IVF_FLAT)
+              .numPartitions(64)
+              .build();
+
+      assertThat(a).isEqualTo(b);
+      assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+  }
+
+  // ==================== LanceVectorSearchOptions Tests ====================
+
+  @Nested
+  @DisplayName("LanceVectorSearchOptions")
+  class VectorSearchOptionsTests {
+
+    @Test
+    @DisplayName("Build with all fields")
+    void testBuildAllFields() {
+      LanceVectorSearchOptions opts =
+          LanceVectorSearchOptions.builder()
+              .columnName("embedding")
+              .metricType(LanceOptions.MetricType.DOT)
+              .nprobes(40)
+              .ef(200)
+              .refineFactor(5)
+              .build();
+
+      assertThat(opts.getColumnName()).isEqualTo("embedding");
+      assertThat(opts.getMetricType()).isEqualTo(LanceOptions.MetricType.DOT);
+      assertThat(opts.getNprobes()).isEqualTo(40);
+      assertThat(opts.getEf()).isEqualTo(200);
+      assertThat(opts.getRefineFactor()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("Default values are correct")
+    void testDefaults() {
+      LanceVectorSearchOptions opts = LanceVectorSearchOptions.builder().build();
+
+      assertThat(opts.getMetricType()).isEqualTo(LanceOptions.MetricType.L2);
+      assertThat(opts.getNprobes()).isEqualTo(20);
+      assertThat(opts.getEf()).isEqualTo(100);
+      assertThat(opts.getRefineFactor()).isNull();
+    }
+
+    @Test
+    @DisplayName("Validation rejects invalid nprobes")
+    void testInvalidNprobes() {
+      assertThatThrownBy(() -> LanceVectorSearchOptions.builder().nprobes(0).build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("nprobes");
+    }
+
+    @Test
+    @DisplayName("Validation rejects invalid ef")
+    void testInvalidEf() {
+      assertThatThrownBy(() -> LanceVectorSearchOptions.builder().ef(-1).build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("ef");
+    }
+
+    @Test
+    @DisplayName("Validation rejects invalid refine factor")
+    void testInvalidRefineFactor() {
+      assertThatThrownBy(() -> LanceVectorSearchOptions.builder().refineFactor(0).build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("refine-factor");
+    }
+
+    @Test
+    @DisplayName("equals and hashCode")
+    void testEqualsHashCode() {
+      LanceVectorSearchOptions a =
+          LanceVectorSearchOptions.builder()
+              .columnName("vec")
+              .metricType(LanceOptions.MetricType.COSINE)
+              .nprobes(10)
+              .ef(50)
+              .build();
+      LanceVectorSearchOptions b =
+          LanceVectorSearchOptions.builder()
+              .columnName("vec")
+              .metricType(LanceOptions.MetricType.COSINE)
+              .nprobes(10)
+              .ef(50)
+              .build();
+
+      assertThat(a).isEqualTo(b);
+      assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    }
+  }
+
+  // ==================== LanceOptions Conversion Tests ====================
+
+  @Nested
+  @DisplayName("LanceOptions sub-options conversion")
+  class ConversionTests {
+
+    @Test
+    @DisplayName("toSourceOptions preserves read fields")
+    void testToSourceOptions() {
+      LanceOptions full =
+          LanceOptions.builder()
+              .path("/data/ds")
+              .readBatchSize(512)
+              .readLimit(100L)
+              .readColumns(Arrays.asList("id", "name"))
+              .readFilter("id > 5")
+              .writeBatchSize(256)
+              .build();
+
+      LanceSourceOptions source = full.toSourceOptions();
+
+      assertThat(source.getPath()).isEqualTo("/data/ds");
+      assertThat(source.getBatchSize()).isEqualTo(512);
+      assertThat(source.getLimit()).isEqualTo(100L);
+      assertThat(source.getColumns()).containsExactly("id", "name");
+      assertThat(source.getFilter()).isEqualTo("id > 5");
+    }
+
+    @Test
+    @DisplayName("toSinkOptions preserves write fields")
+    void testToSinkOptions() {
+      LanceOptions full =
+          LanceOptions.builder()
+              .path("/data/ds")
+              .writeBatchSize(256)
+              .writeMode(LanceOptions.WriteMode.OVERWRITE)
+              .writeMaxRowsPerFile(500000)
+              .readBatchSize(1024)
+              .build();
+
+      LanceSinkOptions sink = full.toSinkOptions();
+
+      assertThat(sink.getPath()).isEqualTo("/data/ds");
+      assertThat(sink.getBatchSize()).isEqualTo(256);
+      assertThat(sink.getWriteMode()).isEqualTo(LanceOptions.WriteMode.OVERWRITE);
+      assertThat(sink.getMaxRowsPerFile()).isEqualTo(500000);
+    }
+
+    @Test
+    @DisplayName("toIndexOptions preserves index fields")
+    void testToIndexOptions() {
+      LanceOptions full =
+          LanceOptions.builder()
+              .path("/data/ds")
+              .indexColumn("embedding")
+              .indexType(LanceOptions.IndexType.IVF_HNSW)
+              .indexNumPartitions(128)
+              .indexNumSubVectors(32)
+              .indexNumBits(4)
+              .indexMaxLevel(5)
+              .indexM(32)
+              .indexEfConstruction(200)
+              .build();
+
+      LanceIndexOptions idx = full.toIndexOptions();
+
+      assertThat(idx.getColumnName()).isEqualTo("embedding");
+      assertThat(idx.getIndexType()).isEqualTo(LanceOptions.IndexType.IVF_HNSW);
+      assertThat(idx.getNumPartitions()).isEqualTo(128);
+      assertThat(idx.getNumSubVectors()).isEqualTo(32);
+      assertThat(idx.getNumBits()).isEqualTo(4);
+      assertThat(idx.getMaxLevel()).isEqualTo(5);
+      assertThat(idx.getM()).isEqualTo(32);
+      assertThat(idx.getEfConstruction()).isEqualTo(200);
+    }
+
+    @Test
+    @DisplayName("toVectorSearchOptions preserves vector search fields")
+    void testToVectorSearchOptions() {
+      LanceOptions full =
+          LanceOptions.builder()
+              .path("/data/ds")
+              .vectorColumn("embedding")
+              .vectorMetric(LanceOptions.MetricType.DOT)
+              .vectorNprobes(40)
+              .vectorEf(200)
+              .vectorRefineFactor(5)
+              .build();
+
+      LanceVectorSearchOptions vs = full.toVectorSearchOptions();
+
+      assertThat(vs.getColumnName()).isEqualTo("embedding");
+      assertThat(vs.getMetricType()).isEqualTo(LanceOptions.MetricType.DOT);
+      assertThat(vs.getNprobes()).isEqualTo(40);
+      assertThat(vs.getEf()).isEqualTo(200);
+      assertThat(vs.getRefineFactor()).isEqualTo(5);
+    }
+
+    @Test
+    @DisplayName("Round-trip: LanceOptions -> sub-options preserve semantics")
+    void testRoundTrip() {
+      LanceOptions original =
+          LanceOptions.builder()
+              .path("/data/ds")
+              .readBatchSize(512)
+              .readLimit(50L)
+              .readColumns(Collections.singletonList("id"))
+              .readFilter("id > 0")
+              .writeBatchSize(256)
+              .writeMode(LanceOptions.WriteMode.OVERWRITE)
+              .writeMaxRowsPerFile(100)
+              .build();
+
+      // Source round-trip
+      LanceSourceOptions source = original.toSourceOptions();
+      assertThat(source.getPath()).isEqualTo(original.getPath());
+      assertThat(source.getBatchSize()).isEqualTo(original.getReadBatchSize());
+      assertThat(source.getLimit()).isEqualTo(original.getReadLimit());
+      assertThat(source.getColumns()).isEqualTo(original.getReadColumns());
+      assertThat(source.getFilter()).isEqualTo(original.getReadFilter());
+
+      // Sink round-trip
+      LanceSinkOptions sink = original.toSinkOptions();
+      assertThat(sink.getPath()).isEqualTo(original.getPath());
+      assertThat(sink.getBatchSize()).isEqualTo(original.getWriteBatchSize());
+      assertThat(sink.getWriteMode()).isEqualTo(original.getWriteMode());
+      assertThat(sink.getMaxRowsPerFile()).isEqualTo(original.getWriteMaxRowsPerFile());
+    }
+  }
+}

--- a/src/test/java/org/apache/flink/connector/lance/sink/LanceSinkV2Test.java
+++ b/src/test/java/org/apache/flink/connector/lance/sink/LanceSinkV2Test.java
@@ -1,0 +1,465 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.lance.sink;
+
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.connector.lance.config.LanceOptions;
+import org.apache.flink.connector.lance.converter.LanceTypeConverter;
+import org.apache.flink.connector.lance.converter.RowDataConverter;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import com.lancedb.lance.Dataset;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowReader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Lance Sink V2 unit tests.
+ *
+ * <p>Tests various components of the Sink V2 API implementation, including:
+ * <ul>
+ *   <li>{@link LanceSink} - Sink entry point</li>
+ *   <li>{@link LanceSinkWriter} - Data writer</li>
+ *   <li>Write verification - Validate data integrity by reading back from Dataset</li>
+ * </ul>
+ */
+class LanceSinkV2Test {
+
+    @TempDir
+    Path tempDir;
+
+    private RowType rowType;
+
+    @BeforeEach
+    void setUp() {
+        List<RowType.RowField> fields = new ArrayList<>();
+        fields.add(new RowType.RowField("id", new BigIntType()));
+        fields.add(new RowType.RowField("name", new VarCharType()));
+        rowType = new RowType(fields);
+    }
+
+    // ==================== LanceSink Tests ====================
+
+    @Test
+    @DisplayName("Test LanceSink basic properties")
+    void testLanceSinkProperties() {
+        String datasetPath = tempDir.resolve("test_dataset.lance").toString();
+        LanceOptions options = LanceOptions.builder()
+                .path(datasetPath)
+                .writeBatchSize(512)
+                .writeMode(LanceOptions.WriteMode.APPEND)
+                .writeMaxRowsPerFile(500000)
+                .build();
+
+        LanceSink sink = new LanceSink(options, rowType);
+
+        assertThat(sink.getOptions().getPath()).isEqualTo(datasetPath);
+        assertThat(sink.getOptions().getWriteBatchSize()).isEqualTo(512);
+        assertThat(sink.getOptions().getWriteMode()).isEqualTo(LanceOptions.WriteMode.APPEND);
+        assertThat(sink.getOptions().getWriteMaxRowsPerFile()).isEqualTo(500000);
+        assertThat(sink.getRowType()).isEqualTo(rowType);
+    }
+
+    @Test
+    @DisplayName("Test LanceSink Builder pattern")
+    void testLanceSinkBuilder() {
+        String datasetPath = tempDir.resolve("test_dataset.lance").toString();
+        LanceSink sink = LanceSink.builder()
+                .path(datasetPath)
+                .batchSize(256)
+                .writeMode(LanceOptions.WriteMode.OVERWRITE)
+                .maxRowsPerFile(100000)
+                .rowType(rowType)
+                .build();
+
+        assertThat(sink.getOptions().getPath()).isEqualTo(datasetPath);
+        assertThat(sink.getOptions().getWriteBatchSize()).isEqualTo(256);
+        assertThat(sink.getOptions().getWriteMode()).isEqualTo(LanceOptions.WriteMode.OVERWRITE);
+        assertThat(sink.getOptions().getWriteMaxRowsPerFile()).isEqualTo(100000);
+    }
+
+    @Test
+    @DisplayName("Test LanceSink Builder throws exception when path is missing")
+    void testLanceSinkBuilderMissingPath() {
+        assertThatThrownBy(() -> LanceSink.builder()
+                .rowType(rowType)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("path must not be empty");
+    }
+
+    @Test
+    @DisplayName("Test LanceSink Builder throws exception when RowType is missing")
+    void testLanceSinkBuilderMissingRowType() {
+        assertThatThrownBy(() -> LanceSink.builder()
+                .path(tempDir.resolve("test.lance").toString())
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("RowType");
+    }
+
+    @Test
+    @DisplayName("Test LanceSink createWriter")
+    void testLanceSinkCreateWriter() throws IOException {
+        String datasetPath = tempDir.resolve("test_writer.lance").toString();
+        LanceOptions options = LanceOptions.builder()
+                .path(datasetPath)
+                .build();
+
+        LanceSink sink = new LanceSink(options, rowType);
+
+        // createWriter should not throw exceptions
+        SinkWriter<RowData> writer = sink.createWriter(null);
+        assertThat(writer).isNotNull();
+        assertThat(writer).isInstanceOf(LanceSinkWriter.class);
+
+        // Close writer
+        try {
+            writer.close();
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
+    // ==================== LanceSinkWriter Write Tests ====================
+
+    @Test
+    @DisplayName("Test writing a single row and verification")
+    void testWriteSingleRow() throws Exception {
+        String datasetPath = tempDir.resolve("single_row.lance").toString();
+        LanceOptions options = LanceOptions.builder()
+                .path(datasetPath)
+                .writeBatchSize(10)
+                .build();
+
+        LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
+
+        // Write one row
+        GenericRowData row = new GenericRowData(2);
+        row.setField(0, 1L);
+        row.setField(1, StringData.fromString("hello"));
+        writer.write(row, null);
+
+        // Flush and close
+        writer.flush(true);
+        writer.close();
+
+        assertThat(writer.getTotalWrittenRows()).isEqualTo(1);
+
+        // Verify written data
+        verifyDataset(datasetPath, 1);
+    }
+
+    @Test
+    @DisplayName("Test writing multiple rows and verification")
+    void testWriteMultipleRows() throws Exception {
+        String datasetPath = tempDir.resolve("multi_rows.lance").toString();
+        LanceOptions options = LanceOptions.builder()
+                .path(datasetPath)
+                .writeBatchSize(100)
+                .build();
+
+        LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
+
+        // Write 50 rows
+        for (int i = 0; i < 50; i++) {
+            GenericRowData row = new GenericRowData(2);
+            row.setField(0, (long) i);
+            row.setField(1, StringData.fromString("name_" + i));
+            writer.write(row, null);
+        }
+
+        // Flush and close
+        writer.flush(true);
+        writer.close();
+
+        assertThat(writer.getTotalWrittenRows()).isEqualTo(50);
+
+        // Verify written data
+        verifyDataset(datasetPath, 50);
+    }
+
+    @Test
+    @DisplayName("Test auto flush on batch size")
+    void testAutoFlushOnBatchSize() throws Exception {
+        String datasetPath = tempDir.resolve("auto_flush.lance").toString();
+        int batchSize = 10;
+        LanceOptions options = LanceOptions.builder()
+                .path(datasetPath)
+                .writeBatchSize(batchSize)
+                .build();
+
+        LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
+
+        // Write 25 rows (triggers 2 auto flushes + 1 final flush)
+        for (int i = 0; i < 25; i++) {
+            GenericRowData row = new GenericRowData(2);
+            row.setField(0, (long) i);
+            row.setField(1, StringData.fromString("auto_" + i));
+            writer.write(row, null);
+        }
+
+        writer.flush(true);
+        writer.close();
+
+        assertThat(writer.getTotalWrittenRows()).isEqualTo(25);
+        verifyDataset(datasetPath, 25);
+    }
+
+    @Test
+    @DisplayName("Test empty flush does not throw errors")
+    void testEmptyFlush() throws Exception {
+        String datasetPath = tempDir.resolve("empty_flush.lance").toString();
+        LanceOptions options = LanceOptions.builder()
+                .path(datasetPath)
+                .build();
+
+        LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
+
+        // Flush without writing any data
+        writer.flush(false);
+        writer.flush(true);
+        writer.close();
+
+        assertThat(writer.getTotalWrittenRows()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("Test overwrite mode")
+    void testOverwriteMode() throws Exception {
+        String datasetPath = tempDir.resolve("overwrite.lance").toString();
+
+        // First write: 10 rows
+        LanceOptions options1 = LanceOptions.builder()
+                .path(datasetPath)
+                .writeBatchSize(100)
+                .writeMode(LanceOptions.WriteMode.APPEND)
+                .build();
+
+        LanceSinkWriter writer1 = new LanceSinkWriter(options1, rowType);
+        for (int i = 0; i < 10; i++) {
+            GenericRowData row = new GenericRowData(2);
+            row.setField(0, (long) i);
+            row.setField(1, StringData.fromString("first_" + i));
+            writer1.write(row, null);
+        }
+        writer1.flush(true);
+        writer1.close();
+
+        verifyDataset(datasetPath, 10);
+
+        // Second write: 5 rows in overwrite mode
+        LanceOptions options2 = LanceOptions.builder()
+                .path(datasetPath)
+                .writeBatchSize(100)
+                .writeMode(LanceOptions.WriteMode.OVERWRITE)
+                .build();
+
+        LanceSinkWriter writer2 = new LanceSinkWriter(options2, rowType);
+        for (int i = 0; i < 5; i++) {
+            GenericRowData row = new GenericRowData(2);
+            row.setField(0, (long) (100 + i));
+            row.setField(1, StringData.fromString("second_" + i));
+            writer2.write(row, null);
+        }
+        writer2.flush(true);
+        writer2.close();
+
+        // Overwrite mode should have only 5 rows
+        verifyDataset(datasetPath, 5);
+    }
+
+    @Test
+    @DisplayName("Test append mode")
+    void testAppendMode() throws Exception {
+        String datasetPath = tempDir.resolve("append.lance").toString();
+
+        // First write: 10 rows
+        LanceOptions options1 = LanceOptions.builder()
+                .path(datasetPath)
+                .writeBatchSize(100)
+                .writeMode(LanceOptions.WriteMode.APPEND)
+                .build();
+
+        LanceSinkWriter writer1 = new LanceSinkWriter(options1, rowType);
+        for (int i = 0; i < 10; i++) {
+            GenericRowData row = new GenericRowData(2);
+            row.setField(0, (long) i);
+            row.setField(1, StringData.fromString("first_" + i));
+            writer1.write(row, null);
+        }
+        writer1.flush(true);
+        writer1.close();
+
+        verifyDataset(datasetPath, 10);
+
+        // Second write: append 5 rows
+        LanceOptions options2 = LanceOptions.builder()
+                .path(datasetPath)
+                .writeBatchSize(100)
+                .writeMode(LanceOptions.WriteMode.APPEND)
+                .build();
+
+        LanceSinkWriter writer2 = new LanceSinkWriter(options2, rowType);
+        for (int i = 0; i < 5; i++) {
+            GenericRowData row = new GenericRowData(2);
+            row.setField(0, (long) (100 + i));
+            row.setField(1, StringData.fromString("second_" + i));
+            writer2.write(row, null);
+        }
+        writer2.flush(true);
+        writer2.close();
+
+        // Append mode should have 15 rows
+        verifyDataset(datasetPath, 15);
+    }
+
+    @Test
+    @DisplayName("Test write and read content correctness")
+    void testWriteAndReadContent() throws Exception {
+        String datasetPath = tempDir.resolve("content_verify.lance").toString();
+        LanceOptions options = LanceOptions.builder()
+                .path(datasetPath)
+                .writeBatchSize(100)
+                .build();
+
+        LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
+
+        // Write 3 rows
+        for (int i = 0; i < 3; i++) {
+            GenericRowData row = new GenericRowData(2);
+            row.setField(0, (long) (i + 1));
+            row.setField(1, StringData.fromString("item_" + (i + 1)));
+            writer.write(row, null);
+        }
+        writer.flush(true);
+        writer.close();
+
+        // Read and verify data content
+        BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        try {
+            Dataset dataset = Dataset.open(datasetPath, allocator);
+            try {
+                assertThat(dataset.countRows()).isEqualTo(3);
+
+                // Read all data through Scanner
+                ArrowReader reader = dataset.newScan().scanBatches();
+                RowDataConverter converter = new RowDataConverter(rowType);
+                List<RowData> allRows = new ArrayList<>();
+
+                while (reader.loadNextBatch()) {
+                    VectorSchemaRoot root = reader.getVectorSchemaRoot();
+                    allRows.addAll(converter.toRowDataList(root));
+                }
+                reader.close();
+
+                assertThat(allRows).hasSize(3);
+
+                // Verify content
+                for (int i = 0; i < 3; i++) {
+                    RowData row = allRows.get(i);
+                    assertThat(row.getLong(0)).isEqualTo(i + 1);
+                    assertThat(row.getString(1).toString()).isEqualTo("item_" + (i + 1));
+                }
+            } finally {
+                dataset.close();
+            }
+        } finally {
+            allocator.close();
+        }
+    }
+
+    @Test
+    @DisplayName("Test checkpoint flush")
+    void testCheckpointFlush() throws Exception {
+        String datasetPath = tempDir.resolve("checkpoint.lance").toString();
+        LanceOptions options = LanceOptions.builder()
+                .path(datasetPath)
+                .writeBatchSize(1000) // Set a large batch to ensure no auto flush
+                .build();
+
+        LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
+
+        // Write 5 rows
+        for (int i = 0; i < 5; i++) {
+            GenericRowData row = new GenericRowData(2);
+            row.setField(0, (long) i);
+            row.setField(1, StringData.fromString("cp_" + i));
+            writer.write(row, null);
+        }
+
+        // Simulate checkpoint flush (endOfInput = false)
+        writer.flush(false);
+
+        assertThat(writer.getTotalWrittenRows()).isEqualTo(5);
+
+        // Write 3 more rows
+        for (int i = 5; i < 8; i++) {
+            GenericRowData row = new GenericRowData(2);
+            row.setField(0, (long) i);
+            row.setField(1, StringData.fromString("cp_" + i));
+            writer.write(row, null);
+        }
+
+        // Final flush (endOfInput = true)
+        writer.flush(true);
+        writer.close();
+
+        assertThat(writer.getTotalWrittenRows()).isEqualTo(8);
+        verifyDataset(datasetPath, 8);
+    }
+
+    // ==================== Helper Methods ====================
+
+    /**
+     * Verify the row count of a Dataset.
+     */
+    private void verifyDataset(String datasetPath, long expectedRowCount) throws Exception {
+        BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+        try {
+            Dataset dataset = Dataset.open(datasetPath, allocator);
+            try {
+                long actualRowCount = dataset.countRows();
+                assertThat(actualRowCount).isEqualTo(expectedRowCount);
+            } finally {
+                dataset.close();
+            }
+        } finally {
+            allocator.close();
+        }
+    }
+}

--- a/src/test/java/org/apache/flink/connector/lance/sink/LanceSinkV2Test.java
+++ b/src/test/java/org/apache/flink/connector/lance/sink/LanceSinkV2Test.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,12 +11,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.sink;
 
+import com.lancedb.lance.Dataset;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.connector.lance.config.LanceOptions;
-import org.apache.flink.connector.lance.converter.LanceTypeConverter;
 import org.apache.flink.connector.lance.converter.RowDataConverter;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -28,12 +27,6 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
-
-import com.lancedb.lance.Dataset;
-import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.vector.VectorSchemaRoot;
-import org.apache.arrow.vector.ipc.ArrowReader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -51,415 +44,402 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Lance Sink V2 unit tests.
  *
  * <p>Tests various components of the Sink V2 API implementation, including:
+ *
  * <ul>
- *   <li>{@link LanceSink} - Sink entry point</li>
- *   <li>{@link LanceSinkWriter} - Data writer</li>
- *   <li>Write verification - Validate data integrity by reading back from Dataset</li>
+ *   <li>{@link LanceSink} - Sink entry point
+ *   <li>{@link LanceSinkWriter} - Data writer
+ *   <li>Write verification - Validate data integrity by reading back from Dataset
  * </ul>
  */
 class LanceSinkV2Test {
 
-    @TempDir
-    Path tempDir;
+  @TempDir Path tempDir;
 
-    private RowType rowType;
+  private RowType rowType;
 
-    @BeforeEach
-    void setUp() {
-        List<RowType.RowField> fields = new ArrayList<>();
-        fields.add(new RowType.RowField("id", new BigIntType()));
-        fields.add(new RowType.RowField("name", new VarCharType()));
-        rowType = new RowType(fields);
+  @BeforeEach
+  void setUp() {
+    List<RowType.RowField> fields = new ArrayList<>();
+    fields.add(new RowType.RowField("id", new BigIntType()));
+    fields.add(new RowType.RowField("name", new VarCharType()));
+    rowType = new RowType(fields);
+  }
+
+  // ==================== LanceSink Tests ====================
+
+  @Test
+  @DisplayName("Test LanceSink basic properties")
+  void testLanceSinkProperties() {
+    String datasetPath = tempDir.resolve("test_dataset.lance").toString();
+    LanceOptions options =
+        LanceOptions.builder()
+            .path(datasetPath)
+            .writeBatchSize(512)
+            .writeMode(LanceOptions.WriteMode.APPEND)
+            .writeMaxRowsPerFile(500000)
+            .build();
+
+    LanceSink sink = new LanceSink(options, rowType);
+
+    assertThat(sink.getOptions().getPath()).isEqualTo(datasetPath);
+    assertThat(sink.getOptions().getWriteBatchSize()).isEqualTo(512);
+    assertThat(sink.getOptions().getWriteMode()).isEqualTo(LanceOptions.WriteMode.APPEND);
+    assertThat(sink.getOptions().getWriteMaxRowsPerFile()).isEqualTo(500000);
+    assertThat(sink.getRowType()).isEqualTo(rowType);
+  }
+
+  @Test
+  @DisplayName("Test LanceSink Builder pattern")
+  void testLanceSinkBuilder() {
+    String datasetPath = tempDir.resolve("test_dataset.lance").toString();
+    LanceSink sink =
+        LanceSink.builder()
+            .path(datasetPath)
+            .batchSize(256)
+            .writeMode(LanceOptions.WriteMode.OVERWRITE)
+            .maxRowsPerFile(100000)
+            .rowType(rowType)
+            .build();
+
+    assertThat(sink.getOptions().getPath()).isEqualTo(datasetPath);
+    assertThat(sink.getOptions().getWriteBatchSize()).isEqualTo(256);
+    assertThat(sink.getOptions().getWriteMode()).isEqualTo(LanceOptions.WriteMode.OVERWRITE);
+    assertThat(sink.getOptions().getWriteMaxRowsPerFile()).isEqualTo(100000);
+  }
+
+  @Test
+  @DisplayName("Test LanceSink Builder throws exception when path is missing")
+  void testLanceSinkBuilderMissingPath() {
+    assertThatThrownBy(() -> LanceSink.builder().rowType(rowType).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("path must not be empty");
+  }
+
+  @Test
+  @DisplayName("Test LanceSink Builder throws exception when RowType is missing")
+  void testLanceSinkBuilderMissingRowType() {
+    assertThatThrownBy(
+            () -> LanceSink.builder().path(tempDir.resolve("test.lance").toString()).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("RowType");
+  }
+
+  @Test
+  @DisplayName("Test LanceSink createWriter")
+  void testLanceSinkCreateWriter() throws IOException {
+    String datasetPath = tempDir.resolve("test_writer.lance").toString();
+    LanceOptions options = LanceOptions.builder().path(datasetPath).build();
+
+    LanceSink sink = new LanceSink(options, rowType);
+
+    // createWriter should not throw exceptions
+    SinkWriter<RowData> writer = sink.createWriter(null);
+    assertThat(writer).isNotNull();
+    assertThat(writer).isInstanceOf(LanceSinkWriter.class);
+
+    // Close writer
+    try {
+      writer.close();
+    } catch (Exception e) {
+      // ignore
+    }
+  }
+
+  // ==================== LanceSinkWriter Write Tests ====================
+
+  @Test
+  @DisplayName("Test writing a single row and verification")
+  void testWriteSingleRow() throws Exception {
+    String datasetPath = tempDir.resolve("single_row.lance").toString();
+    LanceOptions options = LanceOptions.builder().path(datasetPath).writeBatchSize(10).build();
+
+    LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
+
+    // Write one row
+    GenericRowData row = new GenericRowData(2);
+    row.setField(0, 1L);
+    row.setField(1, StringData.fromString("hello"));
+    writer.write(row, null);
+
+    // Flush and close
+    writer.flush(true);
+    writer.close();
+
+    assertThat(writer.getTotalWrittenRows()).isEqualTo(1);
+
+    // Verify written data
+    verifyDataset(datasetPath, 1);
+  }
+
+  @Test
+  @DisplayName("Test writing multiple rows and verification")
+  void testWriteMultipleRows() throws Exception {
+    String datasetPath = tempDir.resolve("multi_rows.lance").toString();
+    LanceOptions options = LanceOptions.builder().path(datasetPath).writeBatchSize(100).build();
+
+    LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
+
+    // Write 50 rows
+    for (int i = 0; i < 50; i++) {
+      GenericRowData row = new GenericRowData(2);
+      row.setField(0, (long) i);
+      row.setField(1, StringData.fromString("name_" + i));
+      writer.write(row, null);
     }
 
-    // ==================== LanceSink Tests ====================
+    // Flush and close
+    writer.flush(true);
+    writer.close();
 
-    @Test
-    @DisplayName("Test LanceSink basic properties")
-    void testLanceSinkProperties() {
-        String datasetPath = tempDir.resolve("test_dataset.lance").toString();
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .writeBatchSize(512)
-                .writeMode(LanceOptions.WriteMode.APPEND)
-                .writeMaxRowsPerFile(500000)
-                .build();
+    assertThat(writer.getTotalWrittenRows()).isEqualTo(50);
 
-        LanceSink sink = new LanceSink(options, rowType);
+    // Verify written data
+    verifyDataset(datasetPath, 50);
+  }
 
-        assertThat(sink.getOptions().getPath()).isEqualTo(datasetPath);
-        assertThat(sink.getOptions().getWriteBatchSize()).isEqualTo(512);
-        assertThat(sink.getOptions().getWriteMode()).isEqualTo(LanceOptions.WriteMode.APPEND);
-        assertThat(sink.getOptions().getWriteMaxRowsPerFile()).isEqualTo(500000);
-        assertThat(sink.getRowType()).isEqualTo(rowType);
+  @Test
+  @DisplayName("Test auto flush on batch size")
+  void testAutoFlushOnBatchSize() throws Exception {
+    String datasetPath = tempDir.resolve("auto_flush.lance").toString();
+    int batchSize = 10;
+    LanceOptions options =
+        LanceOptions.builder().path(datasetPath).writeBatchSize(batchSize).build();
+
+    LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
+
+    // Write 25 rows (triggers 2 auto flushes + 1 final flush)
+    for (int i = 0; i < 25; i++) {
+      GenericRowData row = new GenericRowData(2);
+      row.setField(0, (long) i);
+      row.setField(1, StringData.fromString("auto_" + i));
+      writer.write(row, null);
     }
 
-    @Test
-    @DisplayName("Test LanceSink Builder pattern")
-    void testLanceSinkBuilder() {
-        String datasetPath = tempDir.resolve("test_dataset.lance").toString();
-        LanceSink sink = LanceSink.builder()
-                .path(datasetPath)
-                .batchSize(256)
-                .writeMode(LanceOptions.WriteMode.OVERWRITE)
-                .maxRowsPerFile(100000)
-                .rowType(rowType)
-                .build();
+    writer.flush(true);
+    writer.close();
 
-        assertThat(sink.getOptions().getPath()).isEqualTo(datasetPath);
-        assertThat(sink.getOptions().getWriteBatchSize()).isEqualTo(256);
-        assertThat(sink.getOptions().getWriteMode()).isEqualTo(LanceOptions.WriteMode.OVERWRITE);
-        assertThat(sink.getOptions().getWriteMaxRowsPerFile()).isEqualTo(100000);
+    assertThat(writer.getTotalWrittenRows()).isEqualTo(25);
+    verifyDataset(datasetPath, 25);
+  }
+
+  @Test
+  @DisplayName("Test empty flush does not throw errors")
+  void testEmptyFlush() throws Exception {
+    String datasetPath = tempDir.resolve("empty_flush.lance").toString();
+    LanceOptions options = LanceOptions.builder().path(datasetPath).build();
+
+    LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
+
+    // Flush without writing any data
+    writer.flush(false);
+    writer.flush(true);
+    writer.close();
+
+    assertThat(writer.getTotalWrittenRows()).isEqualTo(0);
+  }
+
+  @Test
+  @DisplayName("Test overwrite mode")
+  void testOverwriteMode() throws Exception {
+    String datasetPath = tempDir.resolve("overwrite.lance").toString();
+
+    // First write: 10 rows
+    LanceOptions options1 =
+        LanceOptions.builder()
+            .path(datasetPath)
+            .writeBatchSize(100)
+            .writeMode(LanceOptions.WriteMode.APPEND)
+            .build();
+
+    LanceSinkWriter writer1 = new LanceSinkWriter(options1, rowType);
+    for (int i = 0; i < 10; i++) {
+      GenericRowData row = new GenericRowData(2);
+      row.setField(0, (long) i);
+      row.setField(1, StringData.fromString("first_" + i));
+      writer1.write(row, null);
     }
+    writer1.flush(true);
+    writer1.close();
 
-    @Test
-    @DisplayName("Test LanceSink Builder throws exception when path is missing")
-    void testLanceSinkBuilderMissingPath() {
-        assertThatThrownBy(() -> LanceSink.builder()
-                .rowType(rowType)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("path must not be empty");
+    verifyDataset(datasetPath, 10);
+
+    // Second write: 5 rows in overwrite mode
+    LanceOptions options2 =
+        LanceOptions.builder()
+            .path(datasetPath)
+            .writeBatchSize(100)
+            .writeMode(LanceOptions.WriteMode.OVERWRITE)
+            .build();
+
+    LanceSinkWriter writer2 = new LanceSinkWriter(options2, rowType);
+    for (int i = 0; i < 5; i++) {
+      GenericRowData row = new GenericRowData(2);
+      row.setField(0, (long) (100 + i));
+      row.setField(1, StringData.fromString("second_" + i));
+      writer2.write(row, null);
     }
+    writer2.flush(true);
+    writer2.close();
 
-    @Test
-    @DisplayName("Test LanceSink Builder throws exception when RowType is missing")
-    void testLanceSinkBuilderMissingRowType() {
-        assertThatThrownBy(() -> LanceSink.builder()
-                .path(tempDir.resolve("test.lance").toString())
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("RowType");
+    // Overwrite mode should have only 5 rows
+    verifyDataset(datasetPath, 5);
+  }
+
+  @Test
+  @DisplayName("Test append mode")
+  void testAppendMode() throws Exception {
+    String datasetPath = tempDir.resolve("append.lance").toString();
+
+    // First write: 10 rows
+    LanceOptions options1 =
+        LanceOptions.builder()
+            .path(datasetPath)
+            .writeBatchSize(100)
+            .writeMode(LanceOptions.WriteMode.APPEND)
+            .build();
+
+    LanceSinkWriter writer1 = new LanceSinkWriter(options1, rowType);
+    for (int i = 0; i < 10; i++) {
+      GenericRowData row = new GenericRowData(2);
+      row.setField(0, (long) i);
+      row.setField(1, StringData.fromString("first_" + i));
+      writer1.write(row, null);
     }
+    writer1.flush(true);
+    writer1.close();
 
-    @Test
-    @DisplayName("Test LanceSink createWriter")
-    void testLanceSinkCreateWriter() throws IOException {
-        String datasetPath = tempDir.resolve("test_writer.lance").toString();
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .build();
+    verifyDataset(datasetPath, 10);
 
-        LanceSink sink = new LanceSink(options, rowType);
+    // Second write: append 5 rows
+    LanceOptions options2 =
+        LanceOptions.builder()
+            .path(datasetPath)
+            .writeBatchSize(100)
+            .writeMode(LanceOptions.WriteMode.APPEND)
+            .build();
 
-        // createWriter should not throw exceptions
-        SinkWriter<RowData> writer = sink.createWriter(null);
-        assertThat(writer).isNotNull();
-        assertThat(writer).isInstanceOf(LanceSinkWriter.class);
+    LanceSinkWriter writer2 = new LanceSinkWriter(options2, rowType);
+    for (int i = 0; i < 5; i++) {
+      GenericRowData row = new GenericRowData(2);
+      row.setField(0, (long) (100 + i));
+      row.setField(1, StringData.fromString("second_" + i));
+      writer2.write(row, null);
+    }
+    writer2.flush(true);
+    writer2.close();
 
-        // Close writer
-        try {
-            writer.close();
-        } catch (Exception e) {
-            // ignore
+    // Append mode should have 15 rows
+    verifyDataset(datasetPath, 15);
+  }
+
+  @Test
+  @DisplayName("Test write and read content correctness")
+  void testWriteAndReadContent() throws Exception {
+    String datasetPath = tempDir.resolve("content_verify.lance").toString();
+    LanceOptions options = LanceOptions.builder().path(datasetPath).writeBatchSize(100).build();
+
+    LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
+
+    // Write 3 rows
+    for (int i = 0; i < 3; i++) {
+      GenericRowData row = new GenericRowData(2);
+      row.setField(0, (long) (i + 1));
+      row.setField(1, StringData.fromString("item_" + (i + 1)));
+      writer.write(row, null);
+    }
+    writer.flush(true);
+    writer.close();
+
+    // Read and verify data content
+    BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+    try {
+      Dataset dataset = Dataset.open(datasetPath, allocator);
+      try {
+        assertThat(dataset.countRows()).isEqualTo(3);
+
+        // Read all data through Scanner
+        ArrowReader reader = dataset.newScan().scanBatches();
+        RowDataConverter converter = new RowDataConverter(rowType);
+        List<RowData> allRows = new ArrayList<>();
+
+        while (reader.loadNextBatch()) {
+          VectorSchemaRoot root = reader.getVectorSchemaRoot();
+          allRows.addAll(converter.toRowDataList(root));
         }
-    }
+        reader.close();
 
-    // ==================== LanceSinkWriter Write Tests ====================
+        assertThat(allRows).hasSize(3);
 
-    @Test
-    @DisplayName("Test writing a single row and verification")
-    void testWriteSingleRow() throws Exception {
-        String datasetPath = tempDir.resolve("single_row.lance").toString();
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .writeBatchSize(10)
-                .build();
-
-        LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
-
-        // Write one row
-        GenericRowData row = new GenericRowData(2);
-        row.setField(0, 1L);
-        row.setField(1, StringData.fromString("hello"));
-        writer.write(row, null);
-
-        // Flush and close
-        writer.flush(true);
-        writer.close();
-
-        assertThat(writer.getTotalWrittenRows()).isEqualTo(1);
-
-        // Verify written data
-        verifyDataset(datasetPath, 1);
-    }
-
-    @Test
-    @DisplayName("Test writing multiple rows and verification")
-    void testWriteMultipleRows() throws Exception {
-        String datasetPath = tempDir.resolve("multi_rows.lance").toString();
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .writeBatchSize(100)
-                .build();
-
-        LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
-
-        // Write 50 rows
-        for (int i = 0; i < 50; i++) {
-            GenericRowData row = new GenericRowData(2);
-            row.setField(0, (long) i);
-            row.setField(1, StringData.fromString("name_" + i));
-            writer.write(row, null);
-        }
-
-        // Flush and close
-        writer.flush(true);
-        writer.close();
-
-        assertThat(writer.getTotalWrittenRows()).isEqualTo(50);
-
-        // Verify written data
-        verifyDataset(datasetPath, 50);
-    }
-
-    @Test
-    @DisplayName("Test auto flush on batch size")
-    void testAutoFlushOnBatchSize() throws Exception {
-        String datasetPath = tempDir.resolve("auto_flush.lance").toString();
-        int batchSize = 10;
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .writeBatchSize(batchSize)
-                .build();
-
-        LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
-
-        // Write 25 rows (triggers 2 auto flushes + 1 final flush)
-        for (int i = 0; i < 25; i++) {
-            GenericRowData row = new GenericRowData(2);
-            row.setField(0, (long) i);
-            row.setField(1, StringData.fromString("auto_" + i));
-            writer.write(row, null);
-        }
-
-        writer.flush(true);
-        writer.close();
-
-        assertThat(writer.getTotalWrittenRows()).isEqualTo(25);
-        verifyDataset(datasetPath, 25);
-    }
-
-    @Test
-    @DisplayName("Test empty flush does not throw errors")
-    void testEmptyFlush() throws Exception {
-        String datasetPath = tempDir.resolve("empty_flush.lance").toString();
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .build();
-
-        LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
-
-        // Flush without writing any data
-        writer.flush(false);
-        writer.flush(true);
-        writer.close();
-
-        assertThat(writer.getTotalWrittenRows()).isEqualTo(0);
-    }
-
-    @Test
-    @DisplayName("Test overwrite mode")
-    void testOverwriteMode() throws Exception {
-        String datasetPath = tempDir.resolve("overwrite.lance").toString();
-
-        // First write: 10 rows
-        LanceOptions options1 = LanceOptions.builder()
-                .path(datasetPath)
-                .writeBatchSize(100)
-                .writeMode(LanceOptions.WriteMode.APPEND)
-                .build();
-
-        LanceSinkWriter writer1 = new LanceSinkWriter(options1, rowType);
-        for (int i = 0; i < 10; i++) {
-            GenericRowData row = new GenericRowData(2);
-            row.setField(0, (long) i);
-            row.setField(1, StringData.fromString("first_" + i));
-            writer1.write(row, null);
-        }
-        writer1.flush(true);
-        writer1.close();
-
-        verifyDataset(datasetPath, 10);
-
-        // Second write: 5 rows in overwrite mode
-        LanceOptions options2 = LanceOptions.builder()
-                .path(datasetPath)
-                .writeBatchSize(100)
-                .writeMode(LanceOptions.WriteMode.OVERWRITE)
-                .build();
-
-        LanceSinkWriter writer2 = new LanceSinkWriter(options2, rowType);
-        for (int i = 0; i < 5; i++) {
-            GenericRowData row = new GenericRowData(2);
-            row.setField(0, (long) (100 + i));
-            row.setField(1, StringData.fromString("second_" + i));
-            writer2.write(row, null);
-        }
-        writer2.flush(true);
-        writer2.close();
-
-        // Overwrite mode should have only 5 rows
-        verifyDataset(datasetPath, 5);
-    }
-
-    @Test
-    @DisplayName("Test append mode")
-    void testAppendMode() throws Exception {
-        String datasetPath = tempDir.resolve("append.lance").toString();
-
-        // First write: 10 rows
-        LanceOptions options1 = LanceOptions.builder()
-                .path(datasetPath)
-                .writeBatchSize(100)
-                .writeMode(LanceOptions.WriteMode.APPEND)
-                .build();
-
-        LanceSinkWriter writer1 = new LanceSinkWriter(options1, rowType);
-        for (int i = 0; i < 10; i++) {
-            GenericRowData row = new GenericRowData(2);
-            row.setField(0, (long) i);
-            row.setField(1, StringData.fromString("first_" + i));
-            writer1.write(row, null);
-        }
-        writer1.flush(true);
-        writer1.close();
-
-        verifyDataset(datasetPath, 10);
-
-        // Second write: append 5 rows
-        LanceOptions options2 = LanceOptions.builder()
-                .path(datasetPath)
-                .writeBatchSize(100)
-                .writeMode(LanceOptions.WriteMode.APPEND)
-                .build();
-
-        LanceSinkWriter writer2 = new LanceSinkWriter(options2, rowType);
-        for (int i = 0; i < 5; i++) {
-            GenericRowData row = new GenericRowData(2);
-            row.setField(0, (long) (100 + i));
-            row.setField(1, StringData.fromString("second_" + i));
-            writer2.write(row, null);
-        }
-        writer2.flush(true);
-        writer2.close();
-
-        // Append mode should have 15 rows
-        verifyDataset(datasetPath, 15);
-    }
-
-    @Test
-    @DisplayName("Test write and read content correctness")
-    void testWriteAndReadContent() throws Exception {
-        String datasetPath = tempDir.resolve("content_verify.lance").toString();
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .writeBatchSize(100)
-                .build();
-
-        LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
-
-        // Write 3 rows
+        // Verify content
         for (int i = 0; i < 3; i++) {
-            GenericRowData row = new GenericRowData(2);
-            row.setField(0, (long) (i + 1));
-            row.setField(1, StringData.fromString("item_" + (i + 1)));
-            writer.write(row, null);
+          RowData row = allRows.get(i);
+          assertThat(row.getLong(0)).isEqualTo(i + 1);
+          assertThat(row.getString(1).toString()).isEqualTo("item_" + (i + 1));
         }
-        writer.flush(true);
-        writer.close();
+      } finally {
+        dataset.close();
+      }
+    } finally {
+      allocator.close();
+    }
+  }
 
-        // Read and verify data content
-        BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-        try {
-            Dataset dataset = Dataset.open(datasetPath, allocator);
-            try {
-                assertThat(dataset.countRows()).isEqualTo(3);
+  @Test
+  @DisplayName("Test checkpoint flush")
+  void testCheckpointFlush() throws Exception {
+    String datasetPath = tempDir.resolve("checkpoint.lance").toString();
+    LanceOptions options =
+        LanceOptions.builder()
+            .path(datasetPath)
+            .writeBatchSize(1000) // Set a large batch to ensure no auto flush
+            .build();
 
-                // Read all data through Scanner
-                ArrowReader reader = dataset.newScan().scanBatches();
-                RowDataConverter converter = new RowDataConverter(rowType);
-                List<RowData> allRows = new ArrayList<>();
+    LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
 
-                while (reader.loadNextBatch()) {
-                    VectorSchemaRoot root = reader.getVectorSchemaRoot();
-                    allRows.addAll(converter.toRowDataList(root));
-                }
-                reader.close();
-
-                assertThat(allRows).hasSize(3);
-
-                // Verify content
-                for (int i = 0; i < 3; i++) {
-                    RowData row = allRows.get(i);
-                    assertThat(row.getLong(0)).isEqualTo(i + 1);
-                    assertThat(row.getString(1).toString()).isEqualTo("item_" + (i + 1));
-                }
-            } finally {
-                dataset.close();
-            }
-        } finally {
-            allocator.close();
-        }
+    // Write 5 rows
+    for (int i = 0; i < 5; i++) {
+      GenericRowData row = new GenericRowData(2);
+      row.setField(0, (long) i);
+      row.setField(1, StringData.fromString("cp_" + i));
+      writer.write(row, null);
     }
 
-    @Test
-    @DisplayName("Test checkpoint flush")
-    void testCheckpointFlush() throws Exception {
-        String datasetPath = tempDir.resolve("checkpoint.lance").toString();
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .writeBatchSize(1000) // Set a large batch to ensure no auto flush
-                .build();
+    // Simulate checkpoint flush (endOfInput = false)
+    writer.flush(false);
 
-        LanceSinkWriter writer = new LanceSinkWriter(options, rowType);
+    assertThat(writer.getTotalWrittenRows()).isEqualTo(5);
 
-        // Write 5 rows
-        for (int i = 0; i < 5; i++) {
-            GenericRowData row = new GenericRowData(2);
-            row.setField(0, (long) i);
-            row.setField(1, StringData.fromString("cp_" + i));
-            writer.write(row, null);
-        }
-
-        // Simulate checkpoint flush (endOfInput = false)
-        writer.flush(false);
-
-        assertThat(writer.getTotalWrittenRows()).isEqualTo(5);
-
-        // Write 3 more rows
-        for (int i = 5; i < 8; i++) {
-            GenericRowData row = new GenericRowData(2);
-            row.setField(0, (long) i);
-            row.setField(1, StringData.fromString("cp_" + i));
-            writer.write(row, null);
-        }
-
-        // Final flush (endOfInput = true)
-        writer.flush(true);
-        writer.close();
-
-        assertThat(writer.getTotalWrittenRows()).isEqualTo(8);
-        verifyDataset(datasetPath, 8);
+    // Write 3 more rows
+    for (int i = 5; i < 8; i++) {
+      GenericRowData row = new GenericRowData(2);
+      row.setField(0, (long) i);
+      row.setField(1, StringData.fromString("cp_" + i));
+      writer.write(row, null);
     }
 
-    // ==================== Helper Methods ====================
+    // Final flush (endOfInput = true)
+    writer.flush(true);
+    writer.close();
 
-    /**
-     * Verify the row count of a Dataset.
-     */
-    private void verifyDataset(String datasetPath, long expectedRowCount) throws Exception {
-        BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-        try {
-            Dataset dataset = Dataset.open(datasetPath, allocator);
-            try {
-                long actualRowCount = dataset.countRows();
-                assertThat(actualRowCount).isEqualTo(expectedRowCount);
-            } finally {
-                dataset.close();
-            }
-        } finally {
-            allocator.close();
-        }
+    assertThat(writer.getTotalWrittenRows()).isEqualTo(8);
+    verifyDataset(datasetPath, 8);
+  }
+
+  // ==================== Helper Methods ====================
+
+  /** Verify the row count of a Dataset. */
+  private void verifyDataset(String datasetPath, long expectedRowCount) throws Exception {
+    BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+    try {
+      Dataset dataset = Dataset.open(datasetPath, allocator);
+      try {
+        long actualRowCount = dataset.countRows();
+        assertThat(actualRowCount).isEqualTo(expectedRowCount);
+      } finally {
+        dataset.close();
+      }
+    } finally {
+      allocator.close();
     }
+  }
 }

--- a/src/test/java/org/apache/flink/connector/lance/source/LanceSourceV2Test.java
+++ b/src/test/java/org/apache/flink/connector/lance/source/LanceSourceV2Test.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,19 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.source;
-
-import org.apache.flink.api.connector.source.Boundedness;
-import org.apache.flink.connector.lance.config.LanceOptions;
-import org.apache.flink.connector.lance.converter.LanceTypeConverter;
-import org.apache.flink.connector.lance.converter.RowDataConverter;
-import org.apache.flink.table.data.GenericRowData;
-import org.apache.flink.table.data.RowData;
-import org.apache.flink.table.data.StringData;
-import org.apache.flink.table.types.logical.BigIntType;
-import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.VarCharType;
 
 import com.lancedb.lance.Dataset;
 import com.lancedb.lance.Fragment;
@@ -40,6 +24,12 @@ import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.connector.lance.config.LanceOptions;
+import org.apache.flink.connector.lance.converter.LanceTypeConverter;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -60,402 +50,392 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Lance Source V2 unit tests.
  *
  * <p>Tests various components of the Source V2 API implementation, including:
+ *
  * <ul>
- *   <li>{@link LanceSourceSplit} - Split model</li>
- *   <li>{@link LanceSourceSplitSerializer} - Split serialization</li>
- *   <li>{@link LanceEnumeratorState} - Enumerator state</li>
- *   <li>{@link LanceEnumeratorStateSerializer} - State serialization</li>
- *   <li>{@link LanceSource} - Source entry point</li>
+ *   <li>{@link LanceSourceSplit} - Split model
+ *   <li>{@link LanceSourceSplitSerializer} - Split serialization
+ *   <li>{@link LanceEnumeratorState} - Enumerator state
+ *   <li>{@link LanceEnumeratorStateSerializer} - State serialization
+ *   <li>{@link LanceSource} - Source entry point
  * </ul>
  */
 class LanceSourceV2Test {
 
-    @TempDir
-    Path tempDir;
+  @TempDir Path tempDir;
 
-    private String datasetPath;
-    private RowType rowType;
+  private String datasetPath;
+  private RowType rowType;
 
-    @BeforeEach
-    void setUp() {
-        datasetPath = tempDir.resolve("test_dataset.lance").toString();
+  @BeforeEach
+  void setUp() {
+    datasetPath = tempDir.resolve("test_dataset.lance").toString();
 
-        // Create test RowType
-        List<RowType.RowField> fields = new ArrayList<>();
-        fields.add(new RowType.RowField("id", new BigIntType()));
-        fields.add(new RowType.RowField("name", new VarCharType()));
-        rowType = new RowType(fields);
+    // Create test RowType
+    List<RowType.RowField> fields = new ArrayList<>();
+    fields.add(new RowType.RowField("id", new BigIntType()));
+    fields.add(new RowType.RowField("name", new VarCharType()));
+    rowType = new RowType(fields);
+  }
+
+  // ==================== LanceSourceSplit Tests ====================
+
+  @Test
+  @DisplayName("Test LanceSourceSplit creation and properties")
+  void testSourceSplitCreation() {
+    LanceSourceSplit split = new LanceSourceSplit(1, datasetPath, 1000);
+
+    assertThat(split.getFragmentId()).isEqualTo(1);
+    assertThat(split.getDatasetPath()).isEqualTo(datasetPath);
+    assertThat(split.getRowCount()).isEqualTo(1000);
+    assertThat(split.splitId()).isEqualTo("lance-split-1");
+  }
+
+  @Test
+  @DisplayName("Test LanceSourceSplit equality")
+  void testSourceSplitEquality() {
+    LanceSourceSplit split1 = new LanceSourceSplit(1, datasetPath, 1000);
+    LanceSourceSplit split2 = new LanceSourceSplit(1, datasetPath, 1000);
+    LanceSourceSplit split3 = new LanceSourceSplit(2, datasetPath, 2000);
+
+    assertThat(split1).isEqualTo(split2);
+    assertThat(split1.hashCode()).isEqualTo(split2.hashCode());
+    assertThat(split1).isNotEqualTo(split3);
+  }
+
+  @Test
+  @DisplayName("Test LanceSourceSplit does not allow null path")
+  void testSourceSplitNullPath() {
+    assertThatThrownBy(() -> new LanceSourceSplit(1, null, 1000))
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  @DisplayName("Test LanceSourceSplit toString")
+  void testSourceSplitToString() {
+    LanceSourceSplit split = new LanceSourceSplit(1, "/test/path", 1000);
+    String str = split.toString();
+
+    assertThat(str).contains("fragmentId=1");
+    assertThat(str).contains("/test/path");
+    assertThat(str).contains("rowCount=1000");
+  }
+
+  // ==================== LanceSourceSplitSerializer Tests ====================
+
+  @Test
+  @DisplayName("Test Split serialize and deserialize")
+  void testSplitSerializeDeserialize() throws IOException {
+    LanceSourceSplit original = new LanceSourceSplit(5, datasetPath, 5000);
+
+    LanceSourceSplitSerializer serializer = LanceSourceSplitSerializer.INSTANCE;
+    byte[] serialized = serializer.serialize(original);
+
+    LanceSourceSplit deserialized = serializer.deserialize(serializer.getVersion(), serialized);
+
+    assertThat(deserialized).isEqualTo(original);
+    assertThat(deserialized.getFragmentId()).isEqualTo(5);
+    assertThat(deserialized.getDatasetPath()).isEqualTo(datasetPath);
+    assertThat(deserialized.getRowCount()).isEqualTo(5000);
+  }
+
+  @Test
+  @DisplayName("Test Split serializer version")
+  void testSplitSerializerVersion() {
+    assertThat(LanceSourceSplitSerializer.INSTANCE.getVersion()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("Test Split deserialization with unsupported version")
+  void testSplitDeserializeUnsupportedVersion() throws IOException {
+    LanceSourceSplit original = new LanceSourceSplit(1, datasetPath, 1000);
+    byte[] serialized = LanceSourceSplitSerializer.INSTANCE.serialize(original);
+
+    assertThatThrownBy(() -> LanceSourceSplitSerializer.INSTANCE.deserialize(999, serialized))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Unsupported serialization version");
+  }
+
+  @Test
+  @DisplayName("Test multiple Splits serialization and deserialization")
+  void testMultipleSplitsSerialization() throws IOException {
+    List<LanceSourceSplit> originals =
+        Arrays.asList(
+            new LanceSourceSplit(0, "/path/a", 100),
+            new LanceSourceSplit(1, "/path/b", 200),
+            new LanceSourceSplit(2, "/path/c", 300));
+
+    LanceSourceSplitSerializer serializer = LanceSourceSplitSerializer.INSTANCE;
+
+    for (LanceSourceSplit original : originals) {
+      byte[] serialized = serializer.serialize(original);
+      LanceSourceSplit deserialized = serializer.deserialize(serializer.getVersion(), serialized);
+      assertThat(deserialized).isEqualTo(original);
+    }
+  }
+
+  // ==================== LanceEnumeratorState Tests ====================
+
+  @Test
+  @DisplayName("Test EnumeratorState creation")
+  void testEnumeratorStateCreation() {
+    List<LanceSourceSplit> splits =
+        Arrays.asList(
+            new LanceSourceSplit(0, datasetPath, 100), new LanceSourceSplit(1, datasetPath, 200));
+
+    LanceEnumeratorState state = new LanceEnumeratorState(splits);
+
+    assertThat(state.getPendingSplits()).hasSize(2);
+    assertThat(state.getPendingSplits().get(0).getFragmentId()).isEqualTo(0);
+    assertThat(state.getPendingSplits().get(1).getFragmentId()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("Test EnumeratorState list is immutable")
+  void testEnumeratorStateImmutableList() {
+    List<LanceSourceSplit> splits = new ArrayList<>();
+    splits.add(new LanceSourceSplit(0, datasetPath, 100));
+
+    LanceEnumeratorState state = new LanceEnumeratorState(splits);
+
+    // Modifying original list should not affect state
+    splits.add(new LanceSourceSplit(1, datasetPath, 200));
+    assertThat(state.getPendingSplits()).hasSize(1);
+
+    // State's list should be unmodifiable
+    assertThatThrownBy(
+            () -> state.getPendingSplits().add(new LanceSourceSplit(2, datasetPath, 300)))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  @Test
+  @DisplayName("Test empty EnumeratorState")
+  void testEmptyEnumeratorState() {
+    LanceEnumeratorState state = new LanceEnumeratorState(Collections.emptyList());
+    assertThat(state.getPendingSplits()).isEmpty();
+  }
+
+  // ==================== LanceEnumeratorStateSerializer Tests ====================
+
+  @Test
+  @DisplayName("Test EnumeratorState serialize and deserialize")
+  void testEnumeratorStateSerializeDeserialize() throws IOException {
+    List<LanceSourceSplit> splits =
+        Arrays.asList(
+            new LanceSourceSplit(0, "/path/a", 100),
+            new LanceSourceSplit(1, "/path/b", 200),
+            new LanceSourceSplit(2, "/path/c", 300));
+
+    LanceEnumeratorState original = new LanceEnumeratorState(splits);
+    LanceEnumeratorStateSerializer serializer = LanceEnumeratorStateSerializer.INSTANCE;
+
+    byte[] serialized = serializer.serialize(original);
+    LanceEnumeratorState deserialized = serializer.deserialize(serializer.getVersion(), serialized);
+
+    assertThat(deserialized.getPendingSplits()).hasSize(3);
+    assertThat(deserialized.getPendingSplits().get(0)).isEqualTo(splits.get(0));
+    assertThat(deserialized.getPendingSplits().get(1)).isEqualTo(splits.get(1));
+    assertThat(deserialized.getPendingSplits().get(2)).isEqualTo(splits.get(2));
+  }
+
+  @Test
+  @DisplayName("Test empty EnumeratorState serialize and deserialize")
+  void testEmptyEnumeratorStateSerializeDeserialize() throws IOException {
+    LanceEnumeratorState original = new LanceEnumeratorState(Collections.emptyList());
+    LanceEnumeratorStateSerializer serializer = LanceEnumeratorStateSerializer.INSTANCE;
+
+    byte[] serialized = serializer.serialize(original);
+    LanceEnumeratorState deserialized = serializer.deserialize(serializer.getVersion(), serialized);
+
+    assertThat(deserialized.getPendingSplits()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Test EnumeratorState serializer version")
+  void testEnumeratorStateSerializerVersion() {
+    assertThat(LanceEnumeratorStateSerializer.INSTANCE.getVersion()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("Test EnumeratorState deserialization with unsupported version")
+  void testEnumeratorStateDeserializeUnsupportedVersion() throws IOException {
+    LanceEnumeratorState original = new LanceEnumeratorState(Collections.emptyList());
+    byte[] serialized = LanceEnumeratorStateSerializer.INSTANCE.serialize(original);
+
+    assertThatThrownBy(() -> LanceEnumeratorStateSerializer.INSTANCE.deserialize(999, serialized))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Unsupported serialization version");
+  }
+
+  // ==================== LanceSource Tests ====================
+
+  @Test
+  @DisplayName("Test LanceSource basic properties")
+  void testLanceSourceProperties() {
+    LanceOptions options = LanceOptions.builder().path(datasetPath).readBatchSize(512).build();
+
+    LanceSource source = new LanceSource(options, rowType);
+
+    assertThat(source.getOptions().getPath()).isEqualTo(datasetPath);
+    assertThat(source.getOptions().getReadBatchSize()).isEqualTo(512);
+    assertThat(source.getRowType()).isEqualTo(rowType);
+    assertThat(source.getBoundedness()).isEqualTo(Boundedness.BOUNDED);
+  }
+
+  @Test
+  @DisplayName("Test LanceSource auto-infer schema (no RowType)")
+  void testLanceSourceWithoutRowType() {
+    LanceOptions options = LanceOptions.builder().path(datasetPath).build();
+
+    LanceSource source = new LanceSource(options);
+
+    assertThat(source.getRowType()).isNull();
+    assertThat(source.getBoundedness()).isEqualTo(Boundedness.BOUNDED);
+  }
+
+  @Test
+  @DisplayName("Test LanceSource Builder pattern")
+  void testLanceSourceBuilder() {
+    LanceSource source =
+        LanceSource.builder()
+            .path(datasetPath)
+            .batchSize(256)
+            .columns(Arrays.asList("id", "name"))
+            .filter("id > 10")
+            .limit(100L)
+            .rowType(rowType)
+            .build();
+
+    assertThat(source.getOptions().getPath()).isEqualTo(datasetPath);
+    assertThat(source.getOptions().getReadBatchSize()).isEqualTo(256);
+    assertThat(source.getOptions().getReadColumns()).containsExactly("id", "name");
+    assertThat(source.getOptions().getReadFilter()).isEqualTo("id > 10");
+    assertThat(source.getOptions().getReadLimit()).isEqualTo(100L);
+    assertThat(source.getRowType()).isEqualTo(rowType);
+  }
+
+  @Test
+  @DisplayName("Test LanceSource Builder throws exception when path is missing")
+  void testLanceSourceBuilderMissingPath() {
+    assertThatThrownBy(() -> LanceSource.builder().rowType(rowType).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("path must not be empty");
+  }
+
+  @Test
+  @DisplayName("Test LanceSource serializers are not null")
+  void testLanceSourceSerializers() {
+    LanceOptions options = LanceOptions.builder().path(datasetPath).build();
+
+    LanceSource source = new LanceSource(options, rowType);
+
+    assertThat(source.getSplitSerializer()).isNotNull();
+    assertThat(source.getEnumeratorCheckpointSerializer()).isNotNull();
+    assertThat(source.getSplitSerializer()).isSameAs(LanceSourceSplitSerializer.INSTANCE);
+    assertThat(source.getEnumeratorCheckpointSerializer())
+        .isSameAs(LanceEnumeratorStateSerializer.INSTANCE);
+  }
+
+  // ==================== Integration Test: Using Real Dataset ====================
+
+  @Test
+  @DisplayName("Test split discovery with real Lance Dataset")
+  void testSplitDiscoveryWithRealDataset() throws Exception {
+    // Create test Dataset
+    String testDatasetPath = createTestDataset(10);
+
+    LanceOptions options = LanceOptions.builder().path(testDatasetPath).build();
+
+    // Create Source and verify serializers are accessible
+    LanceSource source = new LanceSource(options, rowType);
+    assertThat(source.getBoundedness()).isEqualTo(Boundedness.BOUNDED);
+    assertThat(source.getSplitSerializer()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("Test Split end-to-end serialization round trip")
+  void testSplitRoundTripSerialization() throws IOException {
+    // Create a series of Splits with different parameters
+    List<LanceSourceSplit> splits =
+        Arrays.asList(
+            new LanceSourceSplit(0, "/data/table1.lance", 0),
+            new LanceSourceSplit(
+                Integer.MAX_VALUE, "/very/long/path/to/dataset.lance", Long.MAX_VALUE),
+            new LanceSourceSplit(42, "/path/with spaces/and-dashes/data.lance", 999999));
+
+    LanceSourceSplitSerializer serializer = LanceSourceSplitSerializer.INSTANCE;
+
+    for (LanceSourceSplit original : splits) {
+      byte[] bytes = serializer.serialize(original);
+      LanceSourceSplit restored = serializer.deserialize(serializer.getVersion(), bytes);
+
+      assertThat(restored.getFragmentId()).isEqualTo(original.getFragmentId());
+      assertThat(restored.getDatasetPath()).isEqualTo(original.getDatasetPath());
+      assertThat(restored.getRowCount()).isEqualTo(original.getRowCount());
+      assertThat(restored.splitId()).isEqualTo(original.splitId());
+    }
+  }
+
+  @Test
+  @DisplayName("Test EnumeratorState end-to-end serialization round trip")
+  void testEnumeratorStateRoundTripSerialization() throws IOException {
+    // Create State with many Splits
+    List<LanceSourceSplit> splits = new ArrayList<>();
+    for (int i = 0; i < 100; i++) {
+      splits.add(new LanceSourceSplit(i, "/data/table_" + i + ".lance", i * 1000L));
     }
 
-    // ==================== LanceSourceSplit Tests ====================
+    LanceEnumeratorState original = new LanceEnumeratorState(splits);
+    LanceEnumeratorStateSerializer serializer = LanceEnumeratorStateSerializer.INSTANCE;
 
-    @Test
-    @DisplayName("Test LanceSourceSplit creation and properties")
-    void testSourceSplitCreation() {
-        LanceSourceSplit split = new LanceSourceSplit(1, datasetPath, 1000);
+    byte[] bytes = serializer.serialize(original);
+    LanceEnumeratorState restored = serializer.deserialize(serializer.getVersion(), bytes);
 
-        assertThat(split.getFragmentId()).isEqualTo(1);
-        assertThat(split.getDatasetPath()).isEqualTo(datasetPath);
-        assertThat(split.getRowCount()).isEqualTo(1000);
-        assertThat(split.splitId()).isEqualTo("lance-split-1");
+    assertThat(restored.getPendingSplits()).hasSize(100);
+    for (int i = 0; i < 100; i++) {
+      assertThat(restored.getPendingSplits().get(i)).isEqualTo(splits.get(i));
     }
+  }
 
-    @Test
-    @DisplayName("Test LanceSourceSplit equality")
-    void testSourceSplitEquality() {
-        LanceSourceSplit split1 = new LanceSourceSplit(1, datasetPath, 1000);
-        LanceSourceSplit split2 = new LanceSourceSplit(1, datasetPath, 1000);
-        LanceSourceSplit split3 = new LanceSourceSplit(2, datasetPath, 2000);
+  // ==================== Helper Methods ====================
 
-        assertThat(split1).isEqualTo(split2);
-        assertThat(split1.hashCode()).isEqualTo(split2.hashCode());
-        assertThat(split1).isNotEqualTo(split3);
+  /**
+   * Create a test Lance Dataset.
+   *
+   * @param rowCount Number of rows
+   * @return Dataset path
+   */
+  private String createTestDataset(int rowCount) throws Exception {
+    String path = tempDir.resolve("real_dataset.lance").toString();
+
+    Schema arrowSchema = LanceTypeConverter.toArrowSchema(rowType);
+    BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+
+    try {
+      VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator);
+      root.allocateNew();
+
+      BigIntVector idVector = (BigIntVector) root.getVector("id");
+      VarCharVector nameVector = (VarCharVector) root.getVector("name");
+
+      for (int i = 0; i < rowCount; i++) {
+        idVector.setSafe(i, i);
+        nameVector.setSafe(i, ("name_" + i).getBytes());
+      }
+      root.setRowCount(rowCount);
+
+      // Use Fragment.create + FragmentOperation.Overwrite.commit to create Dataset
+      WriteParams writeParams = new WriteParams.Builder().build();
+      List<FragmentMetadata> fragments = Fragment.create(path, allocator, root, writeParams);
+
+      FragmentOperation.Overwrite overwrite =
+          new FragmentOperation.Overwrite(fragments, arrowSchema);
+      Dataset dataset = overwrite.commit(allocator, path, Optional.empty(), Collections.emptyMap());
+      dataset.close();
+      root.close();
+
+      return path;
+    } finally {
+      allocator.close();
     }
-
-    @Test
-    @DisplayName("Test LanceSourceSplit does not allow null path")
-    void testSourceSplitNullPath() {
-        assertThatThrownBy(() -> new LanceSourceSplit(1, null, 1000))
-                .isInstanceOf(NullPointerException.class);
-    }
-
-    @Test
-    @DisplayName("Test LanceSourceSplit toString")
-    void testSourceSplitToString() {
-        LanceSourceSplit split = new LanceSourceSplit(1, "/test/path", 1000);
-        String str = split.toString();
-
-        assertThat(str).contains("fragmentId=1");
-        assertThat(str).contains("/test/path");
-        assertThat(str).contains("rowCount=1000");
-    }
-
-    // ==================== LanceSourceSplitSerializer Tests ====================
-
-    @Test
-    @DisplayName("Test Split serialize and deserialize")
-    void testSplitSerializeDeserialize() throws IOException {
-        LanceSourceSplit original = new LanceSourceSplit(5, datasetPath, 5000);
-
-        LanceSourceSplitSerializer serializer = LanceSourceSplitSerializer.INSTANCE;
-        byte[] serialized = serializer.serialize(original);
-
-        LanceSourceSplit deserialized = serializer.deserialize(serializer.getVersion(), serialized);
-
-        assertThat(deserialized).isEqualTo(original);
-        assertThat(deserialized.getFragmentId()).isEqualTo(5);
-        assertThat(deserialized.getDatasetPath()).isEqualTo(datasetPath);
-        assertThat(deserialized.getRowCount()).isEqualTo(5000);
-    }
-
-    @Test
-    @DisplayName("Test Split serializer version")
-    void testSplitSerializerVersion() {
-        assertThat(LanceSourceSplitSerializer.INSTANCE.getVersion()).isEqualTo(1);
-    }
-
-    @Test
-    @DisplayName("Test Split deserialization with unsupported version")
-    void testSplitDeserializeUnsupportedVersion() throws IOException {
-        LanceSourceSplit original = new LanceSourceSplit(1, datasetPath, 1000);
-        byte[] serialized = LanceSourceSplitSerializer.INSTANCE.serialize(original);
-
-        assertThatThrownBy(() ->
-                LanceSourceSplitSerializer.INSTANCE.deserialize(999, serialized))
-                .isInstanceOf(IOException.class)
-                .hasMessageContaining("Unsupported serialization version");
-    }
-
-    @Test
-    @DisplayName("Test multiple Splits serialization and deserialization")
-    void testMultipleSplitsSerialization() throws IOException {
-        List<LanceSourceSplit> originals = Arrays.asList(
-                new LanceSourceSplit(0, "/path/a", 100),
-                new LanceSourceSplit(1, "/path/b", 200),
-                new LanceSourceSplit(2, "/path/c", 300)
-        );
-
-        LanceSourceSplitSerializer serializer = LanceSourceSplitSerializer.INSTANCE;
-
-        for (LanceSourceSplit original : originals) {
-            byte[] serialized = serializer.serialize(original);
-            LanceSourceSplit deserialized = serializer.deserialize(serializer.getVersion(), serialized);
-            assertThat(deserialized).isEqualTo(original);
-        }
-    }
-
-    // ==================== LanceEnumeratorState Tests ====================
-
-    @Test
-    @DisplayName("Test EnumeratorState creation")
-    void testEnumeratorStateCreation() {
-        List<LanceSourceSplit> splits = Arrays.asList(
-                new LanceSourceSplit(0, datasetPath, 100),
-                new LanceSourceSplit(1, datasetPath, 200)
-        );
-
-        LanceEnumeratorState state = new LanceEnumeratorState(splits);
-
-        assertThat(state.getPendingSplits()).hasSize(2);
-        assertThat(state.getPendingSplits().get(0).getFragmentId()).isEqualTo(0);
-        assertThat(state.getPendingSplits().get(1).getFragmentId()).isEqualTo(1);
-    }
-
-    @Test
-    @DisplayName("Test EnumeratorState list is immutable")
-    void testEnumeratorStateImmutableList() {
-        List<LanceSourceSplit> splits = new ArrayList<>();
-        splits.add(new LanceSourceSplit(0, datasetPath, 100));
-
-        LanceEnumeratorState state = new LanceEnumeratorState(splits);
-
-        // Modifying original list should not affect state
-        splits.add(new LanceSourceSplit(1, datasetPath, 200));
-        assertThat(state.getPendingSplits()).hasSize(1);
-
-        // State's list should be unmodifiable
-        assertThatThrownBy(() ->
-                state.getPendingSplits().add(new LanceSourceSplit(2, datasetPath, 300)))
-                .isInstanceOf(UnsupportedOperationException.class);
-    }
-
-    @Test
-    @DisplayName("Test empty EnumeratorState")
-    void testEmptyEnumeratorState() {
-        LanceEnumeratorState state = new LanceEnumeratorState(Collections.emptyList());
-        assertThat(state.getPendingSplits()).isEmpty();
-    }
-
-    // ==================== LanceEnumeratorStateSerializer Tests ====================
-
-    @Test
-    @DisplayName("Test EnumeratorState serialize and deserialize")
-    void testEnumeratorStateSerializeDeserialize() throws IOException {
-        List<LanceSourceSplit> splits = Arrays.asList(
-                new LanceSourceSplit(0, "/path/a", 100),
-                new LanceSourceSplit(1, "/path/b", 200),
-                new LanceSourceSplit(2, "/path/c", 300)
-        );
-
-        LanceEnumeratorState original = new LanceEnumeratorState(splits);
-        LanceEnumeratorStateSerializer serializer = LanceEnumeratorStateSerializer.INSTANCE;
-
-        byte[] serialized = serializer.serialize(original);
-        LanceEnumeratorState deserialized = serializer.deserialize(serializer.getVersion(), serialized);
-
-        assertThat(deserialized.getPendingSplits()).hasSize(3);
-        assertThat(deserialized.getPendingSplits().get(0)).isEqualTo(splits.get(0));
-        assertThat(deserialized.getPendingSplits().get(1)).isEqualTo(splits.get(1));
-        assertThat(deserialized.getPendingSplits().get(2)).isEqualTo(splits.get(2));
-    }
-
-    @Test
-    @DisplayName("Test empty EnumeratorState serialize and deserialize")
-    void testEmptyEnumeratorStateSerializeDeserialize() throws IOException {
-        LanceEnumeratorState original = new LanceEnumeratorState(Collections.emptyList());
-        LanceEnumeratorStateSerializer serializer = LanceEnumeratorStateSerializer.INSTANCE;
-
-        byte[] serialized = serializer.serialize(original);
-        LanceEnumeratorState deserialized = serializer.deserialize(serializer.getVersion(), serialized);
-
-        assertThat(deserialized.getPendingSplits()).isEmpty();
-    }
-
-    @Test
-    @DisplayName("Test EnumeratorState serializer version")
-    void testEnumeratorStateSerializerVersion() {
-        assertThat(LanceEnumeratorStateSerializer.INSTANCE.getVersion()).isEqualTo(1);
-    }
-
-    @Test
-    @DisplayName("Test EnumeratorState deserialization with unsupported version")
-    void testEnumeratorStateDeserializeUnsupportedVersion() throws IOException {
-        LanceEnumeratorState original = new LanceEnumeratorState(Collections.emptyList());
-        byte[] serialized = LanceEnumeratorStateSerializer.INSTANCE.serialize(original);
-
-        assertThatThrownBy(() ->
-                LanceEnumeratorStateSerializer.INSTANCE.deserialize(999, serialized))
-                .isInstanceOf(IOException.class)
-                .hasMessageContaining("Unsupported serialization version");
-    }
-
-    // ==================== LanceSource Tests ====================
-
-    @Test
-    @DisplayName("Test LanceSource basic properties")
-    void testLanceSourceProperties() {
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .readBatchSize(512)
-                .build();
-
-        LanceSource source = new LanceSource(options, rowType);
-
-        assertThat(source.getOptions().getPath()).isEqualTo(datasetPath);
-        assertThat(source.getOptions().getReadBatchSize()).isEqualTo(512);
-        assertThat(source.getRowType()).isEqualTo(rowType);
-        assertThat(source.getBoundedness()).isEqualTo(Boundedness.BOUNDED);
-    }
-
-    @Test
-    @DisplayName("Test LanceSource auto-infer schema (no RowType)")
-    void testLanceSourceWithoutRowType() {
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .build();
-
-        LanceSource source = new LanceSource(options);
-
-        assertThat(source.getRowType()).isNull();
-        assertThat(source.getBoundedness()).isEqualTo(Boundedness.BOUNDED);
-    }
-
-    @Test
-    @DisplayName("Test LanceSource Builder pattern")
-    void testLanceSourceBuilder() {
-        LanceSource source = LanceSource.builder()
-                .path(datasetPath)
-                .batchSize(256)
-                .columns(Arrays.asList("id", "name"))
-                .filter("id > 10")
-                .limit(100L)
-                .rowType(rowType)
-                .build();
-
-        assertThat(source.getOptions().getPath()).isEqualTo(datasetPath);
-        assertThat(source.getOptions().getReadBatchSize()).isEqualTo(256);
-        assertThat(source.getOptions().getReadColumns()).containsExactly("id", "name");
-        assertThat(source.getOptions().getReadFilter()).isEqualTo("id > 10");
-        assertThat(source.getOptions().getReadLimit()).isEqualTo(100L);
-        assertThat(source.getRowType()).isEqualTo(rowType);
-    }
-
-    @Test
-    @DisplayName("Test LanceSource Builder throws exception when path is missing")
-    void testLanceSourceBuilderMissingPath() {
-        assertThatThrownBy(() -> LanceSource.builder()
-                .rowType(rowType)
-                .build())
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("path must not be empty");
-    }
-
-    @Test
-    @DisplayName("Test LanceSource serializers are not null")
-    void testLanceSourceSerializers() {
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .build();
-
-        LanceSource source = new LanceSource(options, rowType);
-
-        assertThat(source.getSplitSerializer()).isNotNull();
-        assertThat(source.getEnumeratorCheckpointSerializer()).isNotNull();
-        assertThat(source.getSplitSerializer()).isSameAs(LanceSourceSplitSerializer.INSTANCE);
-        assertThat(source.getEnumeratorCheckpointSerializer()).isSameAs(LanceEnumeratorStateSerializer.INSTANCE);
-    }
-
-    // ==================== Integration Test: Using Real Dataset ====================
-
-    @Test
-    @DisplayName("Test split discovery with real Lance Dataset")
-    void testSplitDiscoveryWithRealDataset() throws Exception {
-        // Create test Dataset
-        String testDatasetPath = createTestDataset(10);
-
-        LanceOptions options = LanceOptions.builder()
-                .path(testDatasetPath)
-                .build();
-
-        // Create Source and verify serializers are accessible
-        LanceSource source = new LanceSource(options, rowType);
-        assertThat(source.getBoundedness()).isEqualTo(Boundedness.BOUNDED);
-        assertThat(source.getSplitSerializer()).isNotNull();
-    }
-
-    @Test
-    @DisplayName("Test Split end-to-end serialization round trip")
-    void testSplitRoundTripSerialization() throws IOException {
-        // Create a series of Splits with different parameters
-        List<LanceSourceSplit> splits = Arrays.asList(
-                new LanceSourceSplit(0, "/data/table1.lance", 0),
-                new LanceSourceSplit(Integer.MAX_VALUE, "/very/long/path/to/dataset.lance", Long.MAX_VALUE),
-                new LanceSourceSplit(42, "/path/with spaces/and-dashes/data.lance", 999999)
-        );
-
-        LanceSourceSplitSerializer serializer = LanceSourceSplitSerializer.INSTANCE;
-
-        for (LanceSourceSplit original : splits) {
-            byte[] bytes = serializer.serialize(original);
-            LanceSourceSplit restored = serializer.deserialize(serializer.getVersion(), bytes);
-
-            assertThat(restored.getFragmentId()).isEqualTo(original.getFragmentId());
-            assertThat(restored.getDatasetPath()).isEqualTo(original.getDatasetPath());
-            assertThat(restored.getRowCount()).isEqualTo(original.getRowCount());
-            assertThat(restored.splitId()).isEqualTo(original.splitId());
-        }
-    }
-
-    @Test
-    @DisplayName("Test EnumeratorState end-to-end serialization round trip")
-    void testEnumeratorStateRoundTripSerialization() throws IOException {
-        // Create State with many Splits
-        List<LanceSourceSplit> splits = new ArrayList<>();
-        for (int i = 0; i < 100; i++) {
-            splits.add(new LanceSourceSplit(i, "/data/table_" + i + ".lance", i * 1000L));
-        }
-
-        LanceEnumeratorState original = new LanceEnumeratorState(splits);
-        LanceEnumeratorStateSerializer serializer = LanceEnumeratorStateSerializer.INSTANCE;
-
-        byte[] bytes = serializer.serialize(original);
-        LanceEnumeratorState restored = serializer.deserialize(serializer.getVersion(), bytes);
-
-        assertThat(restored.getPendingSplits()).hasSize(100);
-        for (int i = 0; i < 100; i++) {
-            assertThat(restored.getPendingSplits().get(i)).isEqualTo(splits.get(i));
-        }
-    }
-
-    // ==================== Helper Methods ====================
-
-    /**
-     * Create a test Lance Dataset.
-     *
-     * @param rowCount Number of rows
-     * @return Dataset path
-     */
-    private String createTestDataset(int rowCount) throws Exception {
-        String path = tempDir.resolve("real_dataset.lance").toString();
-
-        Schema arrowSchema = LanceTypeConverter.toArrowSchema(rowType);
-        BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-
-        try {
-            VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator);
-            root.allocateNew();
-
-            BigIntVector idVector = (BigIntVector) root.getVector("id");
-            VarCharVector nameVector = (VarCharVector) root.getVector("name");
-
-            for (int i = 0; i < rowCount; i++) {
-                idVector.setSafe(i, i);
-                nameVector.setSafe(i, ("name_" + i).getBytes());
-            }
-            root.setRowCount(rowCount);
-
-            // Use Fragment.create + FragmentOperation.Overwrite.commit to create Dataset
-            WriteParams writeParams = new WriteParams.Builder().build();
-            List<FragmentMetadata> fragments = Fragment.create(path, allocator, root, writeParams);
-
-            FragmentOperation.Overwrite overwrite = new FragmentOperation.Overwrite(fragments, arrowSchema);
-            Dataset dataset = overwrite.commit(allocator, path, Optional.empty(), Collections.emptyMap());
-            dataset.close();
-            root.close();
-
-            return path;
-        } finally {
-            allocator.close();
-        }
-    }
+  }
 }

--- a/src/test/java/org/apache/flink/connector/lance/source/LanceSourceV2Test.java
+++ b/src/test/java/org/apache/flink/connector/lance/source/LanceSourceV2Test.java
@@ -1,0 +1,461 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.lance.source;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.connector.lance.config.LanceOptions;
+import org.apache.flink.connector.lance.converter.LanceTypeConverter;
+import org.apache.flink.connector.lance.converter.RowDataConverter;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import com.lancedb.lance.Dataset;
+import com.lancedb.lance.Fragment;
+import com.lancedb.lance.FragmentMetadata;
+import com.lancedb.lance.FragmentOperation;
+import com.lancedb.lance.WriteParams;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Lance Source V2 unit tests.
+ *
+ * <p>Tests various components of the Source V2 API implementation, including:
+ * <ul>
+ *   <li>{@link LanceSourceSplit} - Split model</li>
+ *   <li>{@link LanceSourceSplitSerializer} - Split serialization</li>
+ *   <li>{@link LanceEnumeratorState} - Enumerator state</li>
+ *   <li>{@link LanceEnumeratorStateSerializer} - State serialization</li>
+ *   <li>{@link LanceSource} - Source entry point</li>
+ * </ul>
+ */
+class LanceSourceV2Test {
+
+    @TempDir
+    Path tempDir;
+
+    private String datasetPath;
+    private RowType rowType;
+
+    @BeforeEach
+    void setUp() {
+        datasetPath = tempDir.resolve("test_dataset.lance").toString();
+
+        // Create test RowType
+        List<RowType.RowField> fields = new ArrayList<>();
+        fields.add(new RowType.RowField("id", new BigIntType()));
+        fields.add(new RowType.RowField("name", new VarCharType()));
+        rowType = new RowType(fields);
+    }
+
+    // ==================== LanceSourceSplit Tests ====================
+
+    @Test
+    @DisplayName("Test LanceSourceSplit creation and properties")
+    void testSourceSplitCreation() {
+        LanceSourceSplit split = new LanceSourceSplit(1, datasetPath, 1000);
+
+        assertThat(split.getFragmentId()).isEqualTo(1);
+        assertThat(split.getDatasetPath()).isEqualTo(datasetPath);
+        assertThat(split.getRowCount()).isEqualTo(1000);
+        assertThat(split.splitId()).isEqualTo("lance-split-1");
+    }
+
+    @Test
+    @DisplayName("Test LanceSourceSplit equality")
+    void testSourceSplitEquality() {
+        LanceSourceSplit split1 = new LanceSourceSplit(1, datasetPath, 1000);
+        LanceSourceSplit split2 = new LanceSourceSplit(1, datasetPath, 1000);
+        LanceSourceSplit split3 = new LanceSourceSplit(2, datasetPath, 2000);
+
+        assertThat(split1).isEqualTo(split2);
+        assertThat(split1.hashCode()).isEqualTo(split2.hashCode());
+        assertThat(split1).isNotEqualTo(split3);
+    }
+
+    @Test
+    @DisplayName("Test LanceSourceSplit does not allow null path")
+    void testSourceSplitNullPath() {
+        assertThatThrownBy(() -> new LanceSourceSplit(1, null, 1000))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @DisplayName("Test LanceSourceSplit toString")
+    void testSourceSplitToString() {
+        LanceSourceSplit split = new LanceSourceSplit(1, "/test/path", 1000);
+        String str = split.toString();
+
+        assertThat(str).contains("fragmentId=1");
+        assertThat(str).contains("/test/path");
+        assertThat(str).contains("rowCount=1000");
+    }
+
+    // ==================== LanceSourceSplitSerializer Tests ====================
+
+    @Test
+    @DisplayName("Test Split serialize and deserialize")
+    void testSplitSerializeDeserialize() throws IOException {
+        LanceSourceSplit original = new LanceSourceSplit(5, datasetPath, 5000);
+
+        LanceSourceSplitSerializer serializer = LanceSourceSplitSerializer.INSTANCE;
+        byte[] serialized = serializer.serialize(original);
+
+        LanceSourceSplit deserialized = serializer.deserialize(serializer.getVersion(), serialized);
+
+        assertThat(deserialized).isEqualTo(original);
+        assertThat(deserialized.getFragmentId()).isEqualTo(5);
+        assertThat(deserialized.getDatasetPath()).isEqualTo(datasetPath);
+        assertThat(deserialized.getRowCount()).isEqualTo(5000);
+    }
+
+    @Test
+    @DisplayName("Test Split serializer version")
+    void testSplitSerializerVersion() {
+        assertThat(LanceSourceSplitSerializer.INSTANCE.getVersion()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Test Split deserialization with unsupported version")
+    void testSplitDeserializeUnsupportedVersion() throws IOException {
+        LanceSourceSplit original = new LanceSourceSplit(1, datasetPath, 1000);
+        byte[] serialized = LanceSourceSplitSerializer.INSTANCE.serialize(original);
+
+        assertThatThrownBy(() ->
+                LanceSourceSplitSerializer.INSTANCE.deserialize(999, serialized))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Unsupported serialization version");
+    }
+
+    @Test
+    @DisplayName("Test multiple Splits serialization and deserialization")
+    void testMultipleSplitsSerialization() throws IOException {
+        List<LanceSourceSplit> originals = Arrays.asList(
+                new LanceSourceSplit(0, "/path/a", 100),
+                new LanceSourceSplit(1, "/path/b", 200),
+                new LanceSourceSplit(2, "/path/c", 300)
+        );
+
+        LanceSourceSplitSerializer serializer = LanceSourceSplitSerializer.INSTANCE;
+
+        for (LanceSourceSplit original : originals) {
+            byte[] serialized = serializer.serialize(original);
+            LanceSourceSplit deserialized = serializer.deserialize(serializer.getVersion(), serialized);
+            assertThat(deserialized).isEqualTo(original);
+        }
+    }
+
+    // ==================== LanceEnumeratorState Tests ====================
+
+    @Test
+    @DisplayName("Test EnumeratorState creation")
+    void testEnumeratorStateCreation() {
+        List<LanceSourceSplit> splits = Arrays.asList(
+                new LanceSourceSplit(0, datasetPath, 100),
+                new LanceSourceSplit(1, datasetPath, 200)
+        );
+
+        LanceEnumeratorState state = new LanceEnumeratorState(splits);
+
+        assertThat(state.getPendingSplits()).hasSize(2);
+        assertThat(state.getPendingSplits().get(0).getFragmentId()).isEqualTo(0);
+        assertThat(state.getPendingSplits().get(1).getFragmentId()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Test EnumeratorState list is immutable")
+    void testEnumeratorStateImmutableList() {
+        List<LanceSourceSplit> splits = new ArrayList<>();
+        splits.add(new LanceSourceSplit(0, datasetPath, 100));
+
+        LanceEnumeratorState state = new LanceEnumeratorState(splits);
+
+        // Modifying original list should not affect state
+        splits.add(new LanceSourceSplit(1, datasetPath, 200));
+        assertThat(state.getPendingSplits()).hasSize(1);
+
+        // State's list should be unmodifiable
+        assertThatThrownBy(() ->
+                state.getPendingSplits().add(new LanceSourceSplit(2, datasetPath, 300)))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @DisplayName("Test empty EnumeratorState")
+    void testEmptyEnumeratorState() {
+        LanceEnumeratorState state = new LanceEnumeratorState(Collections.emptyList());
+        assertThat(state.getPendingSplits()).isEmpty();
+    }
+
+    // ==================== LanceEnumeratorStateSerializer Tests ====================
+
+    @Test
+    @DisplayName("Test EnumeratorState serialize and deserialize")
+    void testEnumeratorStateSerializeDeserialize() throws IOException {
+        List<LanceSourceSplit> splits = Arrays.asList(
+                new LanceSourceSplit(0, "/path/a", 100),
+                new LanceSourceSplit(1, "/path/b", 200),
+                new LanceSourceSplit(2, "/path/c", 300)
+        );
+
+        LanceEnumeratorState original = new LanceEnumeratorState(splits);
+        LanceEnumeratorStateSerializer serializer = LanceEnumeratorStateSerializer.INSTANCE;
+
+        byte[] serialized = serializer.serialize(original);
+        LanceEnumeratorState deserialized = serializer.deserialize(serializer.getVersion(), serialized);
+
+        assertThat(deserialized.getPendingSplits()).hasSize(3);
+        assertThat(deserialized.getPendingSplits().get(0)).isEqualTo(splits.get(0));
+        assertThat(deserialized.getPendingSplits().get(1)).isEqualTo(splits.get(1));
+        assertThat(deserialized.getPendingSplits().get(2)).isEqualTo(splits.get(2));
+    }
+
+    @Test
+    @DisplayName("Test empty EnumeratorState serialize and deserialize")
+    void testEmptyEnumeratorStateSerializeDeserialize() throws IOException {
+        LanceEnumeratorState original = new LanceEnumeratorState(Collections.emptyList());
+        LanceEnumeratorStateSerializer serializer = LanceEnumeratorStateSerializer.INSTANCE;
+
+        byte[] serialized = serializer.serialize(original);
+        LanceEnumeratorState deserialized = serializer.deserialize(serializer.getVersion(), serialized);
+
+        assertThat(deserialized.getPendingSplits()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Test EnumeratorState serializer version")
+    void testEnumeratorStateSerializerVersion() {
+        assertThat(LanceEnumeratorStateSerializer.INSTANCE.getVersion()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Test EnumeratorState deserialization with unsupported version")
+    void testEnumeratorStateDeserializeUnsupportedVersion() throws IOException {
+        LanceEnumeratorState original = new LanceEnumeratorState(Collections.emptyList());
+        byte[] serialized = LanceEnumeratorStateSerializer.INSTANCE.serialize(original);
+
+        assertThatThrownBy(() ->
+                LanceEnumeratorStateSerializer.INSTANCE.deserialize(999, serialized))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Unsupported serialization version");
+    }
+
+    // ==================== LanceSource Tests ====================
+
+    @Test
+    @DisplayName("Test LanceSource basic properties")
+    void testLanceSourceProperties() {
+        LanceOptions options = LanceOptions.builder()
+                .path(datasetPath)
+                .readBatchSize(512)
+                .build();
+
+        LanceSource source = new LanceSource(options, rowType);
+
+        assertThat(source.getOptions().getPath()).isEqualTo(datasetPath);
+        assertThat(source.getOptions().getReadBatchSize()).isEqualTo(512);
+        assertThat(source.getRowType()).isEqualTo(rowType);
+        assertThat(source.getBoundedness()).isEqualTo(Boundedness.BOUNDED);
+    }
+
+    @Test
+    @DisplayName("Test LanceSource auto-infer schema (no RowType)")
+    void testLanceSourceWithoutRowType() {
+        LanceOptions options = LanceOptions.builder()
+                .path(datasetPath)
+                .build();
+
+        LanceSource source = new LanceSource(options);
+
+        assertThat(source.getRowType()).isNull();
+        assertThat(source.getBoundedness()).isEqualTo(Boundedness.BOUNDED);
+    }
+
+    @Test
+    @DisplayName("Test LanceSource Builder pattern")
+    void testLanceSourceBuilder() {
+        LanceSource source = LanceSource.builder()
+                .path(datasetPath)
+                .batchSize(256)
+                .columns(Arrays.asList("id", "name"))
+                .filter("id > 10")
+                .limit(100L)
+                .rowType(rowType)
+                .build();
+
+        assertThat(source.getOptions().getPath()).isEqualTo(datasetPath);
+        assertThat(source.getOptions().getReadBatchSize()).isEqualTo(256);
+        assertThat(source.getOptions().getReadColumns()).containsExactly("id", "name");
+        assertThat(source.getOptions().getReadFilter()).isEqualTo("id > 10");
+        assertThat(source.getOptions().getReadLimit()).isEqualTo(100L);
+        assertThat(source.getRowType()).isEqualTo(rowType);
+    }
+
+    @Test
+    @DisplayName("Test LanceSource Builder throws exception when path is missing")
+    void testLanceSourceBuilderMissingPath() {
+        assertThatThrownBy(() -> LanceSource.builder()
+                .rowType(rowType)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("path must not be empty");
+    }
+
+    @Test
+    @DisplayName("Test LanceSource serializers are not null")
+    void testLanceSourceSerializers() {
+        LanceOptions options = LanceOptions.builder()
+                .path(datasetPath)
+                .build();
+
+        LanceSource source = new LanceSource(options, rowType);
+
+        assertThat(source.getSplitSerializer()).isNotNull();
+        assertThat(source.getEnumeratorCheckpointSerializer()).isNotNull();
+        assertThat(source.getSplitSerializer()).isSameAs(LanceSourceSplitSerializer.INSTANCE);
+        assertThat(source.getEnumeratorCheckpointSerializer()).isSameAs(LanceEnumeratorStateSerializer.INSTANCE);
+    }
+
+    // ==================== Integration Test: Using Real Dataset ====================
+
+    @Test
+    @DisplayName("Test split discovery with real Lance Dataset")
+    void testSplitDiscoveryWithRealDataset() throws Exception {
+        // Create test Dataset
+        String testDatasetPath = createTestDataset(10);
+
+        LanceOptions options = LanceOptions.builder()
+                .path(testDatasetPath)
+                .build();
+
+        // Create Source and verify serializers are accessible
+        LanceSource source = new LanceSource(options, rowType);
+        assertThat(source.getBoundedness()).isEqualTo(Boundedness.BOUNDED);
+        assertThat(source.getSplitSerializer()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Test Split end-to-end serialization round trip")
+    void testSplitRoundTripSerialization() throws IOException {
+        // Create a series of Splits with different parameters
+        List<LanceSourceSplit> splits = Arrays.asList(
+                new LanceSourceSplit(0, "/data/table1.lance", 0),
+                new LanceSourceSplit(Integer.MAX_VALUE, "/very/long/path/to/dataset.lance", Long.MAX_VALUE),
+                new LanceSourceSplit(42, "/path/with spaces/and-dashes/data.lance", 999999)
+        );
+
+        LanceSourceSplitSerializer serializer = LanceSourceSplitSerializer.INSTANCE;
+
+        for (LanceSourceSplit original : splits) {
+            byte[] bytes = serializer.serialize(original);
+            LanceSourceSplit restored = serializer.deserialize(serializer.getVersion(), bytes);
+
+            assertThat(restored.getFragmentId()).isEqualTo(original.getFragmentId());
+            assertThat(restored.getDatasetPath()).isEqualTo(original.getDatasetPath());
+            assertThat(restored.getRowCount()).isEqualTo(original.getRowCount());
+            assertThat(restored.splitId()).isEqualTo(original.splitId());
+        }
+    }
+
+    @Test
+    @DisplayName("Test EnumeratorState end-to-end serialization round trip")
+    void testEnumeratorStateRoundTripSerialization() throws IOException {
+        // Create State with many Splits
+        List<LanceSourceSplit> splits = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            splits.add(new LanceSourceSplit(i, "/data/table_" + i + ".lance", i * 1000L));
+        }
+
+        LanceEnumeratorState original = new LanceEnumeratorState(splits);
+        LanceEnumeratorStateSerializer serializer = LanceEnumeratorStateSerializer.INSTANCE;
+
+        byte[] bytes = serializer.serialize(original);
+        LanceEnumeratorState restored = serializer.deserialize(serializer.getVersion(), bytes);
+
+        assertThat(restored.getPendingSplits()).hasSize(100);
+        for (int i = 0; i < 100; i++) {
+            assertThat(restored.getPendingSplits().get(i)).isEqualTo(splits.get(i));
+        }
+    }
+
+    // ==================== Helper Methods ====================
+
+    /**
+     * Create a test Lance Dataset.
+     *
+     * @param rowCount Number of rows
+     * @return Dataset path
+     */
+    private String createTestDataset(int rowCount) throws Exception {
+        String path = tempDir.resolve("real_dataset.lance").toString();
+
+        Schema arrowSchema = LanceTypeConverter.toArrowSchema(rowType);
+        BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+
+        try {
+            VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator);
+            root.allocateNew();
+
+            BigIntVector idVector = (BigIntVector) root.getVector("id");
+            VarCharVector nameVector = (VarCharVector) root.getVector("name");
+
+            for (int i = 0; i < rowCount; i++) {
+                idVector.setSafe(i, i);
+                nameVector.setSafe(i, ("name_" + i).getBytes());
+            }
+            root.setRowCount(rowCount);
+
+            // Use Fragment.create + FragmentOperation.Overwrite.commit to create Dataset
+            WriteParams writeParams = new WriteParams.Builder().build();
+            List<FragmentMetadata> fragments = Fragment.create(path, allocator, root, writeParams);
+
+            FragmentOperation.Overwrite overwrite = new FragmentOperation.Overwrite(fragments, arrowSchema);
+            Dataset dataset = overwrite.commit(allocator, path, Optional.empty(), Collections.emptyMap());
+            dataset.close();
+            root.close();
+
+            return path;
+        } finally {
+            allocator.close();
+        }
+    }
+}

--- a/src/test/java/org/apache/flink/connector/lance/table/FlinkSqlDemo.java
+++ b/src/test/java/org/apache/flink/connector/lance/table/FlinkSqlDemo.java
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Flink SQL complete demo test script.
- * 
+ *
  * <p>This test demonstrates how to use Flink SQL to operate Lance datasets:
  * <ul>
  *   <li>Create Lance Catalog</li>
@@ -65,7 +65,7 @@ class FlinkSqlDemo {
                 .inBatchMode()
                 .build();
         tableEnv = TableEnvironment.create(settings);
-        
+
         // Set paths
         warehousePath = tempDir.resolve("lance_warehouse").toString();
         datasetPath = tempDir.resolve("lance_dataset").toString();
@@ -97,11 +97,11 @@ class FlinkSqlDemo {
             "    'write.batch-size' = '1024',\n" +
             "    'write.mode' = 'overwrite'\n" +
             ")", datasetPath);
-        
+
         System.out.println("========== Create Lance Table ==========");
         System.out.println(createTableSql);
         System.out.println();
-        
+
         tableEnv.executeSql(createTableSql);
         System.out.println("✅ Table created successfully!\n");
     }
@@ -122,22 +122,22 @@ class FlinkSqlDemo {
             "    'path' = '%s',\n" +
             "    'write.mode' = 'overwrite'\n" +
             ")", path.resolve("lance-db1"));
-        
+
         tableEnv.executeSql(createTableSql);
-        
+
         // Insert data
-        String insertSql = 
+        String insertSql =
             "INSERT INTO lance_documents VALUES\n" +
             "    (1, 'Introduction to AI', ARRAY[0.1, 0.2, 0.3, 0.4]),\n" +
             "    (2, 'Machine Learning Guide', ARRAY[0.2, 0.3, 0.4, 0.5]),\n" +
             "    (3, 'Deep Learning Basics', ARRAY[0.3, 0.4, 0.5, 0.6]),\n" +
             "    (4, 'Neural Networks', ARRAY[0.4, 0.5, 0.6, 0.7]),\n" +
             "    (5, 'Computer Vision', ARRAY[0.5, 0.6, 0.7, 0.8])";
-        
+
         System.out.println("========== Insert Vector Data ==========");
         System.out.println(insertSql);
         System.out.println();
-        
+
         TableResult result = tableEnv.executeSql(insertSql);
         result.await(30, TimeUnit.SECONDS);
         System.out.println("✅ Data inserted successfully!\n");
@@ -147,7 +147,7 @@ class FlinkSqlDemo {
     @DisplayName("3. Query Lance Table Data")
     void testSelectData() throws Exception {
         // Create source table (for generating test data)
-        String createSourceSql = 
+        String createSourceSql =
             "CREATE TABLE test_source (\n" +
             "    id BIGINT,\n" +
             "    name STRING\n" +
@@ -159,16 +159,16 @@ class FlinkSqlDemo {
             "    'fields.id.start' = '1',\n" +
             "    'fields.id.end' = '10'\n" +
             ")";
-        
+
         tableEnv.executeSql(createSourceSql);
-        
+
         // Query data
         String selectSql = "SELECT id, name FROM test_source LIMIT 5";
-        
+
         System.out.println("========== Query Data ==========");
         System.out.println(selectSql);
         System.out.println();
-        
+
         TableResult result = tableEnv.executeSql(selectSql);
         result.print();
         System.out.println("✅ Query completed!\n");
@@ -201,11 +201,11 @@ class FlinkSqlDemo {
             "    'vector.metric' = 'L2',\n" +
             "    'vector.nprobes' = '20'\n" +
             ")", datasetPath);
-        
+
         System.out.println("========== Create Table with Index Configuration ==========");
         System.out.println(createTableSql);
         System.out.println();
-        
+
         tableEnv.executeSql(createTableSql);
         System.out.println("✅ Table created successfully!\n");
     }
@@ -214,34 +214,34 @@ class FlinkSqlDemo {
     @DisplayName("5. Different Index Type Configuration Examples")
     void testDifferentIndexTypes() {
         System.out.println("========== Index Type Configuration Examples ==========\n");
-        
+
         // IVF_PQ index (recommended, balances accuracy and speed)
-        String ivfPqConfig = 
+        String ivfPqConfig =
             "-- IVF_PQ index configuration (recommended for large-scale vector data)\n" +
             "'index.type' = 'IVF_PQ',\n" +
             "'index.num-partitions' = '256',      -- Number of cluster centers\n" +
             "'index.num-sub-vectors' = '16',      -- Number of sub-vectors\n" +
             "'index.num-bits' = '8'               -- Quantization bits per sub-vector\n";
-        
+
         System.out.println(ivfPqConfig);
-        
+
         // IVF_HNSW index (high accuracy)
-        String ivfHnswConfig = 
+        String ivfHnswConfig =
             "-- IVF_HNSW index configuration (for high accuracy scenarios)\n" +
             "'index.type' = 'IVF_HNSW',\n" +
             "'index.num-partitions' = '256',\n" +
             "'index.max-level' = '7',             -- HNSW max level\n" +
             "'index.m' = '16',                    -- HNSW connections per level\n" +
             "'index.ef-construction' = '100'      -- ef parameter during construction\n";
-        
+
         System.out.println(ivfHnswConfig);
-        
+
         // IVF_FLAT index (highest accuracy, suitable for small datasets)
-        String ivfFlatConfig = 
+        String ivfFlatConfig =
             "-- IVF_FLAT index configuration (for small-scale datasets)\n" +
             "'index.type' = 'IVF_FLAT',\n" +
             "'index.num-partitions' = '64'        -- Number of cluster centers\n";
-        
+
         System.out.println(ivfFlatConfig);
         System.out.println("✅ Configuration examples displayed!\n");
     }
@@ -250,25 +250,25 @@ class FlinkSqlDemo {
     @DisplayName("6. Distance Metric Type Configuration Examples")
     void testMetricTypes() {
         System.out.println("========== Distance Metric Type Examples ==========\n");
-        
-        String l2Config = 
+
+        String l2Config =
             "-- L2 distance (Euclidean distance, default)\n" +
             "'vector.metric' = 'L2'\n" +
             "-- Suitable for: General vector search\n";
         System.out.println(l2Config);
-        
-        String cosineConfig = 
+
+        String cosineConfig =
             "-- Cosine distance (Cosine similarity)\n" +
             "'vector.metric' = 'COSINE'\n" +
             "-- Suitable for: Text semantic similarity\n";
         System.out.println(cosineConfig);
-        
-        String dotConfig = 
+
+        String dotConfig =
             "-- Dot distance (Dot product)\n" +
             "'vector.metric' = 'DOT'\n" +
             "-- Suitable for: Already normalized vectors\n";
         System.out.println(dotConfig);
-        
+
         System.out.println("✅ Configuration examples displayed!\n");
     }
 
@@ -283,21 +283,21 @@ class FlinkSqlDemo {
             "    'warehouse' = '%s',\n" +
             "    'default-database' = 'default'\n" +
             ")", warehousePath);
-        
+
         System.out.println("========== Create Lance Catalog ==========");
         System.out.println(createCatalogSql);
         System.out.println();
-        
+
         tableEnv.executeSql(createCatalogSql);
-        
+
         // Use Catalog
         tableEnv.executeSql("USE CATALOG lance_catalog");
         System.out.println("✅ Catalog created and switched!\n");
-        
+
         // Create database
         tableEnv.executeSql("CREATE DATABASE IF NOT EXISTS vector_db");
         System.out.println("✅ Database vector_db created!\n");
-        
+
         // List databases
         System.out.println("Database list:");
         tableEnv.executeSql("SHOW DATABASES").print();
@@ -312,9 +312,9 @@ class FlinkSqlDemo {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);
         StreamTableEnvironment streamTableEnv = StreamTableEnvironment.create(env);
-        
+
         // Create data generator table (simulating real-time data)
-        String createSourceSql = 
+        String createSourceSql =
             "CREATE TABLE realtime_events (\n" +
             "    event_id BIGINT,\n" +
             "    event_type STRING,\n" +
@@ -328,7 +328,7 @@ class FlinkSqlDemo {
             "    'fields.event_id.end' = '100',\n" +
             "    'fields.event_type.length' = '10'\n" +
             ")";
-        
+
         // Create Lance Sink table
         String createSinkSql = String.format(
             "CREATE TABLE lance_events (\n" +
@@ -340,23 +340,23 @@ class FlinkSqlDemo {
             "    'write.batch-size' = '100',\n" +
             "    'write.mode' = 'append'\n" +
             ")", datasetPath);
-        
+
         System.out.println("========== Streaming Write Example ==========");
         System.out.println("-- Source table definition");
         System.out.println(createSourceSql);
         System.out.println("\n-- Sink table definition");
         System.out.println(createSinkSql);
         System.out.println();
-        
+
         streamTableEnv.executeSql(createSourceSql);
         streamTableEnv.executeSql(createSinkSql);
-        
+
         // Execute streaming write
         String insertSql = "INSERT INTO lance_events SELECT event_id, event_type FROM realtime_events";
         System.out.println("-- Streaming insert statement");
         System.out.println(insertSql);
         System.out.println();
-        
+
         System.out.println("✅ Streaming write configuration completed!\n");
     }
 
@@ -368,7 +368,7 @@ class FlinkSqlDemo {
         // Use relative path based on project root
         Path path = Paths.get(System.getProperty("user.dir"), "test-data");
         System.out.println("========== Complete Vector Storage and Search Example ==========\n");
-        
+
         // 1. Create vector table
         String createTableSql = String.format(
             "-- 1. Create vector storage table\n" +
@@ -395,13 +395,13 @@ class FlinkSqlDemo {
             "    'vector.metric' = 'COSINE',\n" +
             "    'vector.nprobes' = '10'\n" +
             ")", path.resolve("lance-db3"));
-        
+
         System.out.println(createTableSql);
         System.out.println();
         tableEnv.executeSql(createTableSql);
-        
+
         // 2. Insert test data
-        String insertSql = 
+        String insertSql =
             "-- 2. Insert vector data\n" +
             "INSERT INTO document_vectors VALUES\n" +
             "    (1, 'Flink Getting Started Guide', 'Introduction to Apache Flink basics...', \n" +
@@ -414,20 +414,20 @@ class FlinkSqlDemo {
             "     ARRAY[0.4, 0.5, 0.6, 0.7], 'format', TIMESTAMP '2024-01-04 13:00:00'),\n" +
             "    (5, 'SQL Connector Development', 'How to develop Flink SQL connectors...', \n" +
             "     ARRAY[0.5, 0.6, 0.7, 0.8], 'development', TIMESTAMP '2024-01-05 14:00:00')";
-        
+
         System.out.println(insertSql);
         System.out.println();
         TableResult result = tableEnv.executeSql(insertSql);
         result.await(30, TimeUnit.SECONDS);
-        
+
         // 3. Query data
-        String selectSql = 
+        String selectSql =
             "-- 3. Query vector data\n" +
             "SELECT doc_id, title, category, create_time\n" +
             "FROM document_vectors\n" +
             "WHERE category = 'tutorial'\n" +
             "ORDER BY create_time DESC";
-        
+
         System.out.println(selectSql);
         System.out.println();
         TableResult tableResult = tableEnv.executeSql(selectSql);
@@ -438,13 +438,13 @@ class FlinkSqlDemo {
         }
 
         // 4. Aggregation query
-        String aggSql = 
+        String aggSql =
             "-- 4. Count documents by category\n" +
             "SELECT category, COUNT(*) as doc_count\n" +
             "FROM document_vectors\n" +
             "GROUP BY category\n" +
             "ORDER BY doc_count DESC";
-        
+
         System.out.println(aggSql);
         System.out.println();
         tableEnv.executeSql(aggSql).print();
@@ -456,11 +456,11 @@ class FlinkSqlDemo {
     @DisplayName("9.1 Vector Search IVF_PQ Index Example")
     void testVectorSearchWithIvfPq() throws Exception {
         System.out.println("========== Vector Search IVF_PQ Index Example ==========");
-        
+
         // Use relative path based on project root
         Path basePath = Paths.get(System.getProperty("user.dir"), "test-data");
         String datasetPath = basePath.resolve("lance-vector-search").toString();
-        
+
         // ============================================
         // Step 1: Create vector table with IVF_PQ index configuration
         // ============================================
@@ -484,42 +484,42 @@ class FlinkSqlDemo {
             "    'vector.metric' = 'L2',\n" +
             "    'vector.nprobes' = '10'\n" +
             ")", datasetPath);
-        
+
         System.out.println("-- Step 1: Create vector table with IVF_PQ index configuration");
         System.out.println(createTableSql);
         System.out.println();
         tableEnv.executeSql(createTableSql);
-        
+
         // ============================================
         // Step 2: Insert vector data
         // ============================================
-        String insertSql = 
+        String insertSql =
             "INSERT INTO vector_documents VALUES\n" +
             "    (1, 'Flink Stream Processing', ARRAY[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]),\n" +
             "    (2, 'Spark Batch Processing', ARRAY[0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]),\n" +
             "    (3, 'Kafka Message Queue', ARRAY[0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1]),\n" +
             "    (4, 'Vector Database', ARRAY[0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85]),\n" +
             "    (5, 'Machine Learning Basics', ARRAY[0.12, 0.22, 0.32, 0.42, 0.52, 0.62, 0.72, 0.82])";
-        
+
         System.out.println("-- Step 2: Insert vector data");
         System.out.println(insertSql);
         System.out.println();
         tableEnv.executeSql(insertSql).await(30, TimeUnit.SECONDS);
         System.out.println("✅ Data insertion completed\n");
-        
+
         // ============================================
         // Step 3: Register vector search UDF
         // ============================================
-        String createFunctionSql = 
+        String createFunctionSql =
             "CREATE TEMPORARY FUNCTION vector_search AS \n" +
             "    'org.apache.flink.connector.lance.table.LanceVectorSearchFunction'";
-        
+
         System.out.println("-- Step 3: Register vector search UDF");
         System.out.println(createFunctionSql);
         System.out.println();
         tableEnv.executeSql(createFunctionSql);
         System.out.println("✅ UDF registration completed\n");
-        
+
         // ============================================
         // Step 4: Execute vector search - Basic usage
         // ============================================
@@ -531,7 +531,7 @@ class FlinkSqlDemo {
         System.out.println("--   Param 4: TopK count to return");
         System.out.println("--   Param 5: Distance metric type (L2/COSINE/DOT)");
         System.out.println();
-        
+
         String vectorSearchSql = String.format(
             "SELECT * FROM TABLE(\n" +
             "    vector_search(\n" +
@@ -542,12 +542,12 @@ class FlinkSqlDemo {
             "        'L2'                               -- L2 distance metric\n" +
             "    )\n" +
             ")", datasetPath);
-        
+
         System.out.println(vectorSearchSql);
         System.out.println();
         System.out.println("📊 Search results (sorted by L2 distance, smaller distance = more similar):");
         System.out.println("---------------------------------------------------");
-        
+
         try {
             TableResult result = tableEnv.executeSql(vectorSearchSql);
             result.print();
@@ -555,12 +555,12 @@ class FlinkSqlDemo {
             System.out.println("⚠️ Vector search execution error: " + e.getMessage());
             System.out.println("   This may be because the dataset needs to build index first");
         }
-        
+
         // ============================================
         // Step 5: Use COSINE cosine similarity search
         // ============================================
         System.out.println("\n-- Step 5: Use COSINE cosine similarity search");
-        
+
         String cosineSearchSql = String.format(
             "SELECT * FROM TABLE(\n" +
             "    vector_search(\n" +
@@ -571,23 +571,23 @@ class FlinkSqlDemo {
             "        'COSINE'                           -- Cosine similarity\n" +
             "    )\n" +
             ")", datasetPath);
-        
+
         System.out.println(cosineSearchSql);
         System.out.println();
         System.out.println("📊 Search results (sorted by cosine distance):");
         System.out.println("---------------------------------------------------");
-        
+
         try {
             tableEnv.executeSql(cosineSearchSql).print();
         } catch (Exception e) {
             System.out.println("⚠️ Execution error: " + e.getMessage());
         }
-        
+
         // ============================================
         // Step 6: Combine vector search with other queries
         // ============================================
         System.out.println("\n-- Step 6: Combine vector search with other queries (LATERAL TABLE)");
-        
+
         String lateralSearchSql = String.format(
             "-- First query data, then perform vector search based on results\n" +
             "SELECT \n" +
@@ -598,10 +598,10 @@ class FlinkSqlDemo {
             "    vector_search('%s', 'embedding', ARRAY[0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85], 5, 'L2')\n" +
             ") AS v\n" +
             "WHERE v._distance < 1.0  -- Only return results with distance less than 1", datasetPath);
-        
+
         System.out.println(lateralSearchSql);
         System.out.println();
-        
+
         // ============================================
         // Print configuration parameter descriptions
         // ============================================
@@ -617,7 +617,7 @@ class FlinkSqlDemo {
         System.out.println("║ vector.metric               ║ Distance metric: L2(Euclidean)/COSINE/DOT(Dot product)║");
         System.out.println("║ vector.nprobes              ║ Number of partitions to probe during search       ║");
         System.out.println("╚═════════════════════════════╩════════════════════════════════════════════════════╝");
-        
+
         System.out.println("\n========== Distance Metric Type Description ==========");
         System.out.println("╔════════════════╦════════════════════════════════════════════════════════════════╗");
         System.out.println("║  Metric Type   ║                          Description                           ║");
@@ -626,7 +626,7 @@ class FlinkSqlDemo {
         System.out.println("║    COSINE      ║ Cosine distance, range [0,2], smaller = more similar, for text║");
         System.out.println("║    DOT         ║ Negative dot product, smaller = more similar (needs normalization)║");
         System.out.println("╚════════════════╩════════════════════════════════════════════════════════════════╝");
-        
+
         System.out.println("\n✅ Vector search IVF_PQ example completed!\n");
     }
 
@@ -634,10 +634,10 @@ class FlinkSqlDemo {
     @DisplayName("9.2 Different Index Types Comparison Example")
     void testDifferentIndexTypesDetailed() throws Exception {
         System.out.println("========== Different Vector Index Types Comparison ==========");
-        
+
         // Use relative path based on project root
         Path basePath = Paths.get(System.getProperty("user.dir"), "test-data");
-        
+
         // ============================================
         // IVF_PQ Index - For large-scale data, low memory footprint
         // ============================================
@@ -645,7 +645,7 @@ class FlinkSqlDemo {
         System.out.println("Pros: Low memory footprint, fast search speed");
         System.out.println("Cons: Lower accuracy (quantization loss)");
         System.out.println();
-        
+
         String ivfPqSql = String.format(
             "CREATE TABLE ivf_pq_vectors (\n" +
             "    id BIGINT,\n" +
@@ -660,10 +660,10 @@ class FlinkSqlDemo {
             "    'index.num-bits' = '8',            -- Encoding bits per sub-vector\n" +
             "    'vector.metric' = 'L2'\n" +
             ")", basePath.resolve("ivf-pq-demo"));
-        
+
         System.out.println(ivfPqSql);
         System.out.println();
-        
+
         // ============================================
         // IVF_HNSW Index - High accuracy search
         // ============================================
@@ -671,7 +671,7 @@ class FlinkSqlDemo {
         System.out.println("Pros: High search accuracy");
         System.out.println("Cons: Higher memory footprint, slower index building");
         System.out.println();
-        
+
         String ivfHnswSql = String.format(
             "CREATE TABLE ivf_hnsw_vectors (\n" +
             "    id BIGINT,\n" +
@@ -687,10 +687,10 @@ class FlinkSqlDemo {
             "    'vector.metric' = 'COSINE',\n" +
             "    'vector.ef' = '50'                 -- Candidate set size during search\n" +
             ")", basePath.resolve("ivf-hnsw-demo"));
-        
+
         System.out.println(ivfHnswSql);
         System.out.println();
-        
+
         // ============================================
         // IVF_FLAT Index - Highest accuracy, brute force search
         // ============================================
@@ -698,7 +698,7 @@ class FlinkSqlDemo {
         System.out.println("Pros: 100% search accuracy (lossless)");
         System.out.println("Cons: Slower search speed, suitable for small datasets");
         System.out.println();
-        
+
         String ivfFlatSql = String.format(
             "CREATE TABLE ivf_flat_vectors (\n" +
             "    id BIGINT,\n" +
@@ -712,10 +712,10 @@ class FlinkSqlDemo {
             "    'vector.metric' = 'DOT',\n" +
             "    'vector.nprobes' = '32'            -- Number of partitions to probe during search\n" +
             ")", basePath.resolve("ivf-flat-demo"));
-        
+
         System.out.println(ivfFlatSql);
         System.out.println();
-        
+
         // ============================================
         // Index Selection Recommendations
         // ============================================
@@ -727,7 +727,7 @@ class FlinkSqlDemo {
         System.out.println("║    IVF_HNSW       ║   100K-1M      ║    High       ║ Semantic search, Q&A systems   ║");
         System.out.println("║    IVF_FLAT       ║   <100K        ║    Highest    ║ Small-scale high-precision scenarios║");
         System.out.println("╚═══════════════════╩════════════════╩═══════════════╩════════════════════════════════╝");
-        
+
         System.out.println("\n✅ Index type comparison example completed!\n");
     }
 
@@ -737,7 +737,7 @@ class FlinkSqlDemo {
         System.out.println("========================================");
         System.out.println("     Flink SQL Lance Connector Quick Reference");
         System.out.println("========================================\n");
-        
+
         System.out.println("【Create Table】");
         System.out.println("CREATE TABLE table_name (");
         System.out.println("    column_name data_type,");
@@ -746,19 +746,19 @@ class FlinkSqlDemo {
         System.out.println("    'connector' = 'lance',");
         System.out.println("    'path' = '/path/to/dataset'");
         System.out.println(");\n");
-        
+
         System.out.println("【Insert Data】");
         System.out.println("INSERT INTO table_name VALUES (1, 'text', ARRAY[0.1, 0.2, 0.3]);\n");
-        
+
         System.out.println("【Query Data】");
         System.out.println("SELECT * FROM table_name WHERE condition;\n");
-        
+
         System.out.println("【Create Catalog】");
         System.out.println("CREATE CATALOG lance_catalog WITH (");
         System.out.println("    'type' = 'lance',");
         System.out.println("    'warehouse' = '/path/to/warehouse'");
         System.out.println(");\n");
-        
+
         System.out.println("【Data Type Mapping】");
         System.out.println("╔════════════════════╦═══════════════════╗");
         System.out.println("║   Flink SQL Type   ║     Lance Type    ║");
@@ -776,7 +776,7 @@ class FlinkSqlDemo {
         System.out.println("║ TIMESTAMP          ║ Timestamp         ║");
         System.out.println("║ ARRAY<FLOAT>       ║ FixedSizeList     ║");
         System.out.println("╚════════════════════╩═══════════════════╝\n");
-        
+
         System.out.println("【Configuration Options】");
         System.out.println("╔═══════════════════════════╦════════════════════════════════╗");
         System.out.println("║         Option            ║           Description          ║");
@@ -792,7 +792,7 @@ class FlinkSqlDemo {
         System.out.println("║ vector.metric             ║ Distance metric: L2/COSINE/DOT ║");
         System.out.println("║ vector.nprobes            ║ Search probes (default 20)     ║");
         System.out.println("╚═══════════════════════════╩════════════════════════════════╝\n");
-        
+
         System.out.println("✅ Quick reference completed!");
     }
 }

--- a/src/test/java/org/apache/flink/connector/lance/table/FlinkSqlDemo.java
+++ b/src/test/java/org/apache/flink/connector/lance/table/FlinkSqlDemo.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.table;
 
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -23,7 +18,6 @@ import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
-
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.junit.jupiter.api.AfterEach;
@@ -40,759 +34,809 @@ import java.util.concurrent.TimeUnit;
  * Flink SQL complete demo test script.
  *
  * <p>This test demonstrates how to use Flink SQL to operate Lance datasets:
+ *
  * <ul>
- *   <li>Create Lance Catalog</li>
- *   <li>Create Lance tables</li>
- *   <li>Insert vector data</li>
- *   <li>Query data</li>
- *   <li>Build vector index</li>
- *   <li>Execute vector search</li>
+ *   <li>Create Lance Catalog
+ *   <li>Create Lance tables
+ *   <li>Insert vector data
+ *   <li>Query data
+ *   <li>Build vector index
+ *   <li>Execute vector search
  * </ul>
  */
 class FlinkSqlDemo {
 
-    @TempDir
-    Path tempDir;
+  @TempDir Path tempDir;
 
-    private TableEnvironment tableEnv;
-    private String warehousePath;
-    private String datasetPath;
+  private TableEnvironment tableEnv;
+  private String warehousePath;
+  private String datasetPath;
 
-    @BeforeEach
-    void setUp() {
-        // Create Flink Table environment
-        EnvironmentSettings settings = EnvironmentSettings.newInstance()
-                .inBatchMode()
-                .build();
-        tableEnv = TableEnvironment.create(settings);
+  @BeforeEach
+  void setUp() {
+    // Create Flink Table environment
+    EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
+    tableEnv = TableEnvironment.create(settings);
 
-        // Set paths
-        warehousePath = tempDir.resolve("lance_warehouse").toString();
-        datasetPath = tempDir.resolve("lance_dataset").toString();
+    // Set paths
+    warehousePath = tempDir.resolve("lance_warehouse").toString();
+    datasetPath = tempDir.resolve("lance_dataset").toString();
+  }
+
+  @AfterEach
+  void tearDown() {
+    // Cleanup resources
+    if (tableEnv != null) {
+      // TableEnvironment auto cleanup
+    }
+  }
+
+  // ==================== Basic SQL Operations ====================
+
+  @Test
+  @DisplayName("1. Create Lance Connector Table - Basic Usage")
+  void testCreateLanceTable() throws Exception {
+    String createTableSql =
+        String.format(
+            "CREATE TABLE lance_vectors (\n"
+                + "    id BIGINT,\n"
+                + "    content STRING,\n"
+                + "    embedding ARRAY<FLOAT>,\n"
+                + "    category STRING,\n"
+                + "    create_time TIMESTAMP(3)\n"
+                + ") WITH (\n"
+                + "    'connector' = 'lance',\n"
+                + "    'path' = '%s',\n"
+                + "    'write.batch-size' = '1024',\n"
+                + "    'write.mode' = 'overwrite'\n"
+                + ")",
+            datasetPath);
+
+    System.out.println("========== Create Lance Table ==========");
+    System.out.println(createTableSql);
+    System.out.println();
+
+    tableEnv.executeSql(createTableSql);
+    System.out.println("✅ Table created successfully!\n");
+  }
+
+  @Test
+  @DisplayName("2. Insert Vector Data to Lance Table")
+  void testInsertData() throws Exception {
+    // Use relative path based on project root
+    Path path = Paths.get(System.getProperty("user.dir"), "test-data");
+    // First create table
+    String createTableSql =
+        String.format(
+            "CREATE TABLE lance_documents (\n"
+                + "    id BIGINT,\n"
+                + "    title STRING,\n"
+                + "    embedding ARRAY<FLOAT>\n"
+                + ") WITH (\n"
+                + "    'connector' = 'lance',\n"
+                + "    'path' = '%s',\n"
+                + "    'write.mode' = 'overwrite'\n"
+                + ")",
+            path.resolve("lance-db1"));
+
+    tableEnv.executeSql(createTableSql);
+
+    // Insert data
+    String insertSql =
+        "INSERT INTO lance_documents VALUES\n"
+            + "    (1, 'Introduction to AI', ARRAY[0.1, 0.2, 0.3, 0.4]),\n"
+            + "    (2, 'Machine Learning Guide', ARRAY[0.2, 0.3, 0.4, 0.5]),\n"
+            + "    (3, 'Deep Learning Basics', ARRAY[0.3, 0.4, 0.5, 0.6]),\n"
+            + "    (4, 'Neural Networks', ARRAY[0.4, 0.5, 0.6, 0.7]),\n"
+            + "    (5, 'Computer Vision', ARRAY[0.5, 0.6, 0.7, 0.8])";
+
+    System.out.println("========== Insert Vector Data ==========");
+    System.out.println(insertSql);
+    System.out.println();
+
+    TableResult result = tableEnv.executeSql(insertSql);
+    result.await(30, TimeUnit.SECONDS);
+    System.out.println("✅ Data inserted successfully!\n");
+  }
+
+  @Test
+  @DisplayName("3. Query Lance Table Data")
+  void testSelectData() throws Exception {
+    // Create source table (for generating test data)
+    String createSourceSql =
+        "CREATE TABLE test_source (\n"
+            + "    id BIGINT,\n"
+            + "    name STRING\n"
+            + ") WITH (\n"
+            + "    'connector' = 'datagen',\n"
+            + "    'rows-per-second' = '1',\n"
+            + "    'number-of-rows' = '10',\n"
+            + "    'fields.id.kind' = 'sequence',\n"
+            + "    'fields.id.start' = '1',\n"
+            + "    'fields.id.end' = '10'\n"
+            + ")";
+
+    tableEnv.executeSql(createSourceSql);
+
+    // Query data
+    String selectSql = "SELECT id, name FROM test_source LIMIT 5";
+
+    System.out.println("========== Query Data ==========");
+    System.out.println(selectSql);
+    System.out.println();
+
+    TableResult result = tableEnv.executeSql(selectSql);
+    result.print();
+    System.out.println("✅ Query completed!\n");
+  }
+
+  // ==================== Advanced Configuration ====================
+
+  @Test
+  @DisplayName("4. Create Table with Vector Index Configuration")
+  void testCreateTableWithIndexConfig() throws Exception {
+    String createTableSql =
+        String.format(
+            "CREATE TABLE vector_store (\n"
+                + "    id BIGINT,\n"
+                + "    text STRING,\n"
+                + "    embedding ARRAY<FLOAT> COMMENT '768-dim vector'\n"
+                + ") WITH (\n"
+                + "    'connector' = 'lance',\n"
+                + "    'path' = '%s',\n"
+                + "    -- Write configuration\n"
+                + "    'write.batch-size' = '2048',\n"
+                + "    'write.mode' = 'append',\n"
+                + "    'write.max-rows-per-file' = '100000',\n"
+                + "    -- Index configuration\n"
+                + "    'index.type' = 'IVF_PQ',\n"
+                + "    'index.column' = 'embedding',\n"
+                + "    'index.num-partitions' = '256',\n"
+                + "    'index.num-sub-vectors' = '16',\n"
+                + "    -- Vector search configuration\n"
+                + "    'vector.column' = 'embedding',\n"
+                + "    'vector.metric' = 'L2',\n"
+                + "    'vector.nprobes' = '20'\n"
+                + ")",
+            datasetPath);
+
+    System.out.println("========== Create Table with Index Configuration ==========");
+    System.out.println(createTableSql);
+    System.out.println();
+
+    tableEnv.executeSql(createTableSql);
+    System.out.println("✅ Table created successfully!\n");
+  }
+
+  @Test
+  @DisplayName("5. Different Index Type Configuration Examples")
+  void testDifferentIndexTypes() {
+    System.out.println("========== Index Type Configuration Examples ==========\n");
+
+    // IVF_PQ index (recommended, balances accuracy and speed)
+    String ivfPqConfig =
+        "-- IVF_PQ index configuration (recommended for large-scale vector data)\n"
+            + "'index.type' = 'IVF_PQ',\n"
+            + "'index.num-partitions' = '256',      -- Number of cluster centers\n"
+            + "'index.num-sub-vectors' = '16',      -- Number of sub-vectors\n"
+            + "'index.num-bits' = '8'               -- Quantization bits per sub-vector\n";
+
+    System.out.println(ivfPqConfig);
+
+    // IVF_HNSW index (high accuracy)
+    String ivfHnswConfig =
+        "-- IVF_HNSW index configuration (for high accuracy scenarios)\n"
+            + "'index.type' = 'IVF_HNSW',\n"
+            + "'index.num-partitions' = '256',\n"
+            + "'index.max-level' = '7',             -- HNSW max level\n"
+            + "'index.m' = '16',                    -- HNSW connections per level\n"
+            + "'index.ef-construction' = '100'      -- ef parameter during construction\n";
+
+    System.out.println(ivfHnswConfig);
+
+    // IVF_FLAT index (highest accuracy, suitable for small datasets)
+    String ivfFlatConfig =
+        "-- IVF_FLAT index configuration (for small-scale datasets)\n"
+            + "'index.type' = 'IVF_FLAT',\n"
+            + "'index.num-partitions' = '64'        -- Number of cluster centers\n";
+
+    System.out.println(ivfFlatConfig);
+    System.out.println("✅ Configuration examples displayed!\n");
+  }
+
+  @Test
+  @DisplayName("6. Distance Metric Type Configuration Examples")
+  void testMetricTypes() {
+    System.out.println("========== Distance Metric Type Examples ==========\n");
+
+    String l2Config =
+        "-- L2 distance (Euclidean distance, default)\n"
+            + "'vector.metric' = 'L2'\n"
+            + "-- Suitable for: General vector search\n";
+    System.out.println(l2Config);
+
+    String cosineConfig =
+        "-- Cosine distance (Cosine similarity)\n"
+            + "'vector.metric' = 'COSINE'\n"
+            + "-- Suitable for: Text semantic similarity\n";
+    System.out.println(cosineConfig);
+
+    String dotConfig =
+        "-- Dot distance (Dot product)\n"
+            + "'vector.metric' = 'DOT'\n"
+            + "-- Suitable for: Already normalized vectors\n";
+    System.out.println(dotConfig);
+
+    System.out.println("✅ Configuration examples displayed!\n");
+  }
+
+  // ==================== Catalog Operations ====================
+
+  @Test
+  @DisplayName("7. Create and Use Lance Catalog")
+  void testLanceCatalog() throws Exception {
+    String createCatalogSql =
+        String.format(
+            "CREATE CATALOG lance_catalog WITH (\n"
+                + "    'type' = 'lance',\n"
+                + "    'warehouse' = '%s',\n"
+                + "    'default-database' = 'default'\n"
+                + ")",
+            warehousePath);
+
+    System.out.println("========== Create Lance Catalog ==========");
+    System.out.println(createCatalogSql);
+    System.out.println();
+
+    tableEnv.executeSql(createCatalogSql);
+
+    // Use Catalog
+    tableEnv.executeSql("USE CATALOG lance_catalog");
+    System.out.println("✅ Catalog created and switched!\n");
+
+    // Create database
+    tableEnv.executeSql("CREATE DATABASE IF NOT EXISTS vector_db");
+    System.out.println("✅ Database vector_db created!\n");
+
+    // List databases
+    System.out.println("Database list:");
+    tableEnv.executeSql("SHOW DATABASES").print();
+  }
+
+  // ==================== Streaming Processing ====================
+
+  @Test
+  @DisplayName("8. Streaming Write to Lance Table")
+  void testStreamingWrite() throws Exception {
+    // Create streaming environment
+    StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+    env.setParallelism(1);
+    StreamTableEnvironment streamTableEnv = StreamTableEnvironment.create(env);
+
+    // Create data generator table (simulating real-time data)
+    String createSourceSql =
+        "CREATE TABLE realtime_events (\n"
+            + "    event_id BIGINT,\n"
+            + "    event_type STRING,\n"
+            + "    event_time AS PROCTIME()\n"
+            + ") WITH (\n"
+            + "    'connector' = 'datagen',\n"
+            + "    'rows-per-second' = '10',\n"
+            + "    'number-of-rows' = '100',\n"
+            + "    'fields.event_id.kind' = 'sequence',\n"
+            + "    'fields.event_id.start' = '1',\n"
+            + "    'fields.event_id.end' = '100',\n"
+            + "    'fields.event_type.length' = '10'\n"
+            + ")";
+
+    // Create Lance Sink table
+    String createSinkSql =
+        String.format(
+            "CREATE TABLE lance_events (\n"
+                + "    event_id BIGINT,\n"
+                + "    event_type STRING\n"
+                + ") WITH (\n"
+                + "    'connector' = 'lance',\n"
+                + "    'path' = '%s',\n"
+                + "    'write.batch-size' = '100',\n"
+                + "    'write.mode' = 'append'\n"
+                + ")",
+            datasetPath);
+
+    System.out.println("========== Streaming Write Example ==========");
+    System.out.println("-- Source table definition");
+    System.out.println(createSourceSql);
+    System.out.println("\n-- Sink table definition");
+    System.out.println(createSinkSql);
+    System.out.println();
+
+    streamTableEnv.executeSql(createSourceSql);
+    streamTableEnv.executeSql(createSinkSql);
+
+    // Execute streaming write
+    String insertSql = "INSERT INTO lance_events SELECT event_id, event_type FROM realtime_events";
+    System.out.println("-- Streaming insert statement");
+    System.out.println(insertSql);
+    System.out.println();
+
+    System.out.println("✅ Streaming write configuration completed!\n");
+  }
+
+  // ==================== Complete Example ====================
+
+  @Test
+  @DisplayName("9. Complete Vector Storage and Search Example")
+  void testCompleteVectorExample() throws Exception {
+    // Use relative path based on project root
+    Path path = Paths.get(System.getProperty("user.dir"), "test-data");
+    System.out.println("========== Complete Vector Storage and Search Example ==========\n");
+
+    // 1. Create vector table
+    String createTableSql =
+        String.format(
+            "-- 1. Create vector storage table\n"
+                + "CREATE TABLE document_vectors (\n"
+                + "    doc_id BIGINT COMMENT 'Document ID',\n"
+                + "    title STRING COMMENT 'Document title',\n"
+                + "    content STRING COMMENT 'Document content',\n"
+                + "    embedding ARRAY<FLOAT> COMMENT 'Document vector (768-dim)',\n"
+                + "    category STRING COMMENT 'Document category',\n"
+                + "    create_time TIMESTAMP(3) COMMENT 'Creation time'\n"
+                + ") WITH (\n"
+                + "    'connector' = 'lance',\n"
+                + "    'path' = '%s',\n"
+                + "    -- Write configuration\n"
+                + "    'write.batch-size' = '1024',\n"
+                + "    'write.mode' = 'overwrite',\n"
+                + "    -- Index configuration\n"
+                + "    'index.type' = 'IVF_PQ',\n"
+                + "    'index.column' = 'embedding',\n"
+                + "    'index.num-partitions' = '128',\n"
+                + "    'index.num-sub-vectors' = '32',\n"
+                + "    -- Vector search configuration\n"
+                + "    'vector.column' = 'embedding',\n"
+                + "    'vector.metric' = 'COSINE',\n"
+                + "    'vector.nprobes' = '10'\n"
+                + ")",
+            path.resolve("lance-db3"));
+
+    System.out.println(createTableSql);
+    System.out.println();
+    tableEnv.executeSql(createTableSql);
+
+    // 2. Insert test data
+    String insertSql =
+        "-- 2. Insert vector data\n"
+            + "INSERT INTO document_vectors VALUES\n"
+            + "    (1, 'Flink Getting Started Guide', 'Introduction to Apache Flink basics...', \n"
+            + "     ARRAY[0.1, 0.2, 0.3, 0.4], 'tutorial', TIMESTAMP '2024-01-01 10:00:00'),\n"
+            + "    (2, 'Stream Processing in Practice', 'Using Flink to process real-time data streams...', \n"
+            + "     ARRAY[0.2, 0.3, 0.4, 0.5], 'practice', TIMESTAMP '2024-01-02 11:00:00'),\n"
+            + "    (3, 'Vector Database Explained', 'Deep understanding of vector search technology...', \n"
+            + "     ARRAY[0.3, 0.4, 0.5, 0.6], 'database', TIMESTAMP '2024-01-03 12:00:00'),\n"
+            + "    (4, 'Lance Format Introduction', 'Lance is an efficient vector storage format...', \n"
+            + "     ARRAY[0.4, 0.5, 0.6, 0.7], 'format', TIMESTAMP '2024-01-04 13:00:00'),\n"
+            + "    (5, 'SQL Connector Development', 'How to develop Flink SQL connectors...', \n"
+            + "     ARRAY[0.5, 0.6, 0.7, 0.8], 'development', TIMESTAMP '2024-01-05 14:00:00')";
+
+    System.out.println(insertSql);
+    System.out.println();
+    TableResult result = tableEnv.executeSql(insertSql);
+    result.await(30, TimeUnit.SECONDS);
+
+    // 3. Query data
+    String selectSql =
+        "-- 3. Query vector data\n"
+            + "SELECT doc_id, title, category, create_time\n"
+            + "FROM document_vectors\n"
+            + "WHERE category = 'tutorial'\n"
+            + "ORDER BY create_time DESC";
+
+    System.out.println(selectSql);
+    System.out.println();
+    TableResult tableResult = tableEnv.executeSql(selectSql);
+    tableResult.await(3, TimeUnit.SECONDS);
+    CloseableIterator<Row> collect = tableResult.collect();
+    while (collect.hasNext()) {
+      System.out.println(collect.next());
     }
 
-    @AfterEach
-    void tearDown() {
-        // Cleanup resources
-        if (tableEnv != null) {
-            // TableEnvironment auto cleanup
-        }
+    // 4. Aggregation query
+    String aggSql =
+        "-- 4. Count documents by category\n"
+            + "SELECT category, COUNT(*) as doc_count\n"
+            + "FROM document_vectors\n"
+            + "GROUP BY category\n"
+            + "ORDER BY doc_count DESC";
+
+    System.out.println(aggSql);
+    System.out.println();
+    tableEnv.executeSql(aggSql).print();
+
+    System.out.println("✅ Complete example displayed!\n");
+  }
+
+  @Test
+  @DisplayName("9.1 Vector Search IVF_PQ Index Example")
+  void testVectorSearchWithIvfPq() throws Exception {
+    System.out.println("========== Vector Search IVF_PQ Index Example ==========");
+
+    // Use relative path based on project root
+    Path basePath = Paths.get(System.getProperty("user.dir"), "test-data");
+    String datasetPath = basePath.resolve("lance-vector-search").toString();
+
+    // ============================================
+    // Step 1: Create vector table with IVF_PQ index configuration
+    // ============================================
+    String createTableSql =
+        String.format(
+            "CREATE TABLE vector_documents (\n"
+                + "    id BIGINT,\n"
+                + "    title STRING,\n"
+                + "    embedding ARRAY<FLOAT>\n"
+                + ") WITH (\n"
+                + "    'connector' = 'lance',\n"
+                + "    'path' = '%s',\n"
+                + "    'write.batch-size' = '1024',\n"
+                + "    'write.mode' = 'overwrite',\n"
+                + "    -- IVF_PQ index configuration\n"
+                + "    'index.type' = 'IVF_PQ',\n"
+                + "    'index.column' = 'embedding',\n"
+                + "    'index.num-partitions' = '16',\n"
+                + "    'index.num-sub-vectors' = '8',\n"
+                + "    -- Vector search configuration\n"
+                + "    'vector.column' = 'embedding',\n"
+                + "    'vector.metric' = 'L2',\n"
+                + "    'vector.nprobes' = '10'\n"
+                + ")",
+            datasetPath);
+
+    System.out.println("-- Step 1: Create vector table with IVF_PQ index configuration");
+    System.out.println(createTableSql);
+    System.out.println();
+    tableEnv.executeSql(createTableSql);
+
+    // ============================================
+    // Step 2: Insert vector data
+    // ============================================
+    String insertSql =
+        "INSERT INTO vector_documents VALUES\n"
+            + "    (1, 'Flink Stream Processing', ARRAY[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]),\n"
+            + "    (2, 'Spark Batch Processing', ARRAY[0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]),\n"
+            + "    (3, 'Kafka Message Queue', ARRAY[0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1]),\n"
+            + "    (4, 'Vector Database', ARRAY[0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85]),\n"
+            + "    (5, 'Machine Learning Basics', ARRAY[0.12, 0.22, 0.32, 0.42, 0.52, 0.62, 0.72, 0.82])";
+
+    System.out.println("-- Step 2: Insert vector data");
+    System.out.println(insertSql);
+    System.out.println();
+    tableEnv.executeSql(insertSql).await(30, TimeUnit.SECONDS);
+    System.out.println("✅ Data insertion completed\n");
+
+    // ============================================
+    // Step 3: Register vector search UDF
+    // ============================================
+    String createFunctionSql =
+        "CREATE TEMPORARY FUNCTION vector_search AS \n"
+            + "    'org.apache.flink.connector.lance.table.LanceVectorSearchFunction'";
+
+    System.out.println("-- Step 3: Register vector search UDF");
+    System.out.println(createFunctionSql);
+    System.out.println();
+    tableEnv.executeSql(createFunctionSql);
+    System.out.println("✅ UDF registration completed\n");
+
+    // ============================================
+    // Step 4: Execute vector search - Basic usage
+    // ============================================
+    System.out.println("-- Step 4: Execute vector search (Basic usage)");
+    System.out.println("-- Parameter description:");
+    System.out.println("--   Param 1: Dataset path");
+    System.out.println("--   Param 2: Vector column name");
+    System.out.println("--   Param 3: Query vector");
+    System.out.println("--   Param 4: TopK count to return");
+    System.out.println("--   Param 5: Distance metric type (L2/COSINE/DOT)");
+    System.out.println();
+
+    String vectorSearchSql =
+        String.format(
+            "SELECT * FROM TABLE(\n"
+                + "    vector_search(\n"
+                + "        '%s',                              -- Dataset path\n"
+                + "        'embedding',                       -- Vector column name\n"
+                + "        ARRAY[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],  -- Query vector\n"
+                + "        3,                                 -- Return Top 3\n"
+                + "        'L2'                               -- L2 distance metric\n"
+                + "    )\n"
+                + ")",
+            datasetPath);
+
+    System.out.println(vectorSearchSql);
+    System.out.println();
+    System.out.println(
+        "📊 Search results (sorted by L2 distance, smaller distance = more similar):");
+    System.out.println("---------------------------------------------------");
+
+    try {
+      TableResult result = tableEnv.executeSql(vectorSearchSql);
+      result.print();
+    } catch (Exception e) {
+      System.out.println("⚠️ Vector search execution error: " + e.getMessage());
+      System.out.println("   This may be because the dataset needs to build index first");
     }
 
-    // ==================== Basic SQL Operations ====================
+    // ============================================
+    // Step 5: Use COSINE cosine similarity search
+    // ============================================
+    System.out.println("\n-- Step 5: Use COSINE cosine similarity search");
 
-    @Test
-    @DisplayName("1. Create Lance Connector Table - Basic Usage")
-    void testCreateLanceTable() throws Exception {
-        String createTableSql = String.format(
-            "CREATE TABLE lance_vectors (\n" +
-            "    id BIGINT,\n" +
-            "    content STRING,\n" +
-            "    embedding ARRAY<FLOAT>,\n" +
-            "    category STRING,\n" +
-            "    create_time TIMESTAMP(3)\n" +
-            ") WITH (\n" +
-            "    'connector' = 'lance',\n" +
-            "    'path' = '%s',\n" +
-            "    'write.batch-size' = '1024',\n" +
-            "    'write.mode' = 'overwrite'\n" +
-            ")", datasetPath);
+    String cosineSearchSql =
+        String.format(
+            "SELECT * FROM TABLE(\n"
+                + "    vector_search(\n"
+                + "        '%s',\n"
+                + "        'embedding',\n"
+                + "        ARRAY[0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1],\n"
+                + "        3,\n"
+                + "        'COSINE'                           -- Cosine similarity\n"
+                + "    )\n"
+                + ")",
+            datasetPath);
 
-        System.out.println("========== Create Lance Table ==========");
-        System.out.println(createTableSql);
-        System.out.println();
+    System.out.println(cosineSearchSql);
+    System.out.println();
+    System.out.println("📊 Search results (sorted by cosine distance):");
+    System.out.println("---------------------------------------------------");
 
-        tableEnv.executeSql(createTableSql);
-        System.out.println("✅ Table created successfully!\n");
+    try {
+      tableEnv.executeSql(cosineSearchSql).print();
+    } catch (Exception e) {
+      System.out.println("⚠️ Execution error: " + e.getMessage());
     }
 
-    @Test
-    @DisplayName("2. Insert Vector Data to Lance Table")
-    void testInsertData() throws Exception {
-        // Use relative path based on project root
-        Path path = Paths.get(System.getProperty("user.dir"), "test-data");
-        // First create table
-        String createTableSql = String.format(
-            "CREATE TABLE lance_documents (\n" +
-            "    id BIGINT,\n" +
-            "    title STRING,\n" +
-            "    embedding ARRAY<FLOAT>\n" +
-            ") WITH (\n" +
-            "    'connector' = 'lance',\n" +
-            "    'path' = '%s',\n" +
-            "    'write.mode' = 'overwrite'\n" +
-            ")", path.resolve("lance-db1"));
-
-        tableEnv.executeSql(createTableSql);
-
-        // Insert data
-        String insertSql =
-            "INSERT INTO lance_documents VALUES\n" +
-            "    (1, 'Introduction to AI', ARRAY[0.1, 0.2, 0.3, 0.4]),\n" +
-            "    (2, 'Machine Learning Guide', ARRAY[0.2, 0.3, 0.4, 0.5]),\n" +
-            "    (3, 'Deep Learning Basics', ARRAY[0.3, 0.4, 0.5, 0.6]),\n" +
-            "    (4, 'Neural Networks', ARRAY[0.4, 0.5, 0.6, 0.7]),\n" +
-            "    (5, 'Computer Vision', ARRAY[0.5, 0.6, 0.7, 0.8])";
-
-        System.out.println("========== Insert Vector Data ==========");
-        System.out.println(insertSql);
-        System.out.println();
-
-        TableResult result = tableEnv.executeSql(insertSql);
-        result.await(30, TimeUnit.SECONDS);
-        System.out.println("✅ Data inserted successfully!\n");
-    }
-
-    @Test
-    @DisplayName("3. Query Lance Table Data")
-    void testSelectData() throws Exception {
-        // Create source table (for generating test data)
-        String createSourceSql =
-            "CREATE TABLE test_source (\n" +
-            "    id BIGINT,\n" +
-            "    name STRING\n" +
-            ") WITH (\n" +
-            "    'connector' = 'datagen',\n" +
-            "    'rows-per-second' = '1',\n" +
-            "    'number-of-rows' = '10',\n" +
-            "    'fields.id.kind' = 'sequence',\n" +
-            "    'fields.id.start' = '1',\n" +
-            "    'fields.id.end' = '10'\n" +
-            ")";
-
-        tableEnv.executeSql(createSourceSql);
-
-        // Query data
-        String selectSql = "SELECT id, name FROM test_source LIMIT 5";
-
-        System.out.println("========== Query Data ==========");
-        System.out.println(selectSql);
-        System.out.println();
-
-        TableResult result = tableEnv.executeSql(selectSql);
-        result.print();
-        System.out.println("✅ Query completed!\n");
-    }
-
-    // ==================== Advanced Configuration ====================
-
-    @Test
-    @DisplayName("4. Create Table with Vector Index Configuration")
-    void testCreateTableWithIndexConfig() throws Exception {
-        String createTableSql = String.format(
-            "CREATE TABLE vector_store (\n" +
-            "    id BIGINT,\n" +
-            "    text STRING,\n" +
-            "    embedding ARRAY<FLOAT> COMMENT '768-dim vector'\n" +
-            ") WITH (\n" +
-            "    'connector' = 'lance',\n" +
-            "    'path' = '%s',\n" +
-            "    -- Write configuration\n" +
-            "    'write.batch-size' = '2048',\n" +
-            "    'write.mode' = 'append',\n" +
-            "    'write.max-rows-per-file' = '100000',\n" +
-            "    -- Index configuration\n" +
-            "    'index.type' = 'IVF_PQ',\n" +
-            "    'index.column' = 'embedding',\n" +
-            "    'index.num-partitions' = '256',\n" +
-            "    'index.num-sub-vectors' = '16',\n" +
-            "    -- Vector search configuration\n" +
-            "    'vector.column' = 'embedding',\n" +
-            "    'vector.metric' = 'L2',\n" +
-            "    'vector.nprobes' = '20'\n" +
-            ")", datasetPath);
-
-        System.out.println("========== Create Table with Index Configuration ==========");
-        System.out.println(createTableSql);
-        System.out.println();
-
-        tableEnv.executeSql(createTableSql);
-        System.out.println("✅ Table created successfully!\n");
-    }
-
-    @Test
-    @DisplayName("5. Different Index Type Configuration Examples")
-    void testDifferentIndexTypes() {
-        System.out.println("========== Index Type Configuration Examples ==========\n");
-
-        // IVF_PQ index (recommended, balances accuracy and speed)
-        String ivfPqConfig =
-            "-- IVF_PQ index configuration (recommended for large-scale vector data)\n" +
-            "'index.type' = 'IVF_PQ',\n" +
-            "'index.num-partitions' = '256',      -- Number of cluster centers\n" +
-            "'index.num-sub-vectors' = '16',      -- Number of sub-vectors\n" +
-            "'index.num-bits' = '8'               -- Quantization bits per sub-vector\n";
-
-        System.out.println(ivfPqConfig);
-
-        // IVF_HNSW index (high accuracy)
-        String ivfHnswConfig =
-            "-- IVF_HNSW index configuration (for high accuracy scenarios)\n" +
-            "'index.type' = 'IVF_HNSW',\n" +
-            "'index.num-partitions' = '256',\n" +
-            "'index.max-level' = '7',             -- HNSW max level\n" +
-            "'index.m' = '16',                    -- HNSW connections per level\n" +
-            "'index.ef-construction' = '100'      -- ef parameter during construction\n";
-
-        System.out.println(ivfHnswConfig);
-
-        // IVF_FLAT index (highest accuracy, suitable for small datasets)
-        String ivfFlatConfig =
-            "-- IVF_FLAT index configuration (for small-scale datasets)\n" +
-            "'index.type' = 'IVF_FLAT',\n" +
-            "'index.num-partitions' = '64'        -- Number of cluster centers\n";
-
-        System.out.println(ivfFlatConfig);
-        System.out.println("✅ Configuration examples displayed!\n");
-    }
-
-    @Test
-    @DisplayName("6. Distance Metric Type Configuration Examples")
-    void testMetricTypes() {
-        System.out.println("========== Distance Metric Type Examples ==========\n");
-
-        String l2Config =
-            "-- L2 distance (Euclidean distance, default)\n" +
-            "'vector.metric' = 'L2'\n" +
-            "-- Suitable for: General vector search\n";
-        System.out.println(l2Config);
-
-        String cosineConfig =
-            "-- Cosine distance (Cosine similarity)\n" +
-            "'vector.metric' = 'COSINE'\n" +
-            "-- Suitable for: Text semantic similarity\n";
-        System.out.println(cosineConfig);
-
-        String dotConfig =
-            "-- Dot distance (Dot product)\n" +
-            "'vector.metric' = 'DOT'\n" +
-            "-- Suitable for: Already normalized vectors\n";
-        System.out.println(dotConfig);
-
-        System.out.println("✅ Configuration examples displayed!\n");
-    }
-
-    // ==================== Catalog Operations ====================
-
-    @Test
-    @DisplayName("7. Create and Use Lance Catalog")
-    void testLanceCatalog() throws Exception {
-        String createCatalogSql = String.format(
-            "CREATE CATALOG lance_catalog WITH (\n" +
-            "    'type' = 'lance',\n" +
-            "    'warehouse' = '%s',\n" +
-            "    'default-database' = 'default'\n" +
-            ")", warehousePath);
-
-        System.out.println("========== Create Lance Catalog ==========");
-        System.out.println(createCatalogSql);
-        System.out.println();
-
-        tableEnv.executeSql(createCatalogSql);
-
-        // Use Catalog
-        tableEnv.executeSql("USE CATALOG lance_catalog");
-        System.out.println("✅ Catalog created and switched!\n");
-
-        // Create database
-        tableEnv.executeSql("CREATE DATABASE IF NOT EXISTS vector_db");
-        System.out.println("✅ Database vector_db created!\n");
-
-        // List databases
-        System.out.println("Database list:");
-        tableEnv.executeSql("SHOW DATABASES").print();
-    }
-
-    // ==================== Streaming Processing ====================
-
-    @Test
-    @DisplayName("8. Streaming Write to Lance Table")
-    void testStreamingWrite() throws Exception {
-        // Create streaming environment
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setParallelism(1);
-        StreamTableEnvironment streamTableEnv = StreamTableEnvironment.create(env);
-
-        // Create data generator table (simulating real-time data)
-        String createSourceSql =
-            "CREATE TABLE realtime_events (\n" +
-            "    event_id BIGINT,\n" +
-            "    event_type STRING,\n" +
-            "    event_time AS PROCTIME()\n" +
-            ") WITH (\n" +
-            "    'connector' = 'datagen',\n" +
-            "    'rows-per-second' = '10',\n" +
-            "    'number-of-rows' = '100',\n" +
-            "    'fields.event_id.kind' = 'sequence',\n" +
-            "    'fields.event_id.start' = '1',\n" +
-            "    'fields.event_id.end' = '100',\n" +
-            "    'fields.event_type.length' = '10'\n" +
-            ")";
-
-        // Create Lance Sink table
-        String createSinkSql = String.format(
-            "CREATE TABLE lance_events (\n" +
-            "    event_id BIGINT,\n" +
-            "    event_type STRING\n" +
-            ") WITH (\n" +
-            "    'connector' = 'lance',\n" +
-            "    'path' = '%s',\n" +
-            "    'write.batch-size' = '100',\n" +
-            "    'write.mode' = 'append'\n" +
-            ")", datasetPath);
-
-        System.out.println("========== Streaming Write Example ==========");
-        System.out.println("-- Source table definition");
-        System.out.println(createSourceSql);
-        System.out.println("\n-- Sink table definition");
-        System.out.println(createSinkSql);
-        System.out.println();
-
-        streamTableEnv.executeSql(createSourceSql);
-        streamTableEnv.executeSql(createSinkSql);
-
-        // Execute streaming write
-        String insertSql = "INSERT INTO lance_events SELECT event_id, event_type FROM realtime_events";
-        System.out.println("-- Streaming insert statement");
-        System.out.println(insertSql);
-        System.out.println();
-
-        System.out.println("✅ Streaming write configuration completed!\n");
-    }
-
-    // ==================== Complete Example ====================
-
-    @Test
-    @DisplayName("9. Complete Vector Storage and Search Example")
-    void testCompleteVectorExample() throws Exception {
-        // Use relative path based on project root
-        Path path = Paths.get(System.getProperty("user.dir"), "test-data");
-        System.out.println("========== Complete Vector Storage and Search Example ==========\n");
-
-        // 1. Create vector table
-        String createTableSql = String.format(
-            "-- 1. Create vector storage table\n" +
-            "CREATE TABLE document_vectors (\n" +
-            "    doc_id BIGINT COMMENT 'Document ID',\n" +
-            "    title STRING COMMENT 'Document title',\n" +
-            "    content STRING COMMENT 'Document content',\n" +
-            "    embedding ARRAY<FLOAT> COMMENT 'Document vector (768-dim)',\n" +
-            "    category STRING COMMENT 'Document category',\n" +
-            "    create_time TIMESTAMP(3) COMMENT 'Creation time'\n" +
-            ") WITH (\n" +
-            "    'connector' = 'lance',\n" +
-            "    'path' = '%s',\n" +
-            "    -- Write configuration\n" +
-            "    'write.batch-size' = '1024',\n" +
-            "    'write.mode' = 'overwrite',\n" +
-            "    -- Index configuration\n" +
-            "    'index.type' = 'IVF_PQ',\n" +
-            "    'index.column' = 'embedding',\n" +
-            "    'index.num-partitions' = '128',\n" +
-            "    'index.num-sub-vectors' = '32',\n" +
-            "    -- Vector search configuration\n" +
-            "    'vector.column' = 'embedding',\n" +
-            "    'vector.metric' = 'COSINE',\n" +
-            "    'vector.nprobes' = '10'\n" +
-            ")", path.resolve("lance-db3"));
-
-        System.out.println(createTableSql);
-        System.out.println();
-        tableEnv.executeSql(createTableSql);
-
-        // 2. Insert test data
-        String insertSql =
-            "-- 2. Insert vector data\n" +
-            "INSERT INTO document_vectors VALUES\n" +
-            "    (1, 'Flink Getting Started Guide', 'Introduction to Apache Flink basics...', \n" +
-            "     ARRAY[0.1, 0.2, 0.3, 0.4], 'tutorial', TIMESTAMP '2024-01-01 10:00:00'),\n" +
-            "    (2, 'Stream Processing in Practice', 'Using Flink to process real-time data streams...', \n" +
-            "     ARRAY[0.2, 0.3, 0.4, 0.5], 'practice', TIMESTAMP '2024-01-02 11:00:00'),\n" +
-            "    (3, 'Vector Database Explained', 'Deep understanding of vector search technology...', \n" +
-            "     ARRAY[0.3, 0.4, 0.5, 0.6], 'database', TIMESTAMP '2024-01-03 12:00:00'),\n" +
-            "    (4, 'Lance Format Introduction', 'Lance is an efficient vector storage format...', \n" +
-            "     ARRAY[0.4, 0.5, 0.6, 0.7], 'format', TIMESTAMP '2024-01-04 13:00:00'),\n" +
-            "    (5, 'SQL Connector Development', 'How to develop Flink SQL connectors...', \n" +
-            "     ARRAY[0.5, 0.6, 0.7, 0.8], 'development', TIMESTAMP '2024-01-05 14:00:00')";
-
-        System.out.println(insertSql);
-        System.out.println();
-        TableResult result = tableEnv.executeSql(insertSql);
-        result.await(30, TimeUnit.SECONDS);
-
-        // 3. Query data
-        String selectSql =
-            "-- 3. Query vector data\n" +
-            "SELECT doc_id, title, category, create_time\n" +
-            "FROM document_vectors\n" +
-            "WHERE category = 'tutorial'\n" +
-            "ORDER BY create_time DESC";
-
-        System.out.println(selectSql);
-        System.out.println();
-        TableResult tableResult = tableEnv.executeSql(selectSql);
-        tableResult.await(3, TimeUnit.SECONDS);
-        CloseableIterator<Row> collect = tableResult.collect();
-        while (collect.hasNext()) {
-            System.out.println(collect.next());
-        }
-
-        // 4. Aggregation query
-        String aggSql =
-            "-- 4. Count documents by category\n" +
-            "SELECT category, COUNT(*) as doc_count\n" +
-            "FROM document_vectors\n" +
-            "GROUP BY category\n" +
-            "ORDER BY doc_count DESC";
-
-        System.out.println(aggSql);
-        System.out.println();
-        tableEnv.executeSql(aggSql).print();
-
-        System.out.println("✅ Complete example displayed!\n");
-    }
-
-    @Test
-    @DisplayName("9.1 Vector Search IVF_PQ Index Example")
-    void testVectorSearchWithIvfPq() throws Exception {
-        System.out.println("========== Vector Search IVF_PQ Index Example ==========");
-
-        // Use relative path based on project root
-        Path basePath = Paths.get(System.getProperty("user.dir"), "test-data");
-        String datasetPath = basePath.resolve("lance-vector-search").toString();
-
-        // ============================================
-        // Step 1: Create vector table with IVF_PQ index configuration
-        // ============================================
-        String createTableSql = String.format(
-            "CREATE TABLE vector_documents (\n" +
-            "    id BIGINT,\n" +
-            "    title STRING,\n" +
-            "    embedding ARRAY<FLOAT>\n" +
-            ") WITH (\n" +
-            "    'connector' = 'lance',\n" +
-            "    'path' = '%s',\n" +
-            "    'write.batch-size' = '1024',\n" +
-            "    'write.mode' = 'overwrite',\n" +
-            "    -- IVF_PQ index configuration\n" +
-            "    'index.type' = 'IVF_PQ',\n" +
-            "    'index.column' = 'embedding',\n" +
-            "    'index.num-partitions' = '16',\n" +
-            "    'index.num-sub-vectors' = '8',\n" +
-            "    -- Vector search configuration\n" +
-            "    'vector.column' = 'embedding',\n" +
-            "    'vector.metric' = 'L2',\n" +
-            "    'vector.nprobes' = '10'\n" +
-            ")", datasetPath);
-
-        System.out.println("-- Step 1: Create vector table with IVF_PQ index configuration");
-        System.out.println(createTableSql);
-        System.out.println();
-        tableEnv.executeSql(createTableSql);
-
-        // ============================================
-        // Step 2: Insert vector data
-        // ============================================
-        String insertSql =
-            "INSERT INTO vector_documents VALUES\n" +
-            "    (1, 'Flink Stream Processing', ARRAY[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]),\n" +
-            "    (2, 'Spark Batch Processing', ARRAY[0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]),\n" +
-            "    (3, 'Kafka Message Queue', ARRAY[0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1]),\n" +
-            "    (4, 'Vector Database', ARRAY[0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85]),\n" +
-            "    (5, 'Machine Learning Basics', ARRAY[0.12, 0.22, 0.32, 0.42, 0.52, 0.62, 0.72, 0.82])";
-
-        System.out.println("-- Step 2: Insert vector data");
-        System.out.println(insertSql);
-        System.out.println();
-        tableEnv.executeSql(insertSql).await(30, TimeUnit.SECONDS);
-        System.out.println("✅ Data insertion completed\n");
-
-        // ============================================
-        // Step 3: Register vector search UDF
-        // ============================================
-        String createFunctionSql =
-            "CREATE TEMPORARY FUNCTION vector_search AS \n" +
-            "    'org.apache.flink.connector.lance.table.LanceVectorSearchFunction'";
-
-        System.out.println("-- Step 3: Register vector search UDF");
-        System.out.println(createFunctionSql);
-        System.out.println();
-        tableEnv.executeSql(createFunctionSql);
-        System.out.println("✅ UDF registration completed\n");
-
-        // ============================================
-        // Step 4: Execute vector search - Basic usage
-        // ============================================
-        System.out.println("-- Step 4: Execute vector search (Basic usage)");
-        System.out.println("-- Parameter description:");
-        System.out.println("--   Param 1: Dataset path");
-        System.out.println("--   Param 2: Vector column name");
-        System.out.println("--   Param 3: Query vector");
-        System.out.println("--   Param 4: TopK count to return");
-        System.out.println("--   Param 5: Distance metric type (L2/COSINE/DOT)");
-        System.out.println();
-
-        String vectorSearchSql = String.format(
-            "SELECT * FROM TABLE(\n" +
-            "    vector_search(\n" +
-            "        '%s',                              -- Dataset path\n" +
-            "        'embedding',                       -- Vector column name\n" +
-            "        ARRAY[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8],  -- Query vector\n" +
-            "        3,                                 -- Return Top 3\n" +
-            "        'L2'                               -- L2 distance metric\n" +
-            "    )\n" +
-            ")", datasetPath);
-
-        System.out.println(vectorSearchSql);
-        System.out.println();
-        System.out.println("📊 Search results (sorted by L2 distance, smaller distance = more similar):");
-        System.out.println("---------------------------------------------------");
-
-        try {
-            TableResult result = tableEnv.executeSql(vectorSearchSql);
-            result.print();
-        } catch (Exception e) {
-            System.out.println("⚠️ Vector search execution error: " + e.getMessage());
-            System.out.println("   This may be because the dataset needs to build index first");
-        }
-
-        // ============================================
-        // Step 5: Use COSINE cosine similarity search
-        // ============================================
-        System.out.println("\n-- Step 5: Use COSINE cosine similarity search");
-
-        String cosineSearchSql = String.format(
-            "SELECT * FROM TABLE(\n" +
-            "    vector_search(\n" +
-            "        '%s',\n" +
-            "        'embedding',\n" +
-            "        ARRAY[0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2, 0.1],\n" +
-            "        3,\n" +
-            "        'COSINE'                           -- Cosine similarity\n" +
-            "    )\n" +
-            ")", datasetPath);
-
-        System.out.println(cosineSearchSql);
-        System.out.println();
-        System.out.println("📊 Search results (sorted by cosine distance):");
-        System.out.println("---------------------------------------------------");
-
-        try {
-            tableEnv.executeSql(cosineSearchSql).print();
-        } catch (Exception e) {
-            System.out.println("⚠️ Execution error: " + e.getMessage());
-        }
-
-        // ============================================
-        // Step 6: Combine vector search with other queries
-        // ============================================
-        System.out.println("\n-- Step 6: Combine vector search with other queries (LATERAL TABLE)");
-
-        String lateralSearchSql = String.format(
-            "-- First query data, then perform vector search based on results\n" +
-            "SELECT \n" +
-            "    v.id,\n" +
-            "    v.title,\n" +
-            "    v._distance as similarity_distance\n" +
-            "FROM TABLE(\n" +
-            "    vector_search('%s', 'embedding', ARRAY[0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85], 5, 'L2')\n" +
-            ") AS v\n" +
-            "WHERE v._distance < 1.0  -- Only return results with distance less than 1", datasetPath);
-
-        System.out.println(lateralSearchSql);
-        System.out.println();
-
-        // ============================================
-        // Print configuration parameter descriptions
-        // ============================================
-        System.out.println("\n========== IVF_PQ Index Configuration Parameter Description ==========");
-        System.out.println("╔═════════════════════════════╦════════════════════════════════════════════════════╗");
-        System.out.println("║       Configuration         ║                Description                         ║");
-        System.out.println("╠═════════════════════════════╬════════════════════════════════════════════════════╣");
-        System.out.println("║ index.type = 'IVF_PQ'       ║ Use IVF_PQ index type                              ║");
-        System.out.println("║ index.column                ║ Vector column name to build index on              ║");
-        System.out.println("║ index.num-partitions        ║ IVF partition count, recommend: sqrt(n) to 4*sqrt(n)║");
-        System.out.println("║ index.num-sub-vectors       ║ PQ sub-vector count, must divide vector dimension ║");
-        System.out.println("║ index.num-bits              ║ PQ encoding bits, default 8 (256 cluster centers) ║");
-        System.out.println("║ vector.metric               ║ Distance metric: L2(Euclidean)/COSINE/DOT(Dot product)║");
-        System.out.println("║ vector.nprobes              ║ Number of partitions to probe during search       ║");
-        System.out.println("╚═════════════════════════════╩════════════════════════════════════════════════════╝");
-
-        System.out.println("\n========== Distance Metric Type Description ==========");
-        System.out.println("╔════════════════╦════════════════════════════════════════════════════════════════╗");
-        System.out.println("║  Metric Type   ║                          Description                           ║");
-        System.out.println("╠════════════════╬════════════════════════════════════════════════════════════════╣");
-        System.out.println("║    L2          ║ Euclidean distance, smaller = more similar, for dense vectors ║");
-        System.out.println("║    COSINE      ║ Cosine distance, range [0,2], smaller = more similar, for text║");
-        System.out.println("║    DOT         ║ Negative dot product, smaller = more similar (needs normalization)║");
-        System.out.println("╚════════════════╩════════════════════════════════════════════════════════════════╝");
-
-        System.out.println("\n✅ Vector search IVF_PQ example completed!\n");
-    }
-
-    @Test
-    @DisplayName("9.2 Different Index Types Comparison Example")
-    void testDifferentIndexTypesDetailed() throws Exception {
-        System.out.println("========== Different Vector Index Types Comparison ==========");
-
-        // Use relative path based on project root
-        Path basePath = Paths.get(System.getProperty("user.dir"), "test-data");
-
-        // ============================================
-        // IVF_PQ Index - For large-scale data, low memory footprint
-        // ============================================
-        System.out.println("【1. IVF_PQ Index】- Recommended for large-scale data");
-        System.out.println("Pros: Low memory footprint, fast search speed");
-        System.out.println("Cons: Lower accuracy (quantization loss)");
-        System.out.println();
-
-        String ivfPqSql = String.format(
-            "CREATE TABLE ivf_pq_vectors (\n" +
-            "    id BIGINT,\n" +
-            "    embedding ARRAY<FLOAT>\n" +
-            ") WITH (\n" +
-            "    'connector' = 'lance',\n" +
-            "    'path' = '%s',\n" +
-            "    'index.type' = 'IVF_PQ',\n" +
-            "    'index.column' = 'embedding',\n" +
-            "    'index.num-partitions' = '256',    -- IVF partition count\n" +
-            "    'index.num-sub-vectors' = '16',    -- PQ sub-vector count\n" +
-            "    'index.num-bits' = '8',            -- Encoding bits per sub-vector\n" +
-            "    'vector.metric' = 'L2'\n" +
-            ")", basePath.resolve("ivf-pq-demo"));
-
-        System.out.println(ivfPqSql);
-        System.out.println();
-
-        // ============================================
-        // IVF_HNSW Index - High accuracy search
-        // ============================================
-        System.out.println("【2. IVF_HNSW Index】- Recommended for high accuracy requirements");
-        System.out.println("Pros: High search accuracy");
-        System.out.println("Cons: Higher memory footprint, slower index building");
-        System.out.println();
-
-        String ivfHnswSql = String.format(
-            "CREATE TABLE ivf_hnsw_vectors (\n" +
-            "    id BIGINT,\n" +
-            "    embedding ARRAY<FLOAT>\n" +
-            ") WITH (\n" +
-            "    'connector' = 'lance',\n" +
-            "    'path' = '%s',\n" +
-            "    'index.type' = 'IVF_HNSW',\n" +
-            "    'index.column' = 'embedding',\n" +
-            "    'index.num-partitions' = '256',    -- IVF partition count\n" +
-            "    'index.hnsw-m' = '16',             -- HNSW connections per level\n" +
-            "    'index.hnsw-ef-construction' = '100', -- Candidate set size during construction\n" +
-            "    'vector.metric' = 'COSINE',\n" +
-            "    'vector.ef' = '50'                 -- Candidate set size during search\n" +
-            ")", basePath.resolve("ivf-hnsw-demo"));
-
-        System.out.println(ivfHnswSql);
-        System.out.println();
-
-        // ============================================
-        // IVF_FLAT Index - Highest accuracy, brute force search
-        // ============================================
-        System.out.println("【3. IVF_FLAT Index】- Highest accuracy");
-        System.out.println("Pros: 100% search accuracy (lossless)");
-        System.out.println("Cons: Slower search speed, suitable for small datasets");
-        System.out.println();
-
-        String ivfFlatSql = String.format(
-            "CREATE TABLE ivf_flat_vectors (\n" +
-            "    id BIGINT,\n" +
-            "    embedding ARRAY<FLOAT>\n" +
-            ") WITH (\n" +
-            "    'connector' = 'lance',\n" +
-            "    'path' = '%s',\n" +
-            "    'index.type' = 'IVF_FLAT',\n" +
-            "    'index.column' = 'embedding',\n" +
-            "    'index.num-partitions' = '128',    -- IVF partition count\n" +
-            "    'vector.metric' = 'DOT',\n" +
-            "    'vector.nprobes' = '32'            -- Number of partitions to probe during search\n" +
-            ")", basePath.resolve("ivf-flat-demo"));
-
-        System.out.println(ivfFlatSql);
-        System.out.println();
-
-        // ============================================
-        // Index Selection Recommendations
-        // ============================================
-        System.out.println("========== Index Selection Recommendations ==========");
-        System.out.println("╔═══════════════════╦════════════════╦═══════════════╦════════════════════════════════╗");
-        System.out.println("║   Index Type      ║   Data Scale   ║   Accuracy    ║           Use Case             ║");
-        System.out.println("╠═══════════════════╬════════════════╬═══════════════╬════════════════════════════════╣");
-        System.out.println("║    IVF_PQ         ║   1M+          ║    Medium     ║ Large-scale recommendation, image search║");
-        System.out.println("║    IVF_HNSW       ║   100K-1M      ║    High       ║ Semantic search, Q&A systems   ║");
-        System.out.println("║    IVF_FLAT       ║   <100K        ║    Highest    ║ Small-scale high-precision scenarios║");
-        System.out.println("╚═══════════════════╩════════════════╩═══════════════╩════════════════════════════════╝");
-
-        System.out.println("\n✅ Index type comparison example completed!\n");
-    }
-
-    @Test
-    @DisplayName("10. SQL Syntax Quick Reference")
-    void testSqlQuickReference() {
-        System.out.println("========================================");
-        System.out.println("     Flink SQL Lance Connector Quick Reference");
-        System.out.println("========================================\n");
-
-        System.out.println("【Create Table】");
-        System.out.println("CREATE TABLE table_name (");
-        System.out.println("    column_name data_type,");
-        System.out.println("    embedding ARRAY<FLOAT>");
-        System.out.println(") WITH (");
-        System.out.println("    'connector' = 'lance',");
-        System.out.println("    'path' = '/path/to/dataset'");
-        System.out.println(");\n");
-
-        System.out.println("【Insert Data】");
-        System.out.println("INSERT INTO table_name VALUES (1, 'text', ARRAY[0.1, 0.2, 0.3]);\n");
-
-        System.out.println("【Query Data】");
-        System.out.println("SELECT * FROM table_name WHERE condition;\n");
-
-        System.out.println("【Create Catalog】");
-        System.out.println("CREATE CATALOG lance_catalog WITH (");
-        System.out.println("    'type' = 'lance',");
-        System.out.println("    'warehouse' = '/path/to/warehouse'");
-        System.out.println(");\n");
-
-        System.out.println("【Data Type Mapping】");
-        System.out.println("╔════════════════════╦═══════════════════╗");
-        System.out.println("║   Flink SQL Type   ║     Lance Type    ║");
-        System.out.println("╠════════════════════╬═══════════════════╣");
-        System.out.println("║ BOOLEAN            ║ Bool              ║");
-        System.out.println("║ TINYINT            ║ Int8              ║");
-        System.out.println("║ SMALLINT           ║ Int16             ║");
-        System.out.println("║ INT                ║ Int32             ║");
-        System.out.println("║ BIGINT             ║ Int64             ║");
-        System.out.println("║ FLOAT              ║ Float32           ║");
-        System.out.println("║ DOUBLE             ║ Float64           ║");
-        System.out.println("║ STRING             ║ Utf8              ║");
-        System.out.println("║ BYTES              ║ Binary            ║");
-        System.out.println("║ DATE               ║ Date32            ║");
-        System.out.println("║ TIMESTAMP          ║ Timestamp         ║");
-        System.out.println("║ ARRAY<FLOAT>       ║ FixedSizeList     ║");
-        System.out.println("╚════════════════════╩═══════════════════╝\n");
-
-        System.out.println("【Configuration Options】");
-        System.out.println("╔═══════════════════════════╦════════════════════════════════╗");
-        System.out.println("║         Option            ║           Description          ║");
-        System.out.println("╠═══════════════════════════╬════════════════════════════════╣");
-        System.out.println("║ path                      ║ Dataset path (required)        ║");
-        System.out.println("║ write.batch-size          ║ Write batch size (default 1024)║");
-        System.out.println("║ write.mode                ║ Write mode: append/overwrite   ║");
-        System.out.println("║ read.batch-size           ║ Read batch size (default 1024) ║");
-        System.out.println("║ index.type                ║ Index type: IVF_PQ/IVF_HNSW/IVF_FLAT║");
-        System.out.println("║ index.column              ║ Index column name              ║");
-        System.out.println("║ index.num-partitions      ║ IVF partitions (default 256)   ║");
-        System.out.println("║ vector.column             ║ Vector column name             ║");
-        System.out.println("║ vector.metric             ║ Distance metric: L2/COSINE/DOT ║");
-        System.out.println("║ vector.nprobes            ║ Search probes (default 20)     ║");
-        System.out.println("╚═══════════════════════════╩════════════════════════════════╝\n");
-
-        System.out.println("✅ Quick reference completed!");
-    }
+    // ============================================
+    // Step 6: Combine vector search with other queries
+    // ============================================
+    System.out.println("\n-- Step 6: Combine vector search with other queries (LATERAL TABLE)");
+
+    String lateralSearchSql =
+        String.format(
+            "-- First query data, then perform vector search based on results\n"
+                + "SELECT \n"
+                + "    v.id,\n"
+                + "    v.title,\n"
+                + "    v._distance as similarity_distance\n"
+                + "FROM TABLE(\n"
+                + "    vector_search('%s', 'embedding', ARRAY[0.15, 0.25, 0.35, 0.45, 0.55, 0.65, 0.75, 0.85], 5, 'L2')\n"
+                + ") AS v\n"
+                + "WHERE v._distance < 1.0  -- Only return results with distance less than 1",
+            datasetPath);
+
+    System.out.println(lateralSearchSql);
+    System.out.println();
+
+    // ============================================
+    // Print configuration parameter descriptions
+    // ============================================
+    System.out.println("\n========== IVF_PQ Index Configuration Parameter Description ==========");
+    System.out.println(
+        "╔═════════════════════════════╦════════════════════════════════════════════════════╗");
+    System.out.println(
+        "║       Configuration         ║                Description                         ║");
+    System.out.println(
+        "╠═════════════════════════════╬════════════════════════════════════════════════════╣");
+    System.out.println(
+        "║ index.type = 'IVF_PQ'       ║ Use IVF_PQ index type                              ║");
+    System.out.println(
+        "║ index.column                ║ Vector column name to build index on              ║");
+    System.out.println(
+        "║ index.num-partitions        ║ IVF partition count, recommend: sqrt(n) to 4*sqrt(n)║");
+    System.out.println(
+        "║ index.num-sub-vectors       ║ PQ sub-vector count, must divide vector dimension ║");
+    System.out.println(
+        "║ index.num-bits              ║ PQ encoding bits, default 8 (256 cluster centers) ║");
+    System.out.println(
+        "║ vector.metric               ║ Distance metric: L2(Euclidean)/COSINE/DOT(Dot product)║");
+    System.out.println(
+        "║ vector.nprobes              ║ Number of partitions to probe during search       ║");
+    System.out.println(
+        "╚═════════════════════════════╩════════════════════════════════════════════════════╝");
+
+    System.out.println("\n========== Distance Metric Type Description ==========");
+    System.out.println(
+        "╔════════════════╦════════════════════════════════════════════════════════════════╗");
+    System.out.println(
+        "║  Metric Type   ║                          Description                           ║");
+    System.out.println(
+        "╠════════════════╬════════════════════════════════════════════════════════════════╣");
+    System.out.println(
+        "║    L2          ║ Euclidean distance, smaller = more similar, for dense vectors ║");
+    System.out.println(
+        "║    COSINE      ║ Cosine distance, range [0,2], smaller = more similar, for text║");
+    System.out.println(
+        "║    DOT         ║ Negative dot product, smaller = more similar (needs normalization)║");
+    System.out.println(
+        "╚════════════════╩════════════════════════════════════════════════════════════════╝");
+
+    System.out.println("\n✅ Vector search IVF_PQ example completed!\n");
+  }
+
+  @Test
+  @DisplayName("9.2 Different Index Types Comparison Example")
+  void testDifferentIndexTypesDetailed() throws Exception {
+    System.out.println("========== Different Vector Index Types Comparison ==========");
+
+    // Use relative path based on project root
+    Path basePath = Paths.get(System.getProperty("user.dir"), "test-data");
+
+    // ============================================
+    // IVF_PQ Index - For large-scale data, low memory footprint
+    // ============================================
+    System.out.println("【1. IVF_PQ Index】- Recommended for large-scale data");
+    System.out.println("Pros: Low memory footprint, fast search speed");
+    System.out.println("Cons: Lower accuracy (quantization loss)");
+    System.out.println();
+
+    String ivfPqSql =
+        String.format(
+            "CREATE TABLE ivf_pq_vectors (\n"
+                + "    id BIGINT,\n"
+                + "    embedding ARRAY<FLOAT>\n"
+                + ") WITH (\n"
+                + "    'connector' = 'lance',\n"
+                + "    'path' = '%s',\n"
+                + "    'index.type' = 'IVF_PQ',\n"
+                + "    'index.column' = 'embedding',\n"
+                + "    'index.num-partitions' = '256',    -- IVF partition count\n"
+                + "    'index.num-sub-vectors' = '16',    -- PQ sub-vector count\n"
+                + "    'index.num-bits' = '8',            -- Encoding bits per sub-vector\n"
+                + "    'vector.metric' = 'L2'\n"
+                + ")",
+            basePath.resolve("ivf-pq-demo"));
+
+    System.out.println(ivfPqSql);
+    System.out.println();
+
+    // ============================================
+    // IVF_HNSW Index - High accuracy search
+    // ============================================
+    System.out.println("【2. IVF_HNSW Index】- Recommended for high accuracy requirements");
+    System.out.println("Pros: High search accuracy");
+    System.out.println("Cons: Higher memory footprint, slower index building");
+    System.out.println();
+
+    String ivfHnswSql =
+        String.format(
+            "CREATE TABLE ivf_hnsw_vectors (\n"
+                + "    id BIGINT,\n"
+                + "    embedding ARRAY<FLOAT>\n"
+                + ") WITH (\n"
+                + "    'connector' = 'lance',\n"
+                + "    'path' = '%s',\n"
+                + "    'index.type' = 'IVF_HNSW',\n"
+                + "    'index.column' = 'embedding',\n"
+                + "    'index.num-partitions' = '256',    -- IVF partition count\n"
+                + "    'index.hnsw-m' = '16',             -- HNSW connections per level\n"
+                + "    'index.hnsw-ef-construction' = '100', -- Candidate set size during construction\n"
+                + "    'vector.metric' = 'COSINE',\n"
+                + "    'vector.ef' = '50'                 -- Candidate set size during search\n"
+                + ")",
+            basePath.resolve("ivf-hnsw-demo"));
+
+    System.out.println(ivfHnswSql);
+    System.out.println();
+
+    // ============================================
+    // IVF_FLAT Index - Highest accuracy, brute force search
+    // ============================================
+    System.out.println("【3. IVF_FLAT Index】- Highest accuracy");
+    System.out.println("Pros: 100% search accuracy (lossless)");
+    System.out.println("Cons: Slower search speed, suitable for small datasets");
+    System.out.println();
+
+    String ivfFlatSql =
+        String.format(
+            "CREATE TABLE ivf_flat_vectors (\n"
+                + "    id BIGINT,\n"
+                + "    embedding ARRAY<FLOAT>\n"
+                + ") WITH (\n"
+                + "    'connector' = 'lance',\n"
+                + "    'path' = '%s',\n"
+                + "    'index.type' = 'IVF_FLAT',\n"
+                + "    'index.column' = 'embedding',\n"
+                + "    'index.num-partitions' = '128',    -- IVF partition count\n"
+                + "    'vector.metric' = 'DOT',\n"
+                + "    'vector.nprobes' = '32'            -- Number of partitions to probe during search\n"
+                + ")",
+            basePath.resolve("ivf-flat-demo"));
+
+    System.out.println(ivfFlatSql);
+    System.out.println();
+
+    // ============================================
+    // Index Selection Recommendations
+    // ============================================
+    System.out.println("========== Index Selection Recommendations ==========");
+    System.out.println(
+        "╔═══════════════════╦════════════════╦═══════════════╦════════════════════════════════╗");
+    System.out.println(
+        "║   Index Type      ║   Data Scale   ║   Accuracy    ║           Use Case             ║");
+    System.out.println(
+        "╠═══════════════════╬════════════════╬═══════════════╬════════════════════════════════╣");
+    System.out.println(
+        "║    IVF_PQ         ║   1M+          ║    Medium     ║ Large-scale recommendation, image search║");
+    System.out.println(
+        "║    IVF_HNSW       ║   100K-1M      ║    High       ║ Semantic search, Q&A systems   ║");
+    System.out.println(
+        "║    IVF_FLAT       ║   <100K        ║    Highest    ║ Small-scale high-precision scenarios║");
+    System.out.println(
+        "╚═══════════════════╩════════════════╩═══════════════╩════════════════════════════════╝");
+
+    System.out.println("\n✅ Index type comparison example completed!\n");
+  }
+
+  @Test
+  @DisplayName("10. SQL Syntax Quick Reference")
+  void testSqlQuickReference() {
+    System.out.println("========================================");
+    System.out.println("     Flink SQL Lance Connector Quick Reference");
+    System.out.println("========================================\n");
+
+    System.out.println("【Create Table】");
+    System.out.println("CREATE TABLE table_name (");
+    System.out.println("    column_name data_type,");
+    System.out.println("    embedding ARRAY<FLOAT>");
+    System.out.println(") WITH (");
+    System.out.println("    'connector' = 'lance',");
+    System.out.println("    'path' = '/path/to/dataset'");
+    System.out.println(");\n");
+
+    System.out.println("【Insert Data】");
+    System.out.println("INSERT INTO table_name VALUES (1, 'text', ARRAY[0.1, 0.2, 0.3]);\n");
+
+    System.out.println("【Query Data】");
+    System.out.println("SELECT * FROM table_name WHERE condition;\n");
+
+    System.out.println("【Create Catalog】");
+    System.out.println("CREATE CATALOG lance_catalog WITH (");
+    System.out.println("    'type' = 'lance',");
+    System.out.println("    'warehouse' = '/path/to/warehouse'");
+    System.out.println(");\n");
+
+    System.out.println("【Data Type Mapping】");
+    System.out.println("╔════════════════════╦═══════════════════╗");
+    System.out.println("║   Flink SQL Type   ║     Lance Type    ║");
+    System.out.println("╠════════════════════╬═══════════════════╣");
+    System.out.println("║ BOOLEAN            ║ Bool              ║");
+    System.out.println("║ TINYINT            ║ Int8              ║");
+    System.out.println("║ SMALLINT           ║ Int16             ║");
+    System.out.println("║ INT                ║ Int32             ║");
+    System.out.println("║ BIGINT             ║ Int64             ║");
+    System.out.println("║ FLOAT              ║ Float32           ║");
+    System.out.println("║ DOUBLE             ║ Float64           ║");
+    System.out.println("║ STRING             ║ Utf8              ║");
+    System.out.println("║ BYTES              ║ Binary            ║");
+    System.out.println("║ DATE               ║ Date32            ║");
+    System.out.println("║ TIMESTAMP          ║ Timestamp         ║");
+    System.out.println("║ ARRAY<FLOAT>       ║ FixedSizeList     ║");
+    System.out.println("╚════════════════════╩═══════════════════╝\n");
+
+    System.out.println("【Configuration Options】");
+    System.out.println("╔═══════════════════════════╦════════════════════════════════╗");
+    System.out.println("║         Option            ║           Description          ║");
+    System.out.println("╠═══════════════════════════╬════════════════════════════════╣");
+    System.out.println("║ path                      ║ Dataset path (required)        ║");
+    System.out.println("║ write.batch-size          ║ Write batch size (default 1024)║");
+    System.out.println("║ write.mode                ║ Write mode: append/overwrite   ║");
+    System.out.println("║ read.batch-size           ║ Read batch size (default 1024) ║");
+    System.out.println("║ index.type                ║ Index type: IVF_PQ/IVF_HNSW/IVF_FLAT║");
+    System.out.println("║ index.column              ║ Index column name              ║");
+    System.out.println("║ index.num-partitions      ║ IVF partitions (default 256)   ║");
+    System.out.println("║ vector.column             ║ Vector column name             ║");
+    System.out.println("║ vector.metric             ║ Distance metric: L2/COSINE/DOT ║");
+    System.out.println("║ vector.nprobes            ║ Search probes (default 20)     ║");
+    System.out.println("╚═══════════════════════════╩════════════════════════════════╝\n");
+
+    System.out.println("✅ Quick reference completed!");
+  }
 }

--- a/src/test/java/org/apache/flink/connector/lance/table/LanceAggregatePushDownTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/table/LanceAggregatePushDownTest.java
@@ -80,7 +80,7 @@ class LanceAggregatePushDownTest {
         @DisplayName("Initial state should have no aggregate push-down")
         void testInitialState() {
             LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
-            
+
             assertFalse(source.isAggregatePushDownAccepted());
             assertNull(source.getAggregateInfo());
         }
@@ -89,10 +89,10 @@ class LanceAggregatePushDownTest {
         @DisplayName("copy should correctly copy aggregate state")
         void testCopyAggregateState() {
             LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
-            
+
             // Copy source
             LanceDynamicTableSource copied = (LanceDynamicTableSource) source.copy();
-            
+
             // Verify copied state
             assertFalse(copied.isAggregatePushDownAccepted());
             assertNull(copied.getAggregateInfo());
@@ -103,9 +103,9 @@ class LanceAggregatePushDownTest {
         @DisplayName("asSummaryString should return correct summary")
         void testAsSummaryString() {
             LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
-            
+
             String summary = source.asSummaryString();
-            
+
             assertEquals("Lance Table Source", summary);
         }
     }
@@ -122,7 +122,7 @@ class LanceAggregatePushDownTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addCountStar("cnt")
                     .build();
-            
+
             assertTrue(aggInfo.isSimpleCountStar());
             assertFalse(aggInfo.hasGroupBy());
             assertEquals(1, aggInfo.getAggregateCalls().size());
@@ -137,7 +137,7 @@ class LanceAggregatePushDownTest {
                     .groupBy("category")
                     .groupByFieldIndices(new int[]{2})  // category at index 2
                     .build();
-            
+
             assertFalse(aggInfo.isSimpleCountStar());
             assertTrue(aggInfo.hasGroupBy());
             assertEquals(2, aggInfo.getAggregateCalls().size());
@@ -154,9 +154,9 @@ class LanceAggregatePushDownTest {
                     .addMin("amount", "min_amount")
                     .addMax("amount", "max_amount")
                     .build();
-            
+
             assertEquals(5, aggInfo.getAggregateCalls().size());
-            
+
             // Verify each aggregate function type
             List<AggregateInfo.AggregateCall> calls = aggInfo.getAggregateCalls();
             assertEquals(AggregateInfo.AggregateFunction.COUNT, calls.get(0).getFunction());
@@ -174,9 +174,9 @@ class LanceAggregatePushDownTest {
                     .addAvg("quantity", "avg_quantity")
                     .groupBy("category")
                     .build();
-            
+
             List<String> required = aggInfo.getRequiredColumns();
-            
+
             assertTrue(required.contains("category"));
             assertTrue(required.contains("amount"));
             assertTrue(required.contains("quantity"));
@@ -193,10 +193,10 @@ class LanceAggregatePushDownTest {
         @DisplayName("Aggregate push-down with filter push-down combination")
         void testAggregatePushDownWithFilter() {
             LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
-            
+
             // Simulate adding filter conditions (through internal filters list)
             // Note: Actual filter push-down is done through applyFilters method
-            
+
             // Verify source can support both filter and aggregate push-down
             assertNotNull(source.getOptions());
         }
@@ -205,10 +205,10 @@ class LanceAggregatePushDownTest {
         @DisplayName("Aggregate push-down with column pruning combination")
         void testAggregatePushDownWithProjection() {
             LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
-            
+
             // Apply column pruning
             source.applyProjection(new int[][]{{0}, {3}, {4}});  // id, amount, quantity
-            
+
             // Verify source still works correctly
             assertNotNull(source.getOptions());
         }
@@ -217,10 +217,10 @@ class LanceAggregatePushDownTest {
         @DisplayName("Aggregate push-down with Limit combination")
         void testAggregatePushDownWithLimit() {
             LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
-            
+
             // Apply Limit
             source.applyLimit(100);
-            
+
             assertEquals(Long.valueOf(100), source.getLimit());
         }
     }
@@ -239,7 +239,7 @@ class LanceAggregatePushDownTest {
                     .groupBy("category", "name")
                     .groupByFieldIndices(new int[]{2, 1})
                     .build();
-            
+
             assertEquals(2, aggInfo.getGroupByColumns().size());
             assertArrayEquals(new int[]{2, 1}, aggInfo.getGroupByFieldIndices());
         }
@@ -254,9 +254,9 @@ class LanceAggregatePushDownTest {
                     .addMax("amount", "max_amount")
                     .addCount("amount", "count_amount")
                     .build();
-            
+
             assertEquals(5, aggInfo.getAggregateCalls().size());
-            
+
             // Verify getRequiredColumns contains amount only once
             List<String> required = aggInfo.getRequiredColumns();
             long amountCount = required.stream().filter(c -> c.equals("amount")).count();
@@ -269,7 +269,7 @@ class LanceAggregatePushDownTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addCountStar("cnt")
                     .build();
-            
+
             assertFalse(aggInfo.hasGroupBy());
             assertTrue(aggInfo.getGroupByColumns().isEmpty());
             assertEquals(0, aggInfo.getGroupByFieldIndices().length);
@@ -288,7 +288,7 @@ class LanceAggregatePushDownTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addCountStar("cnt")
                     .build();
-            
+
             AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
             assertEquals(AggregateInfo.AggregateFunction.COUNT, call.getFunction());
             assertTrue(call.isCountStar());
@@ -300,7 +300,7 @@ class LanceAggregatePushDownTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addSum("amount", "sum_amount")
                     .build();
-            
+
             AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
             assertEquals(AggregateInfo.AggregateFunction.SUM, call.getFunction());
             assertEquals("amount", call.getColumn());
@@ -312,7 +312,7 @@ class LanceAggregatePushDownTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addAvg("amount", "avg_amount")
                     .build();
-            
+
             AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
             assertEquals(AggregateInfo.AggregateFunction.AVG, call.getFunction());
             assertEquals("amount", call.getColumn());
@@ -324,7 +324,7 @@ class LanceAggregatePushDownTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addMin("amount", "min_amount")
                     .build();
-            
+
             AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
             assertEquals(AggregateInfo.AggregateFunction.MIN, call.getFunction());
             assertEquals("amount", call.getColumn());
@@ -336,7 +336,7 @@ class LanceAggregatePushDownTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addMax("amount", "max_amount")
                     .build();
-            
+
             AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
             assertEquals(AggregateInfo.AggregateFunction.MAX, call.getFunction());
             assertEquals("amount", call.getColumn());
@@ -348,7 +348,7 @@ class LanceAggregatePushDownTest {
             AggregateInfo aggInfo = AggregateInfo.builder()
                     .addAggregateCall(AggregateInfo.AggregateFunction.COUNT_DISTINCT, "category", "distinct_cnt")
                     .build();
-            
+
             AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
             assertEquals(AggregateInfo.AggregateFunction.COUNT_DISTINCT, call.getFunction());
             assertEquals("category", call.getColumn());

--- a/src/test/java/org/apache/flink/connector/lance/table/LanceAggregatePushDownTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/table/LanceAggregatePushDownTest.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.table;
 
 import org.apache.flink.connector.lance.aggregate.AggregateInfo;
@@ -26,332 +21,319 @@ import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.utils.TypeConversions;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-/**
- * LanceDynamicTableSource aggregate push-down tests
- */
+/** LanceDynamicTableSource aggregate push-down tests */
 @DisplayName("LanceDynamicTableSource Aggregate Push-Down Tests")
 class LanceAggregatePushDownTest {
 
-    private LanceOptions options;
-    private DataType physicalDataType;
+  private LanceOptions options;
+  private DataType physicalDataType;
 
-    @BeforeEach
-    void setUp() {
-        options = LanceOptions.builder()
-                .path("/tmp/test_lance_dataset")
-                .readBatchSize(1024)
-                .build();
+  @BeforeEach
+  void setUp() {
+    options = LanceOptions.builder().path("/tmp/test_lance_dataset").readBatchSize(1024).build();
 
-        // Create test physical data type
-        // Schema: (id INT, name VARCHAR, category VARCHAR, amount DOUBLE, quantity INT)
-        RowType rowType = new RowType(Arrays.asList(
+    // Create test physical data type
+    // Schema: (id INT, name VARCHAR, category VARCHAR, amount DOUBLE, quantity INT)
+    RowType rowType =
+        new RowType(
+            Arrays.asList(
                 new RowType.RowField("id", new IntType()),
                 new RowType.RowField("name", new VarCharType(100)),
                 new RowType.RowField("category", new VarCharType(50)),
                 new RowType.RowField("amount", new DoubleType()),
-                new RowType.RowField("quantity", new IntType())
-        ));
-        physicalDataType = TypeConversions.fromLogicalToDataType(rowType);
+                new RowType.RowField("quantity", new IntType())));
+    physicalDataType = TypeConversions.fromLogicalToDataType(rowType);
+  }
+
+  // ==================== Aggregate Push-Down Interface Tests ====================
+
+  @Nested
+  @DisplayName("applyAggregates Method Tests")
+  class ApplyAggregatesTests {
+
+    // Note: Since applyAggregates requires real AggregateExpression objects,
+    // we mainly test aggregate info storage and state management here
+
+    @Test
+    @DisplayName("Initial state should have no aggregate push-down")
+    void testInitialState() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
+
+      assertFalse(source.isAggregatePushDownAccepted());
+      assertNull(source.getAggregateInfo());
     }
 
-    // ==================== Aggregate Push-Down Interface Tests ====================
+    @Test
+    @DisplayName("copy should correctly copy aggregate state")
+    void testCopyAggregateState() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
 
-    @Nested
-    @DisplayName("applyAggregates Method Tests")
-    class ApplyAggregatesTests {
+      // Copy source
+      LanceDynamicTableSource copied = (LanceDynamicTableSource) source.copy();
 
-        // Note: Since applyAggregates requires real AggregateExpression objects,
-        // we mainly test aggregate info storage and state management here
-
-        @Test
-        @DisplayName("Initial state should have no aggregate push-down")
-        void testInitialState() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
-
-            assertFalse(source.isAggregatePushDownAccepted());
-            assertNull(source.getAggregateInfo());
-        }
-
-        @Test
-        @DisplayName("copy should correctly copy aggregate state")
-        void testCopyAggregateState() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
-
-            // Copy source
-            LanceDynamicTableSource copied = (LanceDynamicTableSource) source.copy();
-
-            // Verify copied state
-            assertFalse(copied.isAggregatePushDownAccepted());
-            assertNull(copied.getAggregateInfo());
-            assertNotSame(source, copied);
-        }
-
-        @Test
-        @DisplayName("asSummaryString should return correct summary")
-        void testAsSummaryString() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
-
-            String summary = source.asSummaryString();
-
-            assertEquals("Lance Table Source", summary);
-        }
+      // Verify copied state
+      assertFalse(copied.isAggregatePushDownAccepted());
+      assertNull(copied.getAggregateInfo());
+      assertNotSame(source, copied);
     }
 
-    // ==================== AggregateInfo Integration Tests ====================
+    @Test
+    @DisplayName("asSummaryString should return correct summary")
+    void testAsSummaryString() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
 
-    @Nested
-    @DisplayName("AggregateInfo Integration Tests")
-    class AggregateInfoIntegrationTests {
+      String summary = source.asSummaryString();
 
-        @Test
-        @DisplayName("Simple COUNT(*) aggregate info build")
-        void testSimpleCountStarAggregateInfo() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .build();
+      assertEquals("Lance Table Source", summary);
+    }
+  }
 
-            assertTrue(aggInfo.isSimpleCountStar());
-            assertFalse(aggInfo.hasGroupBy());
-            assertEquals(1, aggInfo.getAggregateCalls().size());
-        }
+  // ==================== AggregateInfo Integration Tests ====================
 
-        @Test
-        @DisplayName("Aggregate info build with GROUP BY")
-        void testGroupByAggregateInfo() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addSum("amount", "total_amount")
-                    .addAvg("amount", "avg_amount")
-                    .groupBy("category")
-                    .groupByFieldIndices(new int[]{2})  // category at index 2
-                    .build();
+  @Nested
+  @DisplayName("AggregateInfo Integration Tests")
+  class AggregateInfoIntegrationTests {
 
-            assertFalse(aggInfo.isSimpleCountStar());
-            assertTrue(aggInfo.hasGroupBy());
-            assertEquals(2, aggInfo.getAggregateCalls().size());
-            assertEquals(Collections.singletonList("category"), aggInfo.getGroupByColumns());
-        }
+    @Test
+    @DisplayName("Simple COUNT(*) aggregate info build")
+    void testSimpleCountStarAggregateInfo() {
+      AggregateInfo aggInfo = AggregateInfo.builder().addCountStar("cnt").build();
 
-        @Test
-        @DisplayName("Multiple aggregates info build")
-        void testMultipleAggregatesInfo() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .addSum("amount", "sum_amount")
-                    .addAvg("amount", "avg_amount")
-                    .addMin("amount", "min_amount")
-                    .addMax("amount", "max_amount")
-                    .build();
-
-            assertEquals(5, aggInfo.getAggregateCalls().size());
-
-            // Verify each aggregate function type
-            List<AggregateInfo.AggregateCall> calls = aggInfo.getAggregateCalls();
-            assertEquals(AggregateInfo.AggregateFunction.COUNT, calls.get(0).getFunction());
-            assertEquals(AggregateInfo.AggregateFunction.SUM, calls.get(1).getFunction());
-            assertEquals(AggregateInfo.AggregateFunction.AVG, calls.get(2).getFunction());
-            assertEquals(AggregateInfo.AggregateFunction.MIN, calls.get(3).getFunction());
-            assertEquals(AggregateInfo.AggregateFunction.MAX, calls.get(4).getFunction());
-        }
-
-        @Test
-        @DisplayName("getRequiredColumns should return correct columns")
-        void testGetRequiredColumns() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addSum("amount", "sum_amount")
-                    .addAvg("quantity", "avg_quantity")
-                    .groupBy("category")
-                    .build();
-
-            List<String> required = aggInfo.getRequiredColumns();
-
-            assertTrue(required.contains("category"));
-            assertTrue(required.contains("amount"));
-            assertTrue(required.contains("quantity"));
-        }
+      assertTrue(aggInfo.isSimpleCountStar());
+      assertFalse(aggInfo.hasGroupBy());
+      assertEquals(1, aggInfo.getAggregateCalls().size());
     }
 
-    // ==================== Combined Functionality Tests ====================
+    @Test
+    @DisplayName("Aggregate info build with GROUP BY")
+    void testGroupByAggregateInfo() {
+      AggregateInfo aggInfo =
+          AggregateInfo.builder()
+              .addSum("amount", "total_amount")
+              .addAvg("amount", "avg_amount")
+              .groupBy("category")
+              .groupByFieldIndices(new int[] {2}) // category at index 2
+              .build();
 
-    @Nested
-    @DisplayName("Combined Functionality Tests")
-    class CombinedFunctionalityTests {
-
-        @Test
-        @DisplayName("Aggregate push-down with filter push-down combination")
-        void testAggregatePushDownWithFilter() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
-
-            // Simulate adding filter conditions (through internal filters list)
-            // Note: Actual filter push-down is done through applyFilters method
-
-            // Verify source can support both filter and aggregate push-down
-            assertNotNull(source.getOptions());
-        }
-
-        @Test
-        @DisplayName("Aggregate push-down with column pruning combination")
-        void testAggregatePushDownWithProjection() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
-
-            // Apply column pruning
-            source.applyProjection(new int[][]{{0}, {3}, {4}});  // id, amount, quantity
-
-            // Verify source still works correctly
-            assertNotNull(source.getOptions());
-        }
-
-        @Test
-        @DisplayName("Aggregate push-down with Limit combination")
-        void testAggregatePushDownWithLimit() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
-
-            // Apply Limit
-            source.applyLimit(100);
-
-            assertEquals(Long.valueOf(100), source.getLimit());
-        }
+      assertFalse(aggInfo.isSimpleCountStar());
+      assertTrue(aggInfo.hasGroupBy());
+      assertEquals(2, aggInfo.getAggregateCalls().size());
+      assertEquals(Collections.singletonList("category"), aggInfo.getGroupByColumns());
     }
 
-    // ==================== Edge Case Tests ====================
+    @Test
+    @DisplayName("Multiple aggregates info build")
+    void testMultipleAggregatesInfo() {
+      AggregateInfo aggInfo =
+          AggregateInfo.builder()
+              .addCountStar("cnt")
+              .addSum("amount", "sum_amount")
+              .addAvg("amount", "avg_amount")
+              .addMin("amount", "min_amount")
+              .addMax("amount", "max_amount")
+              .build();
 
-    @Nested
-    @DisplayName("Edge Case Tests")
-    class EdgeCaseTests {
+      assertEquals(5, aggInfo.getAggregateCalls().size());
 
-        @Test
-        @DisplayName("Multiple group by columns should be handled correctly")
-        void testMultipleGroupByColumns() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .groupBy("category", "name")
-                    .groupByFieldIndices(new int[]{2, 1})
-                    .build();
-
-            assertEquals(2, aggInfo.getGroupByColumns().size());
-            assertArrayEquals(new int[]{2, 1}, aggInfo.getGroupByFieldIndices());
-        }
-
-        @Test
-        @DisplayName("Multiple aggregates on same column should be handled correctly")
-        void testMultipleAggregatesOnSameColumn() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addSum("amount", "sum_amount")
-                    .addAvg("amount", "avg_amount")
-                    .addMin("amount", "min_amount")
-                    .addMax("amount", "max_amount")
-                    .addCount("amount", "count_amount")
-                    .build();
-
-            assertEquals(5, aggInfo.getAggregateCalls().size());
-
-            // Verify getRequiredColumns contains amount only once
-            List<String> required = aggInfo.getRequiredColumns();
-            long amountCount = required.stream().filter(c -> c.equals("amount")).count();
-            assertEquals(1, amountCount);
-        }
-
-        @Test
-        @DisplayName("Empty group by set should be handled correctly")
-        void testEmptyGroupBy() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .build();
-
-            assertFalse(aggInfo.hasGroupBy());
-            assertTrue(aggInfo.getGroupByColumns().isEmpty());
-            assertEquals(0, aggInfo.getGroupByFieldIndices().length);
-        }
+      // Verify each aggregate function type
+      List<AggregateInfo.AggregateCall> calls = aggInfo.getAggregateCalls();
+      assertEquals(AggregateInfo.AggregateFunction.COUNT, calls.get(0).getFunction());
+      assertEquals(AggregateInfo.AggregateFunction.SUM, calls.get(1).getFunction());
+      assertEquals(AggregateInfo.AggregateFunction.AVG, calls.get(2).getFunction());
+      assertEquals(AggregateInfo.AggregateFunction.MIN, calls.get(3).getFunction());
+      assertEquals(AggregateInfo.AggregateFunction.MAX, calls.get(4).getFunction());
     }
 
-    // ==================== Aggregate Function Support Tests ====================
+    @Test
+    @DisplayName("getRequiredColumns should return correct columns")
+    void testGetRequiredColumns() {
+      AggregateInfo aggInfo =
+          AggregateInfo.builder()
+              .addSum("amount", "sum_amount")
+              .addAvg("quantity", "avg_quantity")
+              .groupBy("category")
+              .build();
 
-    @Nested
-    @DisplayName("Aggregate Function Support Tests")
-    class AggregateFunctionSupportTests {
+      List<String> required = aggInfo.getRequiredColumns();
 
-        @Test
-        @DisplayName("COUNT function should be supported")
-        void testCountSupport() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addCountStar("cnt")
-                    .build();
-
-            AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
-            assertEquals(AggregateInfo.AggregateFunction.COUNT, call.getFunction());
-            assertTrue(call.isCountStar());
-        }
-
-        @Test
-        @DisplayName("SUM function should be supported")
-        void testSumSupport() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addSum("amount", "sum_amount")
-                    .build();
-
-            AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
-            assertEquals(AggregateInfo.AggregateFunction.SUM, call.getFunction());
-            assertEquals("amount", call.getColumn());
-        }
-
-        @Test
-        @DisplayName("AVG function should be supported")
-        void testAvgSupport() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addAvg("amount", "avg_amount")
-                    .build();
-
-            AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
-            assertEquals(AggregateInfo.AggregateFunction.AVG, call.getFunction());
-            assertEquals("amount", call.getColumn());
-        }
-
-        @Test
-        @DisplayName("MIN function should be supported")
-        void testMinSupport() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addMin("amount", "min_amount")
-                    .build();
-
-            AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
-            assertEquals(AggregateInfo.AggregateFunction.MIN, call.getFunction());
-            assertEquals("amount", call.getColumn());
-        }
-
-        @Test
-        @DisplayName("MAX function should be supported")
-        void testMaxSupport() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addMax("amount", "max_amount")
-                    .build();
-
-            AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
-            assertEquals(AggregateInfo.AggregateFunction.MAX, call.getFunction());
-            assertEquals("amount", call.getColumn());
-        }
-
-        @Test
-        @DisplayName("COUNT DISTINCT function should be supported")
-        void testCountDistinctSupport() {
-            AggregateInfo aggInfo = AggregateInfo.builder()
-                    .addAggregateCall(AggregateInfo.AggregateFunction.COUNT_DISTINCT, "category", "distinct_cnt")
-                    .build();
-
-            AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
-            assertEquals(AggregateInfo.AggregateFunction.COUNT_DISTINCT, call.getFunction());
-            assertEquals("category", call.getColumn());
-        }
+      assertTrue(required.contains("category"));
+      assertTrue(required.contains("amount"));
+      assertTrue(required.contains("quantity"));
     }
+  }
+
+  // ==================== Combined Functionality Tests ====================
+
+  @Nested
+  @DisplayName("Combined Functionality Tests")
+  class CombinedFunctionalityTests {
+
+    @Test
+    @DisplayName("Aggregate push-down with filter push-down combination")
+    void testAggregatePushDownWithFilter() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
+
+      // Simulate adding filter conditions (through internal filters list)
+      // Note: Actual filter push-down is done through applyFilters method
+
+      // Verify source can support both filter and aggregate push-down
+      assertNotNull(source.getOptions());
+    }
+
+    @Test
+    @DisplayName("Aggregate push-down with column pruning combination")
+    void testAggregatePushDownWithProjection() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
+
+      // Apply column pruning
+      source.applyProjection(new int[][] {{0}, {3}, {4}}); // id, amount, quantity
+
+      // Verify source still works correctly
+      assertNotNull(source.getOptions());
+    }
+
+    @Test
+    @DisplayName("Aggregate push-down with Limit combination")
+    void testAggregatePushDownWithLimit() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(options, physicalDataType);
+
+      // Apply Limit
+      source.applyLimit(100);
+
+      assertEquals(Long.valueOf(100), source.getLimit());
+    }
+  }
+
+  // ==================== Edge Case Tests ====================
+
+  @Nested
+  @DisplayName("Edge Case Tests")
+  class EdgeCaseTests {
+
+    @Test
+    @DisplayName("Multiple group by columns should be handled correctly")
+    void testMultipleGroupByColumns() {
+      AggregateInfo aggInfo =
+          AggregateInfo.builder()
+              .addCountStar("cnt")
+              .groupBy("category", "name")
+              .groupByFieldIndices(new int[] {2, 1})
+              .build();
+
+      assertEquals(2, aggInfo.getGroupByColumns().size());
+      assertArrayEquals(new int[] {2, 1}, aggInfo.getGroupByFieldIndices());
+    }
+
+    @Test
+    @DisplayName("Multiple aggregates on same column should be handled correctly")
+    void testMultipleAggregatesOnSameColumn() {
+      AggregateInfo aggInfo =
+          AggregateInfo.builder()
+              .addSum("amount", "sum_amount")
+              .addAvg("amount", "avg_amount")
+              .addMin("amount", "min_amount")
+              .addMax("amount", "max_amount")
+              .addCount("amount", "count_amount")
+              .build();
+
+      assertEquals(5, aggInfo.getAggregateCalls().size());
+
+      // Verify getRequiredColumns contains amount only once
+      List<String> required = aggInfo.getRequiredColumns();
+      long amountCount = required.stream().filter(c -> c.equals("amount")).count();
+      assertEquals(1, amountCount);
+    }
+
+    @Test
+    @DisplayName("Empty group by set should be handled correctly")
+    void testEmptyGroupBy() {
+      AggregateInfo aggInfo = AggregateInfo.builder().addCountStar("cnt").build();
+
+      assertFalse(aggInfo.hasGroupBy());
+      assertTrue(aggInfo.getGroupByColumns().isEmpty());
+      assertEquals(0, aggInfo.getGroupByFieldIndices().length);
+    }
+  }
+
+  // ==================== Aggregate Function Support Tests ====================
+
+  @Nested
+  @DisplayName("Aggregate Function Support Tests")
+  class AggregateFunctionSupportTests {
+
+    @Test
+    @DisplayName("COUNT function should be supported")
+    void testCountSupport() {
+      AggregateInfo aggInfo = AggregateInfo.builder().addCountStar("cnt").build();
+
+      AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
+      assertEquals(AggregateInfo.AggregateFunction.COUNT, call.getFunction());
+      assertTrue(call.isCountStar());
+    }
+
+    @Test
+    @DisplayName("SUM function should be supported")
+    void testSumSupport() {
+      AggregateInfo aggInfo = AggregateInfo.builder().addSum("amount", "sum_amount").build();
+
+      AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
+      assertEquals(AggregateInfo.AggregateFunction.SUM, call.getFunction());
+      assertEquals("amount", call.getColumn());
+    }
+
+    @Test
+    @DisplayName("AVG function should be supported")
+    void testAvgSupport() {
+      AggregateInfo aggInfo = AggregateInfo.builder().addAvg("amount", "avg_amount").build();
+
+      AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
+      assertEquals(AggregateInfo.AggregateFunction.AVG, call.getFunction());
+      assertEquals("amount", call.getColumn());
+    }
+
+    @Test
+    @DisplayName("MIN function should be supported")
+    void testMinSupport() {
+      AggregateInfo aggInfo = AggregateInfo.builder().addMin("amount", "min_amount").build();
+
+      AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
+      assertEquals(AggregateInfo.AggregateFunction.MIN, call.getFunction());
+      assertEquals("amount", call.getColumn());
+    }
+
+    @Test
+    @DisplayName("MAX function should be supported")
+    void testMaxSupport() {
+      AggregateInfo aggInfo = AggregateInfo.builder().addMax("amount", "max_amount").build();
+
+      AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
+      assertEquals(AggregateInfo.AggregateFunction.MAX, call.getFunction());
+      assertEquals("amount", call.getColumn());
+    }
+
+    @Test
+    @DisplayName("COUNT DISTINCT function should be supported")
+    void testCountDistinctSupport() {
+      AggregateInfo aggInfo =
+          AggregateInfo.builder()
+              .addAggregateCall(
+                  AggregateInfo.AggregateFunction.COUNT_DISTINCT, "category", "distinct_cnt")
+              .build();
+
+      AggregateInfo.AggregateCall call = aggInfo.getAggregateCalls().get(0);
+      assertEquals(AggregateInfo.AggregateFunction.COUNT_DISTINCT, call.getFunction());
+      assertEquals("category", call.getColumn());
+    }
+  }
 }

--- a/src/test/java/org/apache/flink/connector/lance/table/LanceCatalogS3Test.java
+++ b/src/test/java/org/apache/flink/connector/lance/table/LanceCatalogS3Test.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,7 +11,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.table;
 
 import org.apache.flink.table.api.EnvironmentSettings;
@@ -23,7 +18,6 @@ import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.catalog.CatalogDatabase;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,20 +43,24 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Lance Catalog S3 integration tests.
  *
  * <p>This test class is divided into two parts:
+ *
  * <ul>
- *   <li>Unit tests that don't require MinIO connection (always run)</li>
- *   <li>Integration tests that require MinIO connection (require external MinIO service configuration)</li>
+ *   <li>Unit tests that don't require MinIO connection (always run)
+ *   <li>Integration tests that require MinIO connection (require external MinIO service
+ *       configuration)
  * </ul>
  *
  * <p>To run tests that require MinIO, set the following environment variables:
+ *
  * <ul>
- *   <li>MINIO_ENDPOINT - MinIO service address, e.g., http://localhost:9000</li>
- *   <li>MINIO_ACCESS_KEY - MinIO access key (default: minioadmin)</li>
- *   <li>MINIO_SECRET_KEY - MinIO secret key (default: minioadmin)</li>
- *   <li>MINIO_BUCKET - Test bucket name (default: lance-test-bucket)</li>
+ *   <li>MINIO_ENDPOINT - MinIO service address, e.g., http://localhost:9000
+ *   <li>MINIO_ACCESS_KEY - MinIO access key (default: minioadmin)
+ *   <li>MINIO_SECRET_KEY - MinIO secret key (default: minioadmin)
+ *   <li>MINIO_BUCKET - Test bucket name (default: lance-test-bucket)
  * </ul>
  *
  * <p>Quick way to start MinIO (using Docker):
+ *
  * <pre>
  * docker run -p 9000:9000 -p 9001:9001 \
  *   -e "MINIO_ROOT_USER=minioadmin" \
@@ -74,589 +72,577 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class LanceCatalogS3Test {
 
-    private static final Logger LOG = LoggerFactory.getLogger(LanceCatalogS3Test.class);
+  private static final Logger LOG = LoggerFactory.getLogger(LanceCatalogS3Test.class);
 
-    // MinIO configuration - read from environment variables or system properties
-    private static String minioEndpoint;
-    private static String minioAccessKey;
-    private static String minioSecretKey;
-    private static String testBucket;
-    private static boolean minioAvailable = false;
+  // MinIO configuration - read from environment variables or system properties
+  private static String minioEndpoint;
+  private static String minioAccessKey;
+  private static String minioSecretKey;
+  private static String testBucket;
+  private static boolean minioAvailable = false;
 
-    /**
-     * Check if MinIO is available
-     */
-    static boolean isMinioAvailable() {
-        return minioAvailable;
-    }
+  /** Check if MinIO is available */
+  static boolean isMinioAvailable() {
+    return minioAvailable;
+  }
 
-    @BeforeAll
-    static void initMinioConfig() {
-        // Read configuration from environment variables
-        minioEndpoint = getConfigValue("MINIO_ENDPOINT", "minio.endpoint", null);
-        minioAccessKey = getConfigValue("MINIO_ACCESS_KEY", "minio.access.key", "minioadmin");
-        minioSecretKey = getConfigValue("MINIO_SECRET_KEY", "minio.secret.key", "minioadmin");
-        testBucket = getConfigValue("MINIO_BUCKET", "minio.bucket", "lance-test-bucket");
+  @BeforeAll
+  static void initMinioConfig() {
+    // Read configuration from environment variables
+    minioEndpoint = getConfigValue("MINIO_ENDPOINT", "minio.endpoint", null);
+    minioAccessKey = getConfigValue("MINIO_ACCESS_KEY", "minio.access.key", "minioadmin");
+    minioSecretKey = getConfigValue("MINIO_SECRET_KEY", "minio.secret.key", "minioadmin");
+    testBucket = getConfigValue("MINIO_BUCKET", "minio.bucket", "lance-test-bucket");
 
-        if (minioEndpoint != null && !minioEndpoint.isEmpty()) {
-            LOG.info("MinIO configuration detected:");
-            LOG.info("  Endpoint: {}", minioEndpoint);
-            LOG.info("  Bucket: {}", testBucket);
+    if (minioEndpoint != null && !minioEndpoint.isEmpty()) {
+      LOG.info("MinIO configuration detected:");
+      LOG.info("  Endpoint: {}", minioEndpoint);
+      LOG.info("  Bucket: {}", testBucket);
 
-            // Try to connect to MinIO to verify availability
-            try {
-                minioAvailable = checkMinioConnection();
-                if (minioAvailable) {
-                    LOG.info("MinIO connection verification successful, integration tests will be enabled");
-                } else {
-                    LOG.warn("MinIO connection verification failed, integration tests will be skipped");
-                }
-            } catch (Exception e) {
-                LOG.warn("MinIO connection check failed: {}, integration tests will be skipped", e.getMessage());
-                minioAvailable = false;
-            }
+      // Try to connect to MinIO to verify availability
+      try {
+        minioAvailable = checkMinioConnection();
+        if (minioAvailable) {
+          LOG.info("MinIO connection verification successful, integration tests will be enabled");
         } else {
-            LOG.info("No MinIO configuration detected (MINIO_ENDPOINT environment variable not set), integration tests will be skipped");
-            LOG.info("To enable MinIO integration tests, set the following environment variables:");
-            LOG.info("  export MINIO_ENDPOINT=http://localhost:9000");
-            LOG.info("  export MINIO_ACCESS_KEY=minioadmin");
-            LOG.info("  export MINIO_SECRET_KEY=minioadmin");
-            LOG.info("  export MINIO_BUCKET=lance-test-bucket");
+          LOG.warn("MinIO connection verification failed, integration tests will be skipped");
         }
+      } catch (Exception e) {
+        LOG.warn(
+            "MinIO connection check failed: {}, integration tests will be skipped", e.getMessage());
+        minioAvailable = false;
+      }
+    } else {
+      LOG.info(
+          "No MinIO configuration detected (MINIO_ENDPOINT environment variable not set), integration tests will be skipped");
+      LOG.info("To enable MinIO integration tests, set the following environment variables:");
+      LOG.info("  export MINIO_ENDPOINT=http://localhost:9000");
+      LOG.info("  export MINIO_ACCESS_KEY=minioadmin");
+      LOG.info("  export MINIO_SECRET_KEY=minioadmin");
+      LOG.info("  export MINIO_BUCKET=lance-test-bucket");
+    }
+  }
+
+  /** Get configuration value from environment variable or system property */
+  private static String getConfigValue(String envKey, String propKey, String defaultValue) {
+    String value = System.getenv(envKey);
+    if (value == null || value.isEmpty()) {
+      value = System.getProperty(propKey, defaultValue);
+    }
+    return value;
+  }
+
+  /** Check if MinIO connection is available */
+  private static boolean checkMinioConnection() {
+    try {
+      // Try to create a simple HTTP connection to check if MinIO service is available
+      java.net.URL url = new java.net.URL(minioEndpoint + "/minio/health/live");
+      java.net.HttpURLConnection connection = (java.net.HttpURLConnection) url.openConnection();
+      connection.setRequestMethod("GET");
+      connection.setConnectTimeout(5000);
+      connection.setReadTimeout(5000);
+      int responseCode = connection.getResponseCode();
+      connection.disconnect();
+      return responseCode == 200;
+    } catch (Exception e) {
+      LOG.debug("MinIO health check failed: {}", e.getMessage());
+      return false;
+    }
+  }
+
+  // ==================== Unit Tests That Don't Require MinIO (Always Run) ====================
+
+  /** Unit tests that don't require MinIO connection */
+  @Nested
+  @DisplayName("Unit Tests - No MinIO Required")
+  class UnitTests {
+
+    // ==================== Remote Path Detection Tests ====================
+
+    @Test
+    @DisplayName("Test remote path detection - S3 protocol")
+    void testRemotePathDetectionS3() {
+      LanceCatalog catalog = new LanceCatalog("test", "default", "s3://bucket/path");
+      assertThat(catalog.isRemoteStorage()).isTrue();
     }
 
-    /**
-     * Get configuration value from environment variable or system property
-     */
-    private static String getConfigValue(String envKey, String propKey, String defaultValue) {
-        String value = System.getenv(envKey);
-        if (value == null || value.isEmpty()) {
-            value = System.getProperty(propKey, defaultValue);
-        }
-        return value;
+    @Test
+    @DisplayName("Test remote path detection - S3A protocol")
+    void testRemotePathDetectionS3A() {
+      LanceCatalog catalog = new LanceCatalog("test", "default", "s3a://bucket/path");
+      assertThat(catalog.isRemoteStorage()).isTrue();
     }
 
-    /**
-     * Check if MinIO connection is available
-     */
-    private static boolean checkMinioConnection() {
-        try {
-            // Try to create a simple HTTP connection to check if MinIO service is available
-            java.net.URL url = new java.net.URL(minioEndpoint + "/minio/health/live");
-            java.net.HttpURLConnection connection = (java.net.HttpURLConnection) url.openConnection();
-            connection.setRequestMethod("GET");
-            connection.setConnectTimeout(5000);
-            connection.setReadTimeout(5000);
-            int responseCode = connection.getResponseCode();
-            connection.disconnect();
-            return responseCode == 200;
-        } catch (Exception e) {
-            LOG.debug("MinIO health check failed: {}", e.getMessage());
-            return false;
-        }
+    @Test
+    @DisplayName("Test remote path detection - GCS protocol")
+    void testRemotePathDetectionGCS() {
+      LanceCatalog catalog = new LanceCatalog("test", "default", "gs://bucket/path");
+      assertThat(catalog.isRemoteStorage()).isTrue();
     }
 
-    // ==================== Unit Tests That Don't Require MinIO (Always Run) ====================
-
-    /**
-     * Unit tests that don't require MinIO connection
-     */
-    @Nested
-    @DisplayName("Unit Tests - No MinIO Required")
-    class UnitTests {
-
-        // ==================== Remote Path Detection Tests ====================
-
-        @Test
-        @DisplayName("Test remote path detection - S3 protocol")
-        void testRemotePathDetectionS3() {
-            LanceCatalog catalog = new LanceCatalog("test", "default", "s3://bucket/path");
-            assertThat(catalog.isRemoteStorage()).isTrue();
-        }
-
-        @Test
-        @DisplayName("Test remote path detection - S3A protocol")
-        void testRemotePathDetectionS3A() {
-            LanceCatalog catalog = new LanceCatalog("test", "default", "s3a://bucket/path");
-            assertThat(catalog.isRemoteStorage()).isTrue();
-        }
-
-        @Test
-        @DisplayName("Test remote path detection - GCS protocol")
-        void testRemotePathDetectionGCS() {
-            LanceCatalog catalog = new LanceCatalog("test", "default", "gs://bucket/path");
-            assertThat(catalog.isRemoteStorage()).isTrue();
-        }
-
-        @Test
-        @DisplayName("Test remote path detection - Azure protocol")
-        void testRemotePathDetectionAzure() {
-            LanceCatalog catalog = new LanceCatalog("test", "default", "az://container/path");
-            assertThat(catalog.isRemoteStorage()).isTrue();
-        }
-
-        @Test
-        @DisplayName("Test local path detection")
-        void testLocalPathDetection() {
-            LanceCatalog catalog = new LanceCatalog("test", "default", "/tmp/local/path");
-            assertThat(catalog.isRemoteStorage()).isFalse();
-        }
-
-        // ==================== Factory Tests ====================
-
-        @Test
-        @DisplayName("Test LanceCatalogFactory S3 configuration options")
-        void testCatalogFactoryS3Options() {
-            LanceCatalogFactory factory = new LanceCatalogFactory();
-
-            Set<String> optionalOptionKeys = new HashSet<>();
-            factory.optionalOptions().forEach(opt -> optionalOptionKeys.add(opt.key()));
-
-            // Verify S3 related options exist
-            assertThat(optionalOptionKeys).contains(
-                    "s3-access-key",
-                    "s3-secret-key",
-                    "s3-region",
-                    "s3-endpoint",
-                    "s3-virtual-hosted-style",
-                    "s3-allow-http"
-            );
-        }
-
-        @Test
-        @DisplayName("Test S3 configuration options default values")
-        void testS3ConfigOptionsDefaults() {
-            assertThat(LanceCatalogFactory.S3_VIRTUAL_HOSTED_STYLE.defaultValue()).isTrue();
-            assertThat(LanceCatalogFactory.S3_ALLOW_HTTP.defaultValue()).isFalse();
-        }
-
-        @Test
-        @DisplayName("Test S3 configuration options descriptions")
-        void testS3ConfigOptionsDescriptions() {
-            // Verify configuration options exist and have descriptions
-            assertThat(LanceCatalogFactory.S3_ACCESS_KEY.key()).isEqualTo("s3-access-key");
-            assertThat(LanceCatalogFactory.S3_SECRET_KEY.key()).isEqualTo("s3-secret-key");
-            assertThat(LanceCatalogFactory.S3_REGION.key()).isEqualTo("s3-region");
-            assertThat(LanceCatalogFactory.S3_ENDPOINT.key()).isEqualTo("s3-endpoint");
-
-            // Verify descriptions are not null
-            assertThat(LanceCatalogFactory.S3_ACCESS_KEY.description()).isNotNull();
-            assertThat(LanceCatalogFactory.S3_SECRET_KEY.description()).isNotNull();
-            assertThat(LanceCatalogFactory.S3_REGION.description()).isNotNull();
-            assertThat(LanceCatalogFactory.S3_ENDPOINT.description()).isNotNull();
-        }
-
-        // ==================== Path Normalization Tests ====================
-
-        @Test
-        @DisplayName("Test warehouse path normalization - remove trailing slashes")
-        void testWarehousePathNormalization() {
-            LanceCatalog catalog1 = new LanceCatalog("test", "default", "s3://bucket/path/");
-            assertThat(catalog1.getWarehouse()).isEqualTo("s3://bucket/path");
-
-            LanceCatalog catalog2 = new LanceCatalog("test", "default", "s3://bucket/path///");
-            assertThat(catalog2.getWarehouse()).isEqualTo("s3://bucket/path");
-        }
-
-        @Test
-        @DisplayName("Test warehouse path normalization - preserve root path")
-        void testWarehousePathNormalizationRoot() {
-            LanceCatalog catalog = new LanceCatalog("test", "default", "s3://bucket");
-            assertThat(catalog.getWarehouse()).isEqualTo("s3://bucket");
-        }
-
-        // ==================== Edge Case Tests ====================
-
-        @Test
-        @DisplayName("Test S3 path with empty storage options")
-        void testS3PathWithEmptyOptions() {
-            LanceCatalog catalog = new LanceCatalog(
-                    "test", "default",
-                    "s3://bucket/path",
-                    Collections.emptyMap());
-
-            assertThat(catalog.isRemoteStorage()).isTrue();
-            assertThat(catalog.getStorageOptions()).isEmpty();
-        }
-
-        @Test
-        @DisplayName("Test null storage options")
-        void testNullStorageOptions() {
-            LanceCatalog catalog = new LanceCatalog(
-                    "test", "default",
-                    "s3://bucket/path",
-                    null);
-
-            assertThat(catalog.isRemoteStorage()).isTrue();
-            assertThat(catalog.getStorageOptions()).isEmpty();
-        }
-
-        @Test
-        @DisplayName("Test storage options immutability")
-        void testStorageOptionsImmutability() {
-            Map<String, String> originalOptions = new HashMap<>();
-            originalOptions.put("key", "value");
-
-            LanceCatalog catalog = new LanceCatalog(
-                    "test", "default",
-                    "s3://bucket/path",
-                    originalOptions);
-
-            // Modifying original map should not affect catalog internal options
-            originalOptions.put("new_key", "new_value");
-
-            assertThat(catalog.getStorageOptions()).doesNotContainKey("new_key");
-        }
-
-        @Test
-        @DisplayName("Test getStorageOptions returns unmodifiable Map")
-        void testGetStorageOptionsReturnsUnmodifiable() {
-            Map<String, String> storageOptions = new HashMap<>();
-            storageOptions.put("key", "value");
-
-            LanceCatalog catalog = new LanceCatalog(
-                    "test", "default",
-                    "s3://bucket/path",
-                    storageOptions);
-
-            Map<String, String> returnedOptions = catalog.getStorageOptions();
-
-            // Attempting to modify returned map should throw exception
-            assertThatThrownBy(() -> returnedOptions.put("new_key", "new_value"))
-                    .isInstanceOf(UnsupportedOperationException.class);
-        }
-
-        @Test
-        @DisplayName("Test S3 Catalog basic properties (no connection required)")
-        void testS3CatalogBasicProperties() {
-            Map<String, String> storageOptions = new HashMap<>();
-            storageOptions.put("aws_access_key_id", "test_key");
-            storageOptions.put("aws_secret_access_key", "test_secret");
-            storageOptions.put("aws_region", "us-east-1");
-
-            LanceCatalog catalog = new LanceCatalog(
-                    "test_catalog", "default",
-                    "s3://test-bucket/warehouse",
-                    storageOptions);
-
-            assertThat(catalog.getName()).isEqualTo("test_catalog");
-            assertThat(catalog.getDefaultDatabase()).isEqualTo("default");
-            assertThat(catalog.getWarehouse()).isEqualTo("s3://test-bucket/warehouse");
-            assertThat(catalog.isRemoteStorage()).isTrue();
-            assertThat(catalog.getStorageOptions()).containsEntry("aws_access_key_id", "test_key");
-        }
+    @Test
+    @DisplayName("Test remote path detection - Azure protocol")
+    void testRemotePathDetectionAzure() {
+      LanceCatalog catalog = new LanceCatalog("test", "default", "az://container/path");
+      assertThat(catalog.isRemoteStorage()).isTrue();
     }
 
-    // ==================== Integration Tests That Require MinIO ====================
-
-    /**
-     * Integration tests that require MinIO connection.
-     * Only run when MINIO_ENDPOINT environment variable is set and MinIO service is available.
-     */
-    @Nested
-    @DisplayName("Integration Tests - MinIO Required")
-    @EnabledIf("org.apache.flink.connector.lance.table.LanceCatalogS3Test#isMinioAvailable")
-    class MinioIntegrationTests {
-
-        private LanceCatalog s3Catalog;
-        private String warehousePath;
-        private String testId;
-
-        @BeforeEach
-        void setUp() throws Exception {
-            // Generate unique path for each test to avoid interference between tests
-            testId = UUID.randomUUID().toString().substring(0, 8);
-            warehousePath = String.format("s3://%s/lance-warehouse-%s", testBucket, testId);
-
-            // Create Catalog with S3 configuration
-            Map<String, String> storageOptions = new HashMap<>();
-            storageOptions.put("aws_access_key_id", minioAccessKey);
-            storageOptions.put("aws_secret_access_key", minioSecretKey);
-            storageOptions.put("aws_region", "us-east-1");
-            storageOptions.put("aws_endpoint", minioEndpoint);
-            storageOptions.put("aws_virtual_hosted_style_request", "false");
-            storageOptions.put("allow_http", "true");
-
-            s3Catalog = new LanceCatalog("lance_s3_catalog", "default", warehousePath, storageOptions);
-            s3Catalog.open();
-
-            LOG.info("Test Catalog created, warehouse: {}", warehousePath);
-        }
-
-        @AfterEach
-        void tearDown() throws Exception {
-            if (s3Catalog != null) {
-                s3Catalog.close();
-            }
-        }
-
-        // ==================== Basic Properties Tests ====================
-
-        @Test
-        @DisplayName("Test S3 Catalog basic properties")
-        void testS3CatalogProperties() {
-            assertThat(s3Catalog.getName()).isEqualTo("lance_s3_catalog");
-            assertThat(s3Catalog.getDefaultDatabase()).isEqualTo("default");
-            assertThat(s3Catalog.getWarehouse()).isEqualTo(warehousePath);
-            assertThat(s3Catalog.isRemoteStorage()).isTrue();
-        }
-
-        @Test
-        @DisplayName("Test S3 storage options configuration")
-        void testS3StorageOptions() {
-            Map<String, String> options = s3Catalog.getStorageOptions();
-
-            assertThat(options).containsEntry("aws_access_key_id", minioAccessKey);
-            assertThat(options).containsEntry("aws_secret_access_key", minioSecretKey);
-            assertThat(options).containsEntry("aws_region", "us-east-1");
-            assertThat(options).containsEntry("aws_endpoint", minioEndpoint);
-            assertThat(options).containsEntry("allow_http", "true");
-        }
-
-        // ==================== Database Operation Tests ====================
-
-        @Test
-        @DisplayName("Test S3 Catalog default database exists")
-        void testDefaultDatabaseExists() throws Exception {
-            assertThat(s3Catalog.databaseExists("default")).isTrue();
-        }
-
-        @Test
-        @DisplayName("Test S3 Catalog list databases")
-        void testListDatabases() throws Exception {
-            List<String> databases = s3Catalog.listDatabases();
-            assertThat(databases).contains("default");
-        }
-
-        @Test
-        @DisplayName("Test S3 Catalog create database")
-        void testCreateDatabase() throws Exception {
-            String dbName = "test_s3_db_" + testId;
-
-            // Create database
-            s3Catalog.createDatabase(dbName, null, false);
-
-            // Verify database exists
-            assertThat(s3Catalog.databaseExists(dbName)).isTrue();
-
-            // Verify database in list
-            List<String> databases = s3Catalog.listDatabases();
-            assertThat(databases).contains(dbName);
-        }
-
-        @Test
-        @DisplayName("Test S3 Catalog create existing database (ignoreIfExists=false)")
-        void testCreateExistingDatabaseWithoutIgnore() throws Exception {
-            String dbName = "existing_db_" + testId;
-            s3Catalog.createDatabase(dbName, null, false);
-
-            // Creating again should throw exception
-            assertThatThrownBy(() -> s3Catalog.createDatabase(dbName, null, false))
-                    .isInstanceOf(DatabaseAlreadyExistException.class);
-        }
-
-        @Test
-        @DisplayName("Test S3 Catalog create existing database (ignoreIfExists=true)")
-        void testCreateExistingDatabaseWithIgnore() throws Exception {
-            String dbName = "existing_db_2_" + testId;
-            s3Catalog.createDatabase(dbName, null, false);
-
-            // Creating again should not throw exception
-            s3Catalog.createDatabase(dbName, null, true);
-
-            assertThat(s3Catalog.databaseExists(dbName)).isTrue();
-        }
-
-        @Test
-        @DisplayName("Test S3 Catalog get database")
-        void testGetDatabase() throws Exception {
-            String dbName = "get_db_test_" + testId;
-            s3Catalog.createDatabase(dbName, null, false);
-
-            CatalogDatabase database = s3Catalog.getDatabase(dbName);
-            assertThat(database).isNotNull();
-            assertThat(database.getComment()).contains("Lance Database");
-        }
-
-        @Test
-        @DisplayName("Test S3 Catalog get non-existing database")
-        void testGetNonExistingDatabase() {
-            assertThatThrownBy(() -> s3Catalog.getDatabase("non_existing_db_" + testId))
-                    .isInstanceOf(DatabaseNotExistException.class);
-        }
-
-        @Test
-        @DisplayName("Test S3 Catalog drop database")
-        void testDropDatabase() throws Exception {
-            String dbName = "drop_db_test_" + testId;
-            s3Catalog.createDatabase(dbName, null, false);
-            assertThat(s3Catalog.databaseExists(dbName)).isTrue();
-
-            // Drop database
-            s3Catalog.dropDatabase(dbName, false, false);
-
-            // Verify database not in list
-            List<String> databases = s3Catalog.listDatabases();
-            assertThat(databases).doesNotContain(dbName);
-        }
-
-        @Test
-        @DisplayName("Test S3 Catalog drop non-existing database (ignoreIfNotExists=false)")
-        void testDropNonExistingDatabaseWithoutIgnore() {
-            assertThatThrownBy(() -> s3Catalog.dropDatabase("non_existing_drop_db_" + testId, false, false))
-                    .isInstanceOf(DatabaseNotExistException.class);
-        }
-
-        @Test
-        @DisplayName("Test S3 Catalog drop non-existing database (ignoreIfNotExists=true)")
-        void testDropNonExistingDatabaseWithIgnore() throws Exception {
-            // Should not throw exception
-            s3Catalog.dropDatabase("non_existing_drop_db_2_" + testId, true, false);
-        }
-
-        // ==================== Table Operation Tests ====================
-
-        @Test
-        @DisplayName("Test S3 Catalog list tables (empty database)")
-        void testListTablesEmpty() throws Exception {
-            String dbName = "empty_tables_db_" + testId;
-            s3Catalog.createDatabase(dbName, null, false);
-
-            List<String> tables = s3Catalog.listTables(dbName);
-            assertThat(tables).isEmpty();
-        }
-
-        @Test
-        @DisplayName("Test S3 Catalog table not exists")
-        void testTableNotExists() throws Exception {
-            String dbName = "table_check_db_" + testId;
-            s3Catalog.createDatabase(dbName, null, false);
-
-            assertThat(s3Catalog.tableExists(new org.apache.flink.table.catalog.ObjectPath(dbName, "non_existing_table")))
-                    .isFalse();
-        }
-
-        // ==================== SQL DDL Create Catalog Tests ====================
-
-        @Test
-        @DisplayName("Test creating S3 Catalog via SQL DDL")
-        void testCreateS3CatalogViaSql() throws Exception {
-            EnvironmentSettings settings = EnvironmentSettings.newInstance()
-                    .inBatchMode()
-                    .build();
-            TableEnvironment tableEnv = TableEnvironment.create(settings);
-
-            String catalogName = "lance_s3_sql_" + testId;
-
-            // Create S3 Catalog using SQL
-            String createCatalogSql = String.format(
-                    "CREATE CATALOG %s WITH (" +
-                            "'type' = 'lance', " +
-                            "'warehouse' = '%s', " +
-                            "'default-database' = 'default', " +
-                            "'s3-access-key' = '%s', " +
-                            "'s3-secret-key' = '%s', " +
-                            "'s3-region' = 'us-east-1', " +
-                            "'s3-endpoint' = '%s', " +
-                            "'s3-allow-http' = 'true', " +
-                            "'s3-virtual-hosted-style' = 'false'" +
-                            ")",
-                    catalogName, warehousePath, minioAccessKey, minioSecretKey, minioEndpoint);
-
-            tableEnv.executeSql(createCatalogSql);
-
-            // Verify Catalog was created
-            String[] catalogs = tableEnv.listCatalogs();
-            assertThat(catalogs).contains(catalogName);
-
-            // Use Catalog
-            tableEnv.useCatalog(catalogName);
-            assertThat(tableEnv.getCurrentCatalog()).isEqualTo(catalogName);
-
-            // Verify default database
-            assertThat(tableEnv.getCurrentDatabase()).isEqualTo("default");
-        }
-
-        @Test
-        @DisplayName("Test creating database in S3 Catalog via SQL DDL")
-        void testCreateDatabaseViaSql() throws Exception {
-            EnvironmentSettings settings = EnvironmentSettings.newInstance()
-                    .inBatchMode()
-                    .build();
-            TableEnvironment tableEnv = TableEnvironment.create(settings);
-
-            String catalogName = "lance_s3_db_sql_" + testId;
-
-            // Create S3 Catalog
-            String createCatalogSql = String.format(
-                    "CREATE CATALOG %s WITH (" +
-                            "'type' = 'lance', " +
-                            "'warehouse' = '%s', " +
-                            "'s3-access-key' = '%s', " +
-                            "'s3-secret-key' = '%s', " +
-                            "'s3-region' = 'us-east-1', " +
-                            "'s3-endpoint' = '%s', " +
-                            "'s3-allow-http' = 'true', " +
-                            "'s3-virtual-hosted-style' = 'false'" +
-                            ")",
-                    catalogName, warehousePath, minioAccessKey, minioSecretKey, minioEndpoint);
-
-            tableEnv.executeSql(createCatalogSql);
-            tableEnv.useCatalog(catalogName);
-
-            // Create database
-            String dbName = "test_database_" + testId;
-            tableEnv.executeSql("CREATE DATABASE IF NOT EXISTS " + dbName);
-
-            // Verify database was created
-            String[] databases = tableEnv.listDatabases();
-            assertThat(databases).contains(dbName);
-        }
-
-        // ==================== Multiple Catalog Tests ====================
-
-        @Test
-        @DisplayName("Test multiple S3 Catalog instances")
-        void testMultipleS3Catalogs() throws Exception {
-            Map<String, String> storageOptions = new HashMap<>();
-            storageOptions.put("aws_access_key_id", minioAccessKey);
-            storageOptions.put("aws_secret_access_key", minioSecretKey);
-            storageOptions.put("aws_region", "us-east-1");
-            storageOptions.put("aws_endpoint", minioEndpoint);
-            storageOptions.put("allow_http", "true");
-
-            // Create first Catalog
-            LanceCatalog catalog1 = new LanceCatalog(
-                    "catalog1", "default",
-                    "s3://" + testBucket + "/warehouse1_" + testId,
-                    storageOptions);
-            catalog1.open();
-
-            // Create second Catalog
-            LanceCatalog catalog2 = new LanceCatalog(
-                    "catalog2", "default",
-                    "s3://" + testBucket + "/warehouse2_" + testId,
-                    storageOptions);
-            catalog2.open();
-
-            try {
-                // Verify two Catalogs work independently
-                assertThat(catalog1.getWarehouse()).isNotEqualTo(catalog2.getWarehouse());
-
-                String db1 = "db1_" + testId;
-                String db2 = "db2_" + testId;
-
-                catalog1.createDatabase(db1, null, false);
-                catalog2.createDatabase(db2, null, false);
-
-                assertThat(catalog1.listDatabases()).contains(db1);
-                assertThat(catalog2.listDatabases()).contains(db2);
-                assertThat(catalog1.listDatabases()).doesNotContain(db2);
-                assertThat(catalog2.listDatabases()).doesNotContain(db1);
-            } finally {
-                catalog1.close();
-                catalog2.close();
-            }
-        }
+    @Test
+    @DisplayName("Test local path detection")
+    void testLocalPathDetection() {
+      LanceCatalog catalog = new LanceCatalog("test", "default", "/tmp/local/path");
+      assertThat(catalog.isRemoteStorage()).isFalse();
     }
+
+    // ==================== Factory Tests ====================
+
+    @Test
+    @DisplayName("Test LanceCatalogFactory S3 configuration options")
+    void testCatalogFactoryS3Options() {
+      LanceCatalogFactory factory = new LanceCatalogFactory();
+
+      Set<String> optionalOptionKeys = new HashSet<>();
+      factory.optionalOptions().forEach(opt -> optionalOptionKeys.add(opt.key()));
+
+      // Verify S3 related options exist
+      assertThat(optionalOptionKeys)
+          .contains(
+              "s3-access-key",
+              "s3-secret-key",
+              "s3-region",
+              "s3-endpoint",
+              "s3-virtual-hosted-style",
+              "s3-allow-http");
+    }
+
+    @Test
+    @DisplayName("Test S3 configuration options default values")
+    void testS3ConfigOptionsDefaults() {
+      assertThat(LanceCatalogFactory.S3_VIRTUAL_HOSTED_STYLE.defaultValue()).isTrue();
+      assertThat(LanceCatalogFactory.S3_ALLOW_HTTP.defaultValue()).isFalse();
+    }
+
+    @Test
+    @DisplayName("Test S3 configuration options descriptions")
+    void testS3ConfigOptionsDescriptions() {
+      // Verify configuration options exist and have descriptions
+      assertThat(LanceCatalogFactory.S3_ACCESS_KEY.key()).isEqualTo("s3-access-key");
+      assertThat(LanceCatalogFactory.S3_SECRET_KEY.key()).isEqualTo("s3-secret-key");
+      assertThat(LanceCatalogFactory.S3_REGION.key()).isEqualTo("s3-region");
+      assertThat(LanceCatalogFactory.S3_ENDPOINT.key()).isEqualTo("s3-endpoint");
+
+      // Verify descriptions are not null
+      assertThat(LanceCatalogFactory.S3_ACCESS_KEY.description()).isNotNull();
+      assertThat(LanceCatalogFactory.S3_SECRET_KEY.description()).isNotNull();
+      assertThat(LanceCatalogFactory.S3_REGION.description()).isNotNull();
+      assertThat(LanceCatalogFactory.S3_ENDPOINT.description()).isNotNull();
+    }
+
+    // ==================== Path Normalization Tests ====================
+
+    @Test
+    @DisplayName("Test warehouse path normalization - remove trailing slashes")
+    void testWarehousePathNormalization() {
+      LanceCatalog catalog1 = new LanceCatalog("test", "default", "s3://bucket/path/");
+      assertThat(catalog1.getWarehouse()).isEqualTo("s3://bucket/path");
+
+      LanceCatalog catalog2 = new LanceCatalog("test", "default", "s3://bucket/path///");
+      assertThat(catalog2.getWarehouse()).isEqualTo("s3://bucket/path");
+    }
+
+    @Test
+    @DisplayName("Test warehouse path normalization - preserve root path")
+    void testWarehousePathNormalizationRoot() {
+      LanceCatalog catalog = new LanceCatalog("test", "default", "s3://bucket");
+      assertThat(catalog.getWarehouse()).isEqualTo("s3://bucket");
+    }
+
+    // ==================== Edge Case Tests ====================
+
+    @Test
+    @DisplayName("Test S3 path with empty storage options")
+    void testS3PathWithEmptyOptions() {
+      LanceCatalog catalog =
+          new LanceCatalog("test", "default", "s3://bucket/path", Collections.emptyMap());
+
+      assertThat(catalog.isRemoteStorage()).isTrue();
+      assertThat(catalog.getStorageOptions()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Test null storage options")
+    void testNullStorageOptions() {
+      LanceCatalog catalog = new LanceCatalog("test", "default", "s3://bucket/path", null);
+
+      assertThat(catalog.isRemoteStorage()).isTrue();
+      assertThat(catalog.getStorageOptions()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Test storage options immutability")
+    void testStorageOptionsImmutability() {
+      Map<String, String> originalOptions = new HashMap<>();
+      originalOptions.put("key", "value");
+
+      LanceCatalog catalog =
+          new LanceCatalog("test", "default", "s3://bucket/path", originalOptions);
+
+      // Modifying original map should not affect catalog internal options
+      originalOptions.put("new_key", "new_value");
+
+      assertThat(catalog.getStorageOptions()).doesNotContainKey("new_key");
+    }
+
+    @Test
+    @DisplayName("Test getStorageOptions returns unmodifiable Map")
+    void testGetStorageOptionsReturnsUnmodifiable() {
+      Map<String, String> storageOptions = new HashMap<>();
+      storageOptions.put("key", "value");
+
+      LanceCatalog catalog =
+          new LanceCatalog("test", "default", "s3://bucket/path", storageOptions);
+
+      Map<String, String> returnedOptions = catalog.getStorageOptions();
+
+      // Attempting to modify returned map should throw exception
+      assertThatThrownBy(() -> returnedOptions.put("new_key", "new_value"))
+          .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    @DisplayName("Test S3 Catalog basic properties (no connection required)")
+    void testS3CatalogBasicProperties() {
+      Map<String, String> storageOptions = new HashMap<>();
+      storageOptions.put("aws_access_key_id", "test_key");
+      storageOptions.put("aws_secret_access_key", "test_secret");
+      storageOptions.put("aws_region", "us-east-1");
+
+      LanceCatalog catalog =
+          new LanceCatalog("test_catalog", "default", "s3://test-bucket/warehouse", storageOptions);
+
+      assertThat(catalog.getName()).isEqualTo("test_catalog");
+      assertThat(catalog.getDefaultDatabase()).isEqualTo("default");
+      assertThat(catalog.getWarehouse()).isEqualTo("s3://test-bucket/warehouse");
+      assertThat(catalog.isRemoteStorage()).isTrue();
+      assertThat(catalog.getStorageOptions()).containsEntry("aws_access_key_id", "test_key");
+    }
+  }
+
+  // ==================== Integration Tests That Require MinIO ====================
+
+  /**
+   * Integration tests that require MinIO connection. Only run when MINIO_ENDPOINT environment
+   * variable is set and MinIO service is available.
+   */
+  @Nested
+  @DisplayName("Integration Tests - MinIO Required")
+  @EnabledIf("org.apache.flink.connector.lance.table.LanceCatalogS3Test#isMinioAvailable")
+  class MinioIntegrationTests {
+
+    private LanceCatalog s3Catalog;
+    private String warehousePath;
+    private String testId;
+
+    @BeforeEach
+    void setUp() throws Exception {
+      // Generate unique path for each test to avoid interference between tests
+      testId = UUID.randomUUID().toString().substring(0, 8);
+      warehousePath = String.format("s3://%s/lance-warehouse-%s", testBucket, testId);
+
+      // Create Catalog with S3 configuration
+      Map<String, String> storageOptions = new HashMap<>();
+      storageOptions.put("aws_access_key_id", minioAccessKey);
+      storageOptions.put("aws_secret_access_key", minioSecretKey);
+      storageOptions.put("aws_region", "us-east-1");
+      storageOptions.put("aws_endpoint", minioEndpoint);
+      storageOptions.put("aws_virtual_hosted_style_request", "false");
+      storageOptions.put("allow_http", "true");
+
+      s3Catalog = new LanceCatalog("lance_s3_catalog", "default", warehousePath, storageOptions);
+      s3Catalog.open();
+
+      LOG.info("Test Catalog created, warehouse: {}", warehousePath);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+      if (s3Catalog != null) {
+        s3Catalog.close();
+      }
+    }
+
+    // ==================== Basic Properties Tests ====================
+
+    @Test
+    @DisplayName("Test S3 Catalog basic properties")
+    void testS3CatalogProperties() {
+      assertThat(s3Catalog.getName()).isEqualTo("lance_s3_catalog");
+      assertThat(s3Catalog.getDefaultDatabase()).isEqualTo("default");
+      assertThat(s3Catalog.getWarehouse()).isEqualTo(warehousePath);
+      assertThat(s3Catalog.isRemoteStorage()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Test S3 storage options configuration")
+    void testS3StorageOptions() {
+      Map<String, String> options = s3Catalog.getStorageOptions();
+
+      assertThat(options).containsEntry("aws_access_key_id", minioAccessKey);
+      assertThat(options).containsEntry("aws_secret_access_key", minioSecretKey);
+      assertThat(options).containsEntry("aws_region", "us-east-1");
+      assertThat(options).containsEntry("aws_endpoint", minioEndpoint);
+      assertThat(options).containsEntry("allow_http", "true");
+    }
+
+    // ==================== Database Operation Tests ====================
+
+    @Test
+    @DisplayName("Test S3 Catalog default database exists")
+    void testDefaultDatabaseExists() throws Exception {
+      assertThat(s3Catalog.databaseExists("default")).isTrue();
+    }
+
+    @Test
+    @DisplayName("Test S3 Catalog list databases")
+    void testListDatabases() throws Exception {
+      List<String> databases = s3Catalog.listDatabases();
+      assertThat(databases).contains("default");
+    }
+
+    @Test
+    @DisplayName("Test S3 Catalog create database")
+    void testCreateDatabase() throws Exception {
+      String dbName = "test_s3_db_" + testId;
+
+      // Create database
+      s3Catalog.createDatabase(dbName, null, false);
+
+      // Verify database exists
+      assertThat(s3Catalog.databaseExists(dbName)).isTrue();
+
+      // Verify database in list
+      List<String> databases = s3Catalog.listDatabases();
+      assertThat(databases).contains(dbName);
+    }
+
+    @Test
+    @DisplayName("Test S3 Catalog create existing database (ignoreIfExists=false)")
+    void testCreateExistingDatabaseWithoutIgnore() throws Exception {
+      String dbName = "existing_db_" + testId;
+      s3Catalog.createDatabase(dbName, null, false);
+
+      // Creating again should throw exception
+      assertThatThrownBy(() -> s3Catalog.createDatabase(dbName, null, false))
+          .isInstanceOf(DatabaseAlreadyExistException.class);
+    }
+
+    @Test
+    @DisplayName("Test S3 Catalog create existing database (ignoreIfExists=true)")
+    void testCreateExistingDatabaseWithIgnore() throws Exception {
+      String dbName = "existing_db_2_" + testId;
+      s3Catalog.createDatabase(dbName, null, false);
+
+      // Creating again should not throw exception
+      s3Catalog.createDatabase(dbName, null, true);
+
+      assertThat(s3Catalog.databaseExists(dbName)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Test S3 Catalog get database")
+    void testGetDatabase() throws Exception {
+      String dbName = "get_db_test_" + testId;
+      s3Catalog.createDatabase(dbName, null, false);
+
+      CatalogDatabase database = s3Catalog.getDatabase(dbName);
+      assertThat(database).isNotNull();
+      assertThat(database.getComment()).contains("Lance Database");
+    }
+
+    @Test
+    @DisplayName("Test S3 Catalog get non-existing database")
+    void testGetNonExistingDatabase() {
+      assertThatThrownBy(() -> s3Catalog.getDatabase("non_existing_db_" + testId))
+          .isInstanceOf(DatabaseNotExistException.class);
+    }
+
+    @Test
+    @DisplayName("Test S3 Catalog drop database")
+    void testDropDatabase() throws Exception {
+      String dbName = "drop_db_test_" + testId;
+      s3Catalog.createDatabase(dbName, null, false);
+      assertThat(s3Catalog.databaseExists(dbName)).isTrue();
+
+      // Drop database
+      s3Catalog.dropDatabase(dbName, false, false);
+
+      // Verify database not in list
+      List<String> databases = s3Catalog.listDatabases();
+      assertThat(databases).doesNotContain(dbName);
+    }
+
+    @Test
+    @DisplayName("Test S3 Catalog drop non-existing database (ignoreIfNotExists=false)")
+    void testDropNonExistingDatabaseWithoutIgnore() {
+      assertThatThrownBy(
+              () -> s3Catalog.dropDatabase("non_existing_drop_db_" + testId, false, false))
+          .isInstanceOf(DatabaseNotExistException.class);
+    }
+
+    @Test
+    @DisplayName("Test S3 Catalog drop non-existing database (ignoreIfNotExists=true)")
+    void testDropNonExistingDatabaseWithIgnore() throws Exception {
+      // Should not throw exception
+      s3Catalog.dropDatabase("non_existing_drop_db_2_" + testId, true, false);
+    }
+
+    // ==================== Table Operation Tests ====================
+
+    @Test
+    @DisplayName("Test S3 Catalog list tables (empty database)")
+    void testListTablesEmpty() throws Exception {
+      String dbName = "empty_tables_db_" + testId;
+      s3Catalog.createDatabase(dbName, null, false);
+
+      List<String> tables = s3Catalog.listTables(dbName);
+      assertThat(tables).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Test S3 Catalog table not exists")
+    void testTableNotExists() throws Exception {
+      String dbName = "table_check_db_" + testId;
+      s3Catalog.createDatabase(dbName, null, false);
+
+      assertThat(
+              s3Catalog.tableExists(
+                  new org.apache.flink.table.catalog.ObjectPath(dbName, "non_existing_table")))
+          .isFalse();
+    }
+
+    // ==================== SQL DDL Create Catalog Tests ====================
+
+    @Test
+    @DisplayName("Test creating S3 Catalog via SQL DDL")
+    void testCreateS3CatalogViaSql() throws Exception {
+      EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
+      TableEnvironment tableEnv = TableEnvironment.create(settings);
+
+      String catalogName = "lance_s3_sql_" + testId;
+
+      // Create S3 Catalog using SQL
+      String createCatalogSql =
+          String.format(
+              "CREATE CATALOG %s WITH ("
+                  + "'type' = 'lance', "
+                  + "'warehouse' = '%s', "
+                  + "'default-database' = 'default', "
+                  + "'s3-access-key' = '%s', "
+                  + "'s3-secret-key' = '%s', "
+                  + "'s3-region' = 'us-east-1', "
+                  + "'s3-endpoint' = '%s', "
+                  + "'s3-allow-http' = 'true', "
+                  + "'s3-virtual-hosted-style' = 'false'"
+                  + ")",
+              catalogName, warehousePath, minioAccessKey, minioSecretKey, minioEndpoint);
+
+      tableEnv.executeSql(createCatalogSql);
+
+      // Verify Catalog was created
+      String[] catalogs = tableEnv.listCatalogs();
+      assertThat(catalogs).contains(catalogName);
+
+      // Use Catalog
+      tableEnv.useCatalog(catalogName);
+      assertThat(tableEnv.getCurrentCatalog()).isEqualTo(catalogName);
+
+      // Verify default database
+      assertThat(tableEnv.getCurrentDatabase()).isEqualTo("default");
+    }
+
+    @Test
+    @DisplayName("Test creating database in S3 Catalog via SQL DDL")
+    void testCreateDatabaseViaSql() throws Exception {
+      EnvironmentSettings settings = EnvironmentSettings.newInstance().inBatchMode().build();
+      TableEnvironment tableEnv = TableEnvironment.create(settings);
+
+      String catalogName = "lance_s3_db_sql_" + testId;
+
+      // Create S3 Catalog
+      String createCatalogSql =
+          String.format(
+              "CREATE CATALOG %s WITH ("
+                  + "'type' = 'lance', "
+                  + "'warehouse' = '%s', "
+                  + "'s3-access-key' = '%s', "
+                  + "'s3-secret-key' = '%s', "
+                  + "'s3-region' = 'us-east-1', "
+                  + "'s3-endpoint' = '%s', "
+                  + "'s3-allow-http' = 'true', "
+                  + "'s3-virtual-hosted-style' = 'false'"
+                  + ")",
+              catalogName, warehousePath, minioAccessKey, minioSecretKey, minioEndpoint);
+
+      tableEnv.executeSql(createCatalogSql);
+      tableEnv.useCatalog(catalogName);
+
+      // Create database
+      String dbName = "test_database_" + testId;
+      tableEnv.executeSql("CREATE DATABASE IF NOT EXISTS " + dbName);
+
+      // Verify database was created
+      String[] databases = tableEnv.listDatabases();
+      assertThat(databases).contains(dbName);
+    }
+
+    // ==================== Multiple Catalog Tests ====================
+
+    @Test
+    @DisplayName("Test multiple S3 Catalog instances")
+    void testMultipleS3Catalogs() throws Exception {
+      Map<String, String> storageOptions = new HashMap<>();
+      storageOptions.put("aws_access_key_id", minioAccessKey);
+      storageOptions.put("aws_secret_access_key", minioSecretKey);
+      storageOptions.put("aws_region", "us-east-1");
+      storageOptions.put("aws_endpoint", minioEndpoint);
+      storageOptions.put("allow_http", "true");
+
+      // Create first Catalog
+      LanceCatalog catalog1 =
+          new LanceCatalog(
+              "catalog1",
+              "default",
+              "s3://" + testBucket + "/warehouse1_" + testId,
+              storageOptions);
+      catalog1.open();
+
+      // Create second Catalog
+      LanceCatalog catalog2 =
+          new LanceCatalog(
+              "catalog2",
+              "default",
+              "s3://" + testBucket + "/warehouse2_" + testId,
+              storageOptions);
+      catalog2.open();
+
+      try {
+        // Verify two Catalogs work independently
+        assertThat(catalog1.getWarehouse()).isNotEqualTo(catalog2.getWarehouse());
+
+        String db1 = "db1_" + testId;
+        String db2 = "db2_" + testId;
+
+        catalog1.createDatabase(db1, null, false);
+        catalog2.createDatabase(db2, null, false);
+
+        assertThat(catalog1.listDatabases()).contains(db1);
+        assertThat(catalog2.listDatabases()).contains(db2);
+        assertThat(catalog1.listDatabases()).doesNotContain(db2);
+        assertThat(catalog2.listDatabases()).doesNotContain(db1);
+      } finally {
+        catalog1.close();
+        catalog2.close();
+      }
+    }
+  }
 }

--- a/src/test/java/org/apache/flink/connector/lance/table/LanceCatalogS3Test.java
+++ b/src/test/java/org/apache/flink/connector/lance/table/LanceCatalogS3Test.java
@@ -47,13 +47,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Lance Catalog S3 integration tests.
- * 
+ *
  * <p>This test class is divided into two parts:
  * <ul>
  *   <li>Unit tests that don't require MinIO connection (always run)</li>
  *   <li>Integration tests that require MinIO connection (require external MinIO service configuration)</li>
  * </ul>
- * 
+ *
  * <p>To run tests that require MinIO, set the following environment variables:
  * <ul>
  *   <li>MINIO_ENDPOINT - MinIO service address, e.g., http://localhost:9000</li>
@@ -61,7 +61,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *   <li>MINIO_SECRET_KEY - MinIO secret key (default: minioadmin)</li>
  *   <li>MINIO_BUCKET - Test bucket name (default: lance-test-bucket)</li>
  * </ul>
- * 
+ *
  * <p>Quick way to start MinIO (using Docker):
  * <pre>
  * docker run -p 9000:9000 -p 9001:9001 \
@@ -69,7 +69,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *   -e "MINIO_ROOT_PASSWORD=minioadmin" \
  *   minio/minio server /data --console-address ":9001"
  * </pre>
- * 
+ *
  * <p>Or use a locally installed MinIO service.
  */
 class LanceCatalogS3Test {
@@ -102,7 +102,7 @@ class LanceCatalogS3Test {
             LOG.info("MinIO configuration detected:");
             LOG.info("  Endpoint: {}", minioEndpoint);
             LOG.info("  Bucket: {}", testBucket);
-            
+
             // Try to connect to MinIO to verify availability
             try {
                 minioAvailable = checkMinioConnection();
@@ -238,7 +238,7 @@ class LanceCatalogS3Test {
             assertThat(LanceCatalogFactory.S3_SECRET_KEY.key()).isEqualTo("s3-secret-key");
             assertThat(LanceCatalogFactory.S3_REGION.key()).isEqualTo("s3-region");
             assertThat(LanceCatalogFactory.S3_ENDPOINT.key()).isEqualTo("s3-endpoint");
-            
+
             // Verify descriptions are not null
             assertThat(LanceCatalogFactory.S3_ACCESS_KEY.description()).isNotNull();
             assertThat(LanceCatalogFactory.S3_SECRET_KEY.description()).isNotNull();
@@ -645,7 +645,7 @@ class LanceCatalogS3Test {
 
                 String db1 = "db1_" + testId;
                 String db2 = "db2_" + testId;
-                
+
                 catalog1.createDatabase(db1, null, false);
                 catalog2.createDatabase(db2, null, false);
 

--- a/src/test/java/org/apache/flink/connector/lance/table/LanceReadOptimizationsTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/table/LanceReadOptimizationsTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Read optimization tests
- * 
+ *
  * <p>Test contents:
  * <ul>
  *   <li>Limit push-down</li>
@@ -171,7 +171,7 @@ public class LanceReadOptimizationsTest {
             // Create status = 'active' AND score > 60 expression
             ResolvedExpression statusFilter = createEqualsExpression("status", "active");
             ResolvedExpression scoreFilter = createComparisonExpression("score", 60.0, BuiltInFunctionDefinitions.GREATER_THAN);
-            
+
             CallExpression andExpr = CallExpression.permanent(
                     BuiltInFunctionDefinitions.AND,
                     Arrays.asList(statusFilter, scoreFilter),
@@ -191,7 +191,7 @@ public class LanceReadOptimizationsTest {
             // Create name IS NULL expression
             FieldReferenceExpression fieldRef = new FieldReferenceExpression(
                     "name", DataTypes.STRING(), 0, 1);
-            
+
             CallExpression isNullExpr = CallExpression.permanent(
                     BuiltInFunctionDefinitions.IS_NULL,
                     Collections.singletonList(fieldRef),
@@ -211,7 +211,7 @@ public class LanceReadOptimizationsTest {
             // Create name IS NOT NULL expression
             FieldReferenceExpression fieldRef = new FieldReferenceExpression(
                     "name", DataTypes.STRING(), 0, 1);
-            
+
             CallExpression isNotNullExpr = CallExpression.permanent(
                     BuiltInFunctionDefinitions.IS_NOT_NULL,
                     Collections.singletonList(fieldRef),
@@ -232,7 +232,7 @@ public class LanceReadOptimizationsTest {
             FieldReferenceExpression fieldRef = new FieldReferenceExpression(
                     "name", DataTypes.STRING(), 0, 1);
             ValueLiteralExpression pattern = new ValueLiteralExpression("test%");
-            
+
             CallExpression likeExpr = CallExpression.permanent(
                     BuiltInFunctionDefinitions.LIKE,
                     Arrays.asList(fieldRef, pattern),
@@ -255,7 +255,7 @@ public class LanceReadOptimizationsTest {
             ValueLiteralExpression value1 = new ValueLiteralExpression("active");
             ValueLiteralExpression value2 = new ValueLiteralExpression("pending");
             ValueLiteralExpression value3 = new ValueLiteralExpression("completed");
-            
+
             CallExpression inExpr = CallExpression.permanent(
                     BuiltInFunctionDefinitions.IN,
                     Arrays.asList(fieldRef, value1, value2, value3),

--- a/src/test/java/org/apache/flink/connector/lance/table/LanceReadOptimizationsTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/table/LanceReadOptimizationsTest.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,20 +11,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.table;
 
 import org.apache.flink.connector.lance.config.LanceOptions;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.ValueLiteralExpression;
-import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
-import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.functions.BuiltInFunctionDefinition;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.types.DataType;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -47,482 +41,475 @@ import static org.junit.jupiter.api.Assertions.*;
  * Read optimization tests
  *
  * <p>Test contents:
+ *
  * <ul>
- *   <li>Limit push-down</li>
- *   <li>Predicate push-down (basic comparison, IN, BETWEEN)</li>
- *   <li>Column pruning</li>
+ *   <li>Limit push-down
+ *   <li>Predicate push-down (basic comparison, IN, BETWEEN)
+ *   <li>Column pruning
  * </ul>
  */
 @DisplayName("Read Optimization Tests")
 public class LanceReadOptimizationsTest {
 
-    @TempDir
-    File tempDir;
+  @TempDir File tempDir;
 
-    private LanceOptions baseOptions;
-    private DataType physicalDataType;
+  private LanceOptions baseOptions;
+  private DataType physicalDataType;
 
-    @BeforeEach
-    void setUp() {
-        baseOptions = LanceOptions.builder()
-                .path(tempDir.getAbsolutePath() + "/test_dataset")
-                .readBatchSize(100)
-                .build();
+  @BeforeEach
+  void setUp() {
+    baseOptions =
+        LanceOptions.builder()
+            .path(tempDir.getAbsolutePath() + "/test_dataset")
+            .readBatchSize(100)
+            .build();
 
-        // Define test table schema
-        physicalDataType = DataTypes.ROW(
-                DataTypes.FIELD("id", DataTypes.BIGINT()),
-                DataTypes.FIELD("name", DataTypes.STRING()),
-                DataTypes.FIELD("status", DataTypes.STRING()),
-                DataTypes.FIELD("score", DataTypes.DOUBLE()),
-                DataTypes.FIELD("created_time", DataTypes.STRING())
-        );
+    // Define test table schema
+    physicalDataType =
+        DataTypes.ROW(
+            DataTypes.FIELD("id", DataTypes.BIGINT()),
+            DataTypes.FIELD("name", DataTypes.STRING()),
+            DataTypes.FIELD("status", DataTypes.STRING()),
+            DataTypes.FIELD("score", DataTypes.DOUBLE()),
+            DataTypes.FIELD("created_time", DataTypes.STRING()));
+  }
+
+  // ==================== Limit Push-Down Tests ====================
+
+  @Nested
+  @DisplayName("Limit Push-Down Tests")
+  class LimitPushDownTests {
+
+    @Test
+    @DisplayName("Test applyLimit method")
+    void testApplyLimit() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
+
+      // Initial state should have no limit
+      assertNull(source.getLimit(), "Initial limit should be null");
+
+      // Apply limit
+      source.applyLimit(100);
+
+      // Verify limit is set
+      assertEquals(100L, source.getLimit(), "Limit should be correctly set to 100");
     }
 
-    // ==================== Limit Push-Down Tests ====================
-
-    @Nested
-    @DisplayName("Limit Push-Down Tests")
-    class LimitPushDownTests {
-
-        @Test
-        @DisplayName("Test applyLimit method")
-        void testApplyLimit() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
-
-            // Initial state should have no limit
-            assertNull(source.getLimit(), "Initial limit should be null");
-
-            // Apply limit
-            source.applyLimit(100);
-
-            // Verify limit is set
-            assertEquals(100L, source.getLimit(), "Limit should be correctly set to 100");
-        }
-
-        @Test
-        @DisplayName("Test Limit of 0")
-        void testZeroLimit() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
-            source.applyLimit(0);
-            assertEquals(0L, source.getLimit(), "Limit should be settable to 0");
-        }
-
-        @Test
-        @DisplayName("Test large Limit value")
-        void testLargeLimit() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
-            long largeLimit = Long.MAX_VALUE;
-            source.applyLimit(largeLimit);
-            assertEquals(largeLimit, source.getLimit(), "Should support large Limit values");
-        }
-
-        @Test
-        @DisplayName("Test copy preserves Limit")
-        void testCopyPreservesLimit() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
-            source.applyLimit(50);
-
-            LanceDynamicTableSource copied = (LanceDynamicTableSource) source.copy();
-
-            assertEquals(50L, copied.getLimit(), "copy() should preserve limit value");
-        }
+    @Test
+    @DisplayName("Test Limit of 0")
+    void testZeroLimit() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
+      source.applyLimit(0);
+      assertEquals(0L, source.getLimit(), "Limit should be settable to 0");
     }
 
-    // ==================== Predicate Push-Down Tests ====================
-
-    @Nested
-    @DisplayName("Predicate Push-Down Tests")
-    class FilterPushDownTests {
-
-        @Test
-        @DisplayName("Test equals comparison push-down")
-        void testEqualsFilterPushDown() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
-
-            // Create status = 'active' expression
-            List<ResolvedExpression> filters = createEqualsFilter("status", "active");
-
-            SupportsFilterPushDown.Result result = source.applyFilters(filters);
-
-            // Verify filter is accepted
-            assertEquals(1, result.getAcceptedFilters().size(), "Equals comparison should be accepted");
-            assertEquals(0, result.getRemainingFilters().size(), "Should not have remaining filters");
-        }
-
-        @Test
-        @DisplayName("Test numeric comparison push-down")
-        void testNumericComparisonPushDown() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
-
-            // Create score > 80 expression
-            List<ResolvedExpression> filters = createComparisonFilter("score", 80.0, BuiltInFunctionDefinitions.GREATER_THAN);
-
-            SupportsFilterPushDown.Result result = source.applyFilters(filters);
-
-            assertEquals(1, result.getAcceptedFilters().size(), "Numeric comparison should be accepted");
-        }
-
-        @Test
-        @DisplayName("Test AND logic push-down")
-        void testAndLogicPushDown() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
-
-            // Create status = 'active' AND score > 60 expression
-            ResolvedExpression statusFilter = createEqualsExpression("status", "active");
-            ResolvedExpression scoreFilter = createComparisonExpression("score", 60.0, BuiltInFunctionDefinitions.GREATER_THAN);
-
-            CallExpression andExpr = CallExpression.permanent(
-                    BuiltInFunctionDefinitions.AND,
-                    Arrays.asList(statusFilter, scoreFilter),
-                    DataTypes.BOOLEAN()
-            );
-
-            SupportsFilterPushDown.Result result = source.applyFilters(Collections.singletonList(andExpr));
-
-            assertEquals(1, result.getAcceptedFilters().size(), "AND logic should be accepted");
-        }
-
-        @Test
-        @DisplayName("Test IS NULL push-down")
-        void testIsNullPushDown() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
-
-            // Create name IS NULL expression
-            FieldReferenceExpression fieldRef = new FieldReferenceExpression(
-                    "name", DataTypes.STRING(), 0, 1);
-
-            CallExpression isNullExpr = CallExpression.permanent(
-                    BuiltInFunctionDefinitions.IS_NULL,
-                    Collections.singletonList(fieldRef),
-                    DataTypes.BOOLEAN()
-            );
-
-            SupportsFilterPushDown.Result result = source.applyFilters(Collections.singletonList(isNullExpr));
-
-            assertEquals(1, result.getAcceptedFilters().size(), "IS NULL should be accepted");
-        }
-
-        @Test
-        @DisplayName("Test IS NOT NULL push-down")
-        void testIsNotNullPushDown() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
-
-            // Create name IS NOT NULL expression
-            FieldReferenceExpression fieldRef = new FieldReferenceExpression(
-                    "name", DataTypes.STRING(), 0, 1);
-
-            CallExpression isNotNullExpr = CallExpression.permanent(
-                    BuiltInFunctionDefinitions.IS_NOT_NULL,
-                    Collections.singletonList(fieldRef),
-                    DataTypes.BOOLEAN()
-            );
-
-            SupportsFilterPushDown.Result result = source.applyFilters(Collections.singletonList(isNotNullExpr));
-
-            assertEquals(1, result.getAcceptedFilters().size(), "IS NOT NULL should be accepted");
-        }
-
-        @Test
-        @DisplayName("Test LIKE push-down")
-        void testLikePushDown() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
-
-            // Create name LIKE 'test%' expression
-            FieldReferenceExpression fieldRef = new FieldReferenceExpression(
-                    "name", DataTypes.STRING(), 0, 1);
-            ValueLiteralExpression pattern = new ValueLiteralExpression("test%");
-
-            CallExpression likeExpr = CallExpression.permanent(
-                    BuiltInFunctionDefinitions.LIKE,
-                    Arrays.asList(fieldRef, pattern),
-                    DataTypes.BOOLEAN()
-            );
-
-            SupportsFilterPushDown.Result result = source.applyFilters(Collections.singletonList(likeExpr));
-
-            assertEquals(1, result.getAcceptedFilters().size(), "LIKE should be accepted");
-        }
-
-        @Test
-        @DisplayName("Test IN predicate push-down")
-        void testInPredicatePushDown() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
-
-            // Create status IN ('active', 'pending', 'completed') expression
-            FieldReferenceExpression fieldRef = new FieldReferenceExpression(
-                    "status", DataTypes.STRING(), 0, 2);
-            ValueLiteralExpression value1 = new ValueLiteralExpression("active");
-            ValueLiteralExpression value2 = new ValueLiteralExpression("pending");
-            ValueLiteralExpression value3 = new ValueLiteralExpression("completed");
-
-            CallExpression inExpr = CallExpression.permanent(
-                    BuiltInFunctionDefinitions.IN,
-                    Arrays.asList(fieldRef, value1, value2, value3),
-                    DataTypes.BOOLEAN()
-            );
-
-            SupportsFilterPushDown.Result result = source.applyFilters(Collections.singletonList(inExpr));
-
-            assertEquals(1, result.getAcceptedFilters().size(), "IN predicate should be accepted");
-        }
-
-        @Test
-        @DisplayName("Test multiple independent filter conditions")
-        void testMultipleFilters() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
-
-            // Create multiple independent filter conditions
-            List<ResolvedExpression> filter1 = createEqualsFilter("status", "active");
-            List<ResolvedExpression> filter2 = createComparisonFilter("score", 60.0, BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL);
-
-            List<ResolvedExpression> allFilters = new ArrayList<>();
-            allFilters.addAll(filter1);
-            allFilters.addAll(filter2);
-
-            SupportsFilterPushDown.Result result = source.applyFilters(allFilters);
-
-            assertEquals(2, result.getAcceptedFilters().size(), "Two filter conditions should be accepted");
-            assertEquals(0, result.getRemainingFilters().size(), "Should not have remaining filters");
-        }
-
-        @Test
-        @DisplayName("Test copy preserves filter conditions")
-        void testCopyPreservesFilters() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
-
-            // Apply filter conditions
-            List<ResolvedExpression> filters = createEqualsFilter("status", "active");
-            source.applyFilters(filters);
-
-            LanceDynamicTableSource copied = (LanceDynamicTableSource) source.copy();
-
-            // Verify copied source preserves filter conditions
-            assertNotNull(copied, "copy() should succeed");
-        }
+    @Test
+    @DisplayName("Test large Limit value")
+    void testLargeLimit() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
+      long largeLimit = Long.MAX_VALUE;
+      source.applyLimit(largeLimit);
+      assertEquals(largeLimit, source.getLimit(), "Should support large Limit values");
     }
 
-    // ==================== Column Pruning Tests ====================
+    @Test
+    @DisplayName("Test copy preserves Limit")
+    void testCopyPreservesLimit() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
+      source.applyLimit(50);
 
-    @Nested
-    @DisplayName("Column Pruning Tests")
-    class ProjectionPushDownTests {
+      LanceDynamicTableSource copied = (LanceDynamicTableSource) source.copy();
 
-        @Test
-        @DisplayName("Test single column projection")
-        void testSingleColumnProjection() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
+      assertEquals(50L, copied.getLimit(), "copy() should preserve limit value");
+    }
+  }
 
-            // Select only id column
-            int[][] projection = {{0}};  // First column
-            source.applyProjection(projection);
+  // ==================== Predicate Push-Down Tests ====================
 
-            // Verify projection is applied
-            assertNotNull(source, "Projection should be successfully applied");
-        }
+  @Nested
+  @DisplayName("Predicate Push-Down Tests")
+  class FilterPushDownTests {
 
-        @Test
-        @DisplayName("Test multiple column projection")
-        void testMultipleColumnProjection() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
+    @Test
+    @DisplayName("Test equals comparison push-down")
+    void testEqualsFilterPushDown() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
 
-            // Select id, name, score columns
-            int[][] projection = {{0}, {1}, {3}};
-            source.applyProjection(projection);
+      // Create status = 'active' expression
+      List<ResolvedExpression> filters = createEqualsFilter("status", "active");
 
-            assertNotNull(source, "Multiple column projection should be successfully applied");
-        }
+      SupportsFilterPushDown.Result result = source.applyFilters(filters);
 
-        @Test
-        @DisplayName("Test nested projection not supported")
-        void testNestedProjectionNotSupported() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
-
-            assertFalse(source.supportsNestedProjection(), "Should not support nested projection");
-        }
-
-        @Test
-        @DisplayName("Test copy preserves projection")
-        void testCopyPreservesProjection() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
-
-            int[][] projection = {{0}, {2}};
-            source.applyProjection(projection);
-
-            LanceDynamicTableSource copied = (LanceDynamicTableSource) source.copy();
-
-            assertNotNull(copied, "copy() should preserve projection information");
-        }
+      // Verify filter is accepted
+      assertEquals(1, result.getAcceptedFilters().size(), "Equals comparison should be accepted");
+      assertEquals(0, result.getRemainingFilters().size(), "Should not have remaining filters");
     }
 
-    // ==================== Combined Tests ====================
+    @Test
+    @DisplayName("Test numeric comparison push-down")
+    void testNumericComparisonPushDown() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
 
-    @Nested
-    @DisplayName("Combined Optimization Tests")
-    class CombinedOptimizationsTests {
+      // Create score > 80 expression
+      List<ResolvedExpression> filters =
+          createComparisonFilter("score", 80.0, BuiltInFunctionDefinitions.GREATER_THAN);
 
-        @Test
-        @DisplayName("Test Limit + filter condition combination")
-        void testLimitWithFilter() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
+      SupportsFilterPushDown.Result result = source.applyFilters(filters);
 
-            // Apply filter condition
-            List<ResolvedExpression> filters = createEqualsFilter("status", "active");
-            source.applyFilters(filters);
-
-            // Apply limit
-            source.applyLimit(100L);
-
-            assertEquals(Long.valueOf(100L), source.getLimit(), "Limit should be correctly set");
-        }
-
-        @Test
-        @DisplayName("Test Limit + projection combination")
-        void testLimitWithProjection() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
-
-            // Apply projection
-            int[][] projection = {{0}, {1}};
-            source.applyProjection(projection);
-
-            // Apply limit
-            source.applyLimit(50L);
-
-            assertEquals(Long.valueOf(50L), source.getLimit(), "Limit should be correctly set");
-        }
-
-        @Test
-        @DisplayName("Test all optimizations combined")
-        void testAllOptimizations() {
-            LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
-
-            // 1. Apply projection
-            int[][] projection = {{0}, {1}, {3}};  // id, name, score
-            source.applyProjection(projection);
-
-            // 2. Apply filter condition
-            List<ResolvedExpression> filters = createComparisonFilter("score", 60.0, BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL);
-            SupportsFilterPushDown.Result result = source.applyFilters(filters);
-
-            // 3. Apply limit
-            source.applyLimit(100L);
-
-            // Verify all optimizations are correctly applied
-            assertEquals(1, result.getAcceptedFilters().size(), "Filter condition should be accepted");
-            assertEquals(Long.valueOf(100L), source.getLimit(), "Limit should be correctly set");
-        }
+      assertEquals(1, result.getAcceptedFilters().size(), "Numeric comparison should be accepted");
     }
 
-    // ==================== LanceOptions Tests ====================
+    @Test
+    @DisplayName("Test AND logic push-down")
+    void testAndLogicPushDown() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
 
-    @Nested
-    @DisplayName("LanceOptions Limit Configuration Tests")
-    class LanceOptionsLimitTests {
+      // Create status = 'active' AND score > 60 expression
+      ResolvedExpression statusFilter = createEqualsExpression("status", "active");
+      ResolvedExpression scoreFilter =
+          createComparisonExpression("score", 60.0, BuiltInFunctionDefinitions.GREATER_THAN);
 
-        @Test
-        @DisplayName("Test readLimit configuration")
-        void testReadLimitConfig() {
-            LanceOptions options = LanceOptions.builder()
-                    .path("/test/path")
-                    .readLimit(500L)
-                    .build();
+      CallExpression andExpr =
+          CallExpression.permanent(
+              BuiltInFunctionDefinitions.AND,
+              Arrays.asList(statusFilter, scoreFilter),
+              DataTypes.BOOLEAN());
 
-            assertEquals(500L, options.getReadLimit(), "readLimit should be correctly configured");
-        }
+      SupportsFilterPushDown.Result result =
+          source.applyFilters(Collections.singletonList(andExpr));
 
-        @Test
-        @DisplayName("Test readLimit default value")
-        void testReadLimitDefault() {
-            LanceOptions options = LanceOptions.builder()
-                    .path("/test/path")
-                    .build();
-
-            assertNull(options.getReadLimit(), "readLimit default should be null");
-        }
-
-        @Test
-        @DisplayName("Test readLimit of 0")
-        void testReadLimitZero() {
-            // 0 should be allowed (means don't read any data)
-            LanceOptions options = LanceOptions.builder()
-                    .path("/test/path")
-                    .readLimit(0L)
-                    .build();
-
-            assertEquals(0L, options.getReadLimit());
-        }
-
-        @Test
-        @DisplayName("Test negative readLimit should fail")
-        void testNegativeReadLimit() {
-            assertThrows(IllegalArgumentException.class, () -> {
-                LanceOptions.builder()
-                        .path("/test/path")
-                        .readLimit(-1L)
-                        .build();
-            }, "Negative readLimit should throw exception");
-        }
+      assertEquals(1, result.getAcceptedFilters().size(), "AND logic should be accepted");
     }
 
-    // ==================== Helper Methods ====================
+    @Test
+    @DisplayName("Test IS NULL push-down")
+    void testIsNullPushDown() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
 
-    /**
-     * Create equals comparison filter expression
-     */
-    private List<ResolvedExpression> createEqualsFilter(String fieldName, String value) {
-        ResolvedExpression expr = createEqualsExpression(fieldName, value);
-        return Collections.singletonList(expr);
+      // Create name IS NULL expression
+      FieldReferenceExpression fieldRef =
+          new FieldReferenceExpression("name", DataTypes.STRING(), 0, 1);
+
+      CallExpression isNullExpr =
+          CallExpression.permanent(
+              BuiltInFunctionDefinitions.IS_NULL,
+              Collections.singletonList(fieldRef),
+              DataTypes.BOOLEAN());
+
+      SupportsFilterPushDown.Result result =
+          source.applyFilters(Collections.singletonList(isNullExpr));
+
+      assertEquals(1, result.getAcceptedFilters().size(), "IS NULL should be accepted");
     }
 
-    /**
-     * Create equals comparison expression
-     */
-    private ResolvedExpression createEqualsExpression(String fieldName, String value) {
-        FieldReferenceExpression fieldRef = new FieldReferenceExpression(
-                fieldName, DataTypes.STRING(), 0, getFieldIndex(fieldName));
-        ValueLiteralExpression literal = new ValueLiteralExpression(value);
+    @Test
+    @DisplayName("Test IS NOT NULL push-down")
+    void testIsNotNullPushDown() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
 
-        return CallExpression.permanent(
-                BuiltInFunctionDefinitions.EQUALS,
-                Arrays.asList(fieldRef, literal),
-                DataTypes.BOOLEAN()
-        );
+      // Create name IS NOT NULL expression
+      FieldReferenceExpression fieldRef =
+          new FieldReferenceExpression("name", DataTypes.STRING(), 0, 1);
+
+      CallExpression isNotNullExpr =
+          CallExpression.permanent(
+              BuiltInFunctionDefinitions.IS_NOT_NULL,
+              Collections.singletonList(fieldRef),
+              DataTypes.BOOLEAN());
+
+      SupportsFilterPushDown.Result result =
+          source.applyFilters(Collections.singletonList(isNotNullExpr));
+
+      assertEquals(1, result.getAcceptedFilters().size(), "IS NOT NULL should be accepted");
     }
 
-    /**
-     * Create comparison filter expression
-     */
-    private List<ResolvedExpression> createComparisonFilter(String fieldName, Double value, BuiltInFunctionDefinition funcDef) {
-        ResolvedExpression expr = createComparisonExpression(fieldName, value, funcDef);
-        return Collections.singletonList(expr);
+    @Test
+    @DisplayName("Test LIKE push-down")
+    void testLikePushDown() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
+
+      // Create name LIKE 'test%' expression
+      FieldReferenceExpression fieldRef =
+          new FieldReferenceExpression("name", DataTypes.STRING(), 0, 1);
+      ValueLiteralExpression pattern = new ValueLiteralExpression("test%");
+
+      CallExpression likeExpr =
+          CallExpression.permanent(
+              BuiltInFunctionDefinitions.LIKE,
+              Arrays.asList(fieldRef, pattern),
+              DataTypes.BOOLEAN());
+
+      SupportsFilterPushDown.Result result =
+          source.applyFilters(Collections.singletonList(likeExpr));
+
+      assertEquals(1, result.getAcceptedFilters().size(), "LIKE should be accepted");
     }
 
-    /**
-     * Create comparison expression
-     */
-    private ResolvedExpression createComparisonExpression(String fieldName, Double value, BuiltInFunctionDefinition funcDef) {
-        FieldReferenceExpression fieldRef = new FieldReferenceExpression(
-                fieldName, DataTypes.DOUBLE(), 0, getFieldIndex(fieldName));
-        ValueLiteralExpression literal = new ValueLiteralExpression(value);
+    @Test
+    @DisplayName("Test IN predicate push-down")
+    void testInPredicatePushDown() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
 
-        return CallExpression.permanent(
-                funcDef,
-                Arrays.asList(fieldRef, literal),
-                DataTypes.BOOLEAN()
-        );
+      // Create status IN ('active', 'pending', 'completed') expression
+      FieldReferenceExpression fieldRef =
+          new FieldReferenceExpression("status", DataTypes.STRING(), 0, 2);
+      ValueLiteralExpression value1 = new ValueLiteralExpression("active");
+      ValueLiteralExpression value2 = new ValueLiteralExpression("pending");
+      ValueLiteralExpression value3 = new ValueLiteralExpression("completed");
+
+      CallExpression inExpr =
+          CallExpression.permanent(
+              BuiltInFunctionDefinitions.IN,
+              Arrays.asList(fieldRef, value1, value2, value3),
+              DataTypes.BOOLEAN());
+
+      SupportsFilterPushDown.Result result = source.applyFilters(Collections.singletonList(inExpr));
+
+      assertEquals(1, result.getAcceptedFilters().size(), "IN predicate should be accepted");
     }
 
-    /**
-     * Get field index
-     */
-    private int getFieldIndex(String fieldName) {
-        switch (fieldName) {
-            case "id": return 0;
-            case "name": return 1;
-            case "status": return 2;
-            case "score": return 3;
-            case "created_time": return 4;
-            default: return 0;
-        }
+    @Test
+    @DisplayName("Test multiple independent filter conditions")
+    void testMultipleFilters() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
+
+      // Create multiple independent filter conditions
+      List<ResolvedExpression> filter1 = createEqualsFilter("status", "active");
+      List<ResolvedExpression> filter2 =
+          createComparisonFilter("score", 60.0, BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL);
+
+      List<ResolvedExpression> allFilters = new ArrayList<>();
+      allFilters.addAll(filter1);
+      allFilters.addAll(filter2);
+
+      SupportsFilterPushDown.Result result = source.applyFilters(allFilters);
+
+      assertEquals(
+          2, result.getAcceptedFilters().size(), "Two filter conditions should be accepted");
+      assertEquals(0, result.getRemainingFilters().size(), "Should not have remaining filters");
     }
+
+    @Test
+    @DisplayName("Test copy preserves filter conditions")
+    void testCopyPreservesFilters() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
+
+      // Apply filter conditions
+      List<ResolvedExpression> filters = createEqualsFilter("status", "active");
+      source.applyFilters(filters);
+
+      LanceDynamicTableSource copied = (LanceDynamicTableSource) source.copy();
+
+      // Verify copied source preserves filter conditions
+      assertNotNull(copied, "copy() should succeed");
+    }
+  }
+
+  // ==================== Column Pruning Tests ====================
+
+  @Nested
+  @DisplayName("Column Pruning Tests")
+  class ProjectionPushDownTests {
+
+    @Test
+    @DisplayName("Test single column projection")
+    void testSingleColumnProjection() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
+
+      // Select only id column
+      int[][] projection = {{0}}; // First column
+      source.applyProjection(projection);
+
+      // Verify projection is applied
+      assertNotNull(source, "Projection should be successfully applied");
+    }
+
+    @Test
+    @DisplayName("Test multiple column projection")
+    void testMultipleColumnProjection() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
+
+      // Select id, name, score columns
+      int[][] projection = {{0}, {1}, {3}};
+      source.applyProjection(projection);
+
+      assertNotNull(source, "Multiple column projection should be successfully applied");
+    }
+
+    @Test
+    @DisplayName("Test nested projection not supported")
+    void testNestedProjectionNotSupported() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
+
+      assertFalse(source.supportsNestedProjection(), "Should not support nested projection");
+    }
+
+    @Test
+    @DisplayName("Test copy preserves projection")
+    void testCopyPreservesProjection() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
+
+      int[][] projection = {{0}, {2}};
+      source.applyProjection(projection);
+
+      LanceDynamicTableSource copied = (LanceDynamicTableSource) source.copy();
+
+      assertNotNull(copied, "copy() should preserve projection information");
+    }
+  }
+
+  // ==================== Combined Tests ====================
+
+  @Nested
+  @DisplayName("Combined Optimization Tests")
+  class CombinedOptimizationsTests {
+
+    @Test
+    @DisplayName("Test Limit + filter condition combination")
+    void testLimitWithFilter() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
+
+      // Apply filter condition
+      List<ResolvedExpression> filters = createEqualsFilter("status", "active");
+      source.applyFilters(filters);
+
+      // Apply limit
+      source.applyLimit(100L);
+
+      assertEquals(Long.valueOf(100L), source.getLimit(), "Limit should be correctly set");
+    }
+
+    @Test
+    @DisplayName("Test Limit + projection combination")
+    void testLimitWithProjection() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
+
+      // Apply projection
+      int[][] projection = {{0}, {1}};
+      source.applyProjection(projection);
+
+      // Apply limit
+      source.applyLimit(50L);
+
+      assertEquals(Long.valueOf(50L), source.getLimit(), "Limit should be correctly set");
+    }
+
+    @Test
+    @DisplayName("Test all optimizations combined")
+    void testAllOptimizations() {
+      LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
+
+      // 1. Apply projection
+      int[][] projection = {{0}, {1}, {3}}; // id, name, score
+      source.applyProjection(projection);
+
+      // 2. Apply filter condition
+      List<ResolvedExpression> filters =
+          createComparisonFilter("score", 60.0, BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL);
+      SupportsFilterPushDown.Result result = source.applyFilters(filters);
+
+      // 3. Apply limit
+      source.applyLimit(100L);
+
+      // Verify all optimizations are correctly applied
+      assertEquals(1, result.getAcceptedFilters().size(), "Filter condition should be accepted");
+      assertEquals(Long.valueOf(100L), source.getLimit(), "Limit should be correctly set");
+    }
+  }
+
+  // ==================== LanceOptions Tests ====================
+
+  @Nested
+  @DisplayName("LanceOptions Limit Configuration Tests")
+  class LanceOptionsLimitTests {
+
+    @Test
+    @DisplayName("Test readLimit configuration")
+    void testReadLimitConfig() {
+      LanceOptions options = LanceOptions.builder().path("/test/path").readLimit(500L).build();
+
+      assertEquals(500L, options.getReadLimit(), "readLimit should be correctly configured");
+    }
+
+    @Test
+    @DisplayName("Test readLimit default value")
+    void testReadLimitDefault() {
+      LanceOptions options = LanceOptions.builder().path("/test/path").build();
+
+      assertNull(options.getReadLimit(), "readLimit default should be null");
+    }
+
+    @Test
+    @DisplayName("Test readLimit of 0")
+    void testReadLimitZero() {
+      // 0 should be allowed (means don't read any data)
+      LanceOptions options = LanceOptions.builder().path("/test/path").readLimit(0L).build();
+
+      assertEquals(0L, options.getReadLimit());
+    }
+
+    @Test
+    @DisplayName("Test negative readLimit should fail")
+    void testNegativeReadLimit() {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> {
+            LanceOptions.builder().path("/test/path").readLimit(-1L).build();
+          },
+          "Negative readLimit should throw exception");
+    }
+  }
+
+  // ==================== Helper Methods ====================
+
+  /** Create equals comparison filter expression */
+  private List<ResolvedExpression> createEqualsFilter(String fieldName, String value) {
+    ResolvedExpression expr = createEqualsExpression(fieldName, value);
+    return Collections.singletonList(expr);
+  }
+
+  /** Create equals comparison expression */
+  private ResolvedExpression createEqualsExpression(String fieldName, String value) {
+    FieldReferenceExpression fieldRef =
+        new FieldReferenceExpression(fieldName, DataTypes.STRING(), 0, getFieldIndex(fieldName));
+    ValueLiteralExpression literal = new ValueLiteralExpression(value);
+
+    return CallExpression.permanent(
+        BuiltInFunctionDefinitions.EQUALS, Arrays.asList(fieldRef, literal), DataTypes.BOOLEAN());
+  }
+
+  /** Create comparison filter expression */
+  private List<ResolvedExpression> createComparisonFilter(
+      String fieldName, Double value, BuiltInFunctionDefinition funcDef) {
+    ResolvedExpression expr = createComparisonExpression(fieldName, value, funcDef);
+    return Collections.singletonList(expr);
+  }
+
+  /** Create comparison expression */
+  private ResolvedExpression createComparisonExpression(
+      String fieldName, Double value, BuiltInFunctionDefinition funcDef) {
+    FieldReferenceExpression fieldRef =
+        new FieldReferenceExpression(fieldName, DataTypes.DOUBLE(), 0, getFieldIndex(fieldName));
+    ValueLiteralExpression literal = new ValueLiteralExpression(value);
+
+    return CallExpression.permanent(funcDef, Arrays.asList(fieldRef, literal), DataTypes.BOOLEAN());
+  }
+
+  /** Get field index */
+  private int getFieldIndex(String fieldName) {
+    switch (fieldName) {
+      case "id":
+        return 0;
+      case "name":
+        return 1;
+      case "status":
+        return 2;
+      case "score":
+        return 3;
+      case "created_time":
+        return 4;
+      default:
+        return 0;
+    }
+  }
 }

--- a/src/test/java/org/apache/flink/connector/lance/table/LanceSourceHandleTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/table/LanceSourceHandleTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.connector.lance.table;
+
+import org.apache.flink.connector.lance.aggregate.AggregateInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for {@link LanceSourceHandle}. */
+class LanceSourceHandleTest {
+
+  @Test
+  @DisplayName("EMPTY handle has no push-down")
+  void testEmptyHandle() {
+    LanceSourceHandle handle = LanceSourceHandle.EMPTY;
+
+    assertThat(handle.getProjectedFields()).isNull();
+    assertThat(handle.getFilters()).isEmpty();
+    assertThat(handle.getLimit()).isNull();
+    assertThat(handle.getAggregateInfo()).isNull();
+    assertThat(handle.hasPushDown()).isFalse();
+  }
+
+  @Test
+  @DisplayName("Handle with projection only")
+  void testProjectionOnly() {
+    LanceSourceHandle handle =
+        LanceSourceHandle.builder().projectedFields(new int[] {0, 2}).build();
+
+    assertThat(handle.getProjectedFields()).containsExactly(0, 2);
+    assertThat(handle.getFilters()).isEmpty();
+    assertThat(handle.getLimit()).isNull();
+    assertThat(handle.hasPushDown()).isTrue();
+  }
+
+  @Test
+  @DisplayName("Handle with filters only")
+  void testFiltersOnly() {
+    LanceSourceHandle handle =
+        LanceSourceHandle.builder().filters(Arrays.asList("id > 10", "name = 'x'")).build();
+
+    assertThat(handle.getProjectedFields()).isNull();
+    assertThat(handle.getFilters()).containsExactly("id > 10", "name = 'x'");
+    assertThat(handle.hasPushDown()).isTrue();
+  }
+
+  @Test
+  @DisplayName("Handle with limit only")
+  void testLimitOnly() {
+    LanceSourceHandle handle = LanceSourceHandle.builder().limit(100L).build();
+
+    assertThat(handle.getLimit()).isEqualTo(100L);
+    assertThat(handle.hasPushDown()).isTrue();
+  }
+
+  @Test
+  @DisplayName("Handle with all push-down types")
+  void testAllPushDownTypes() {
+    AggregateInfo aggInfo =
+        AggregateInfo.builder()
+            .groupBy(Collections.singletonList("category"))
+            .addAggregateCall(
+                new AggregateInfo.AggregateCall(AggregateInfo.AggregateFunction.COUNT, null, "cnt"))
+            .build();
+
+    LanceSourceHandle handle =
+        LanceSourceHandle.builder()
+            .projectedFields(new int[] {0, 1})
+            .filters(Arrays.asList("id > 5"))
+            .limit(50L)
+            .aggregateInfo(aggInfo)
+            .build();
+
+    assertThat(handle.getProjectedFields()).containsExactly(0, 1);
+    assertThat(handle.getFilters()).containsExactly("id > 5");
+    assertThat(handle.getLimit()).isEqualTo(50L);
+    assertThat(handle.getAggregateInfo()).isEqualTo(aggInfo);
+    assertThat(handle.hasPushDown()).isTrue();
+  }
+
+  @Test
+  @DisplayName("Projected fields defensive copy: external mutation does not affect handle")
+  void testProjectedFieldsDefensiveCopy() {
+    int[] fields = {0, 1, 2};
+    LanceSourceHandle handle = LanceSourceHandle.builder().projectedFields(fields).build();
+
+    // Mutate the original array
+    fields[0] = 99;
+
+    // Handle should not be affected
+    assertThat(handle.getProjectedFields()).containsExactly(0, 1, 2);
+  }
+
+  @Test
+  @DisplayName("getProjectedFields returns a copy each time")
+  void testGetProjectedFieldsReturnsCopy() {
+    LanceSourceHandle handle =
+        LanceSourceHandle.builder().projectedFields(new int[] {0, 1}).build();
+
+    int[] first = handle.getProjectedFields();
+    int[] second = handle.getProjectedFields();
+
+    assertThat(first).isNotSameAs(second);
+    assertThat(first).containsExactly(0, 1);
+  }
+
+  @Test
+  @DisplayName("Filters list is unmodifiable")
+  void testFiltersImmutable() {
+    LanceSourceHandle handle = LanceSourceHandle.builder().filters(Arrays.asList("id > 1")).build();
+
+    assertThat(handle.getFilters()).hasSize(1);
+    org.junit.jupiter.api.Assertions.assertThrows(
+        UnsupportedOperationException.class, () -> handle.getFilters().add("extra"));
+  }
+
+  @Test
+  @DisplayName("toBuilder creates a modified copy")
+  void testToBuilder() {
+    LanceSourceHandle original =
+        LanceSourceHandle.builder()
+            .projectedFields(new int[] {0})
+            .filters(Arrays.asList("a > 1"))
+            .build();
+
+    LanceSourceHandle modified = original.toBuilder().limit(10L).build();
+
+    // Original is unchanged
+    assertThat(original.getLimit()).isNull();
+    // Modified has new limit and retains original state
+    assertThat(modified.getLimit()).isEqualTo(10L);
+    assertThat(modified.getProjectedFields()).containsExactly(0);
+    assertThat(modified.getFilters()).containsExactly("a > 1");
+  }
+
+  @Test
+  @DisplayName("equals and hashCode")
+  void testEqualsHashCode() {
+    LanceSourceHandle a =
+        LanceSourceHandle.builder()
+            .projectedFields(new int[] {0, 1})
+            .filters(Arrays.asList("id > 5"))
+            .limit(50L)
+            .build();
+
+    LanceSourceHandle b =
+        LanceSourceHandle.builder()
+            .projectedFields(new int[] {0, 1})
+            .filters(Arrays.asList("id > 5"))
+            .limit(50L)
+            .build();
+
+    LanceSourceHandle c = LanceSourceHandle.builder().limit(100L).build();
+
+    assertThat(a).isEqualTo(b);
+    assertThat(a.hashCode()).isEqualTo(b.hashCode());
+    assertThat(a).isNotEqualTo(c);
+  }
+
+  @Test
+  @DisplayName("toString contains key info")
+  void testToString() {
+    LanceSourceHandle handle =
+        LanceSourceHandle.builder()
+            .projectedFields(new int[] {0})
+            .filters(Arrays.asList("id > 5"))
+            .limit(50L)
+            .build();
+
+    String str = handle.toString();
+    assertThat(str).contains("projectedFields");
+    assertThat(str).contains("id > 5");
+    assertThat(str).contains("50");
+  }
+}

--- a/src/test/java/org/apache/flink/connector/lance/table/LanceSqlITCase.java
+++ b/src/test/java/org/apache/flink/connector/lance/table/LanceSqlITCase.java
@@ -15,6 +15,12 @@ package org.apache.flink.connector.lance.table;
 
 import org.apache.flink.connector.lance.config.LanceOptions;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
+import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
@@ -28,6 +34,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -35,6 +42,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Lance SQL integration tests. */
 class LanceSqlITCase {
@@ -58,13 +66,14 @@ class LanceSqlITCase {
   }
 
   @Test
-  @DisplayName("Test LanceDynamicTableFactory required options")
+  @DisplayName("Test LanceDynamicTableFactory required options - path is now optional")
   void testRequiredOptions() {
     LanceDynamicTableFactory factory = new LanceDynamicTableFactory();
     Set<String> requiredOptionKeys = new HashSet<>();
     factory.requiredOptions().forEach(opt -> requiredOptionKeys.add(opt.key()));
 
-    assertThat(requiredOptionKeys).contains("path");
+    // path is no longer required (Catalog mode injects it automatically)
+    assertThat(requiredOptionKeys).isEmpty();
   }
 
   @Test
@@ -76,6 +85,7 @@ class LanceSqlITCase {
 
     assertThat(optionalOptionKeys)
         .contains(
+            "path",
             "read.batch-size",
             "read.columns",
             "read.filter",
@@ -85,7 +95,11 @@ class LanceSqlITCase {
             "index.type",
             "index.column",
             "vector.column",
-            "vector.metric");
+            "vector.metric",
+            "s3-access-key",
+            "s3-secret-key",
+            "s3-region",
+            "s3-endpoint");
   }
 
   @Test
@@ -320,5 +334,229 @@ class LanceSqlITCase {
   void testVectorSearchFunctionConfiguration() {
     LanceVectorSearchFunction function = new LanceVectorSearchFunction();
     assertThat(function).isNotNull();
+  }
+
+  // ==================== CREATE TABLE with Namespace Integration Tests ====================
+
+  @Test
+  @DisplayName("Test CREATE TABLE via Catalog creates empty Lance Dataset")
+  void testCreateTableViaCatalogCreatesDataset() throws Exception {
+    LanceCatalog catalog = new LanceCatalog("test_catalog", "default", warehousePath);
+
+    try {
+      catalog.open();
+
+      // Build a CatalogTable with schema
+      Schema schema =
+          Schema.newBuilder()
+              .column("id", DataTypes.BIGINT())
+              .column("name", DataTypes.STRING())
+              .column("score", DataTypes.DOUBLE())
+              .build();
+      CatalogTable catalogTable =
+          CatalogTable.of(schema, "test table", Collections.emptyList(), Collections.emptyMap());
+
+      ObjectPath tablePath = new ObjectPath("default", "users");
+
+      // Create table
+      catalog.createTable(tablePath, catalogTable, false);
+
+      // Table should now exist
+      assertThat(catalog.tableExists(tablePath)).isTrue();
+
+      // Should appear in listTables
+      List<String> tables = catalog.listTables("default");
+      assertThat(tables).contains("users");
+
+      // getTable should return valid CatalogTable with correct schema
+      CatalogBaseTable retrievedTable = catalog.getTable(tablePath);
+      assertThat(retrievedTable).isInstanceOf(CatalogTable.class);
+
+      // Verify the returned table has correct options
+      Map<String, String> options = retrievedTable.getOptions();
+      assertThat(options).containsKey("connector");
+      assertThat(options.get("connector")).isEqualTo("lance");
+      assertThat(options).containsKey("path");
+
+    } finally {
+      catalog.close();
+    }
+  }
+
+  @Test
+  @DisplayName("Test CREATE TABLE via Catalog preserves user options")
+  void testCreateTablePreservesUserOptions() throws Exception {
+    LanceCatalog catalog = new LanceCatalog("test_catalog", "default", warehousePath);
+
+    try {
+      catalog.open();
+
+      Schema schema =
+          Schema.newBuilder()
+              .column("id", DataTypes.BIGINT())
+              .column("value", DataTypes.STRING())
+              .build();
+
+      Map<String, String> userOptions = new HashMap<>();
+      userOptions.put("write.batch-size", "256");
+      userOptions.put("write.mode", "overwrite");
+
+      CatalogTable catalogTable =
+          CatalogTable.of(schema, "test table", Collections.emptyList(), userOptions);
+
+      ObjectPath tablePath = new ObjectPath("default", "my_table");
+      catalog.createTable(tablePath, catalogTable, false);
+
+      // getTable should return merged options
+      CatalogBaseTable retrievedTable = catalog.getTable(tablePath);
+      Map<String, String> options = retrievedTable.getOptions();
+      assertThat(options.get("write.batch-size")).isEqualTo("256");
+      assertThat(options.get("write.mode")).isEqualTo("overwrite");
+      // Connector and path should be set by catalog
+      assertThat(options.get("connector")).isEqualTo("lance");
+      assertThat(options).containsKey("path");
+
+    } finally {
+      catalog.close();
+    }
+  }
+
+  @Test
+  @DisplayName("Test CREATE TABLE twice throws TableAlreadyExistException")
+  void testCreateTableDuplicate() throws Exception {
+    LanceCatalog catalog = new LanceCatalog("test_catalog", "default", warehousePath);
+
+    try {
+      catalog.open();
+
+      Schema schema = Schema.newBuilder().column("id", DataTypes.BIGINT()).build();
+      CatalogTable catalogTable =
+          CatalogTable.of(schema, "test", Collections.emptyList(), Collections.emptyMap());
+
+      ObjectPath tablePath = new ObjectPath("default", "dup_table");
+      catalog.createTable(tablePath, catalogTable, false);
+
+      // Second create should throw
+      assertThatThrownBy(() -> catalog.createTable(tablePath, catalogTable, false))
+          .isInstanceOf(TableAlreadyExistException.class);
+
+      // With ignoreIfExists=true, should not throw
+      catalog.createTable(tablePath, catalogTable, true);
+
+    } finally {
+      catalog.close();
+    }
+  }
+
+  @Test
+  @DisplayName("Test DROP TABLE after CREATE TABLE")
+  void testDropTableAfterCreate() throws Exception {
+    LanceCatalog catalog = new LanceCatalog("test_catalog", "default", warehousePath);
+
+    try {
+      catalog.open();
+
+      Schema schema =
+          Schema.newBuilder()
+              .column("id", DataTypes.BIGINT())
+              .column("name", DataTypes.STRING())
+              .build();
+      CatalogTable catalogTable =
+          CatalogTable.of(schema, "drop test", Collections.emptyList(), Collections.emptyMap());
+
+      ObjectPath tablePath = new ObjectPath("default", "to_drop");
+      catalog.createTable(tablePath, catalogTable, false);
+      assertThat(catalog.tableExists(tablePath)).isTrue();
+
+      // Drop table
+      catalog.dropTable(tablePath, false);
+      assertThat(catalog.tableExists(tablePath)).isFalse();
+
+      // Drop again should throw
+      assertThatThrownBy(() -> catalog.dropTable(tablePath, false))
+          .isInstanceOf(TableNotExistException.class);
+
+    } finally {
+      catalog.close();
+    }
+  }
+
+  @Test
+  @DisplayName("Test CREATE TABLE with vector column")
+  void testCreateTableWithVectorColumn() throws Exception {
+    LanceCatalog catalog = new LanceCatalog("test_catalog", "default", warehousePath);
+
+    try {
+      catalog.open();
+
+      Schema schema =
+          Schema.newBuilder()
+              .column("id", DataTypes.BIGINT())
+              .column("content", DataTypes.STRING())
+              .column("embedding", DataTypes.ARRAY(DataTypes.FLOAT()))
+              .build();
+      CatalogTable catalogTable =
+          CatalogTable.of(schema, "vector table", Collections.emptyList(), Collections.emptyMap());
+
+      ObjectPath tablePath = new ObjectPath("default", "vector_table");
+      catalog.createTable(tablePath, catalogTable, false);
+
+      assertThat(catalog.tableExists(tablePath)).isTrue();
+
+      // Verify schema round-trip
+      CatalogBaseTable retrieved = catalog.getTable(tablePath);
+      assertThat(retrieved).isInstanceOf(CatalogTable.class);
+
+    } finally {
+      catalog.close();
+    }
+  }
+
+  @Test
+  @DisplayName("Test CREATE TABLE in non-default database")
+  void testCreateTableInCustomDatabase() throws Exception {
+    LanceCatalog catalog = new LanceCatalog("test_catalog", "default", warehousePath);
+
+    try {
+      catalog.open();
+
+      // Create a custom database first
+      catalog.createDatabase("mydb", null, false);
+
+      Schema schema =
+          Schema.newBuilder()
+              .column("id", DataTypes.BIGINT())
+              .column("data", DataTypes.STRING())
+              .build();
+      CatalogTable catalogTable =
+          CatalogTable.of(
+              schema, "custom db table", Collections.emptyList(), Collections.emptyMap());
+
+      ObjectPath tablePath = new ObjectPath("mydb", "my_table");
+      catalog.createTable(tablePath, catalogTable, false);
+
+      assertThat(catalog.tableExists(tablePath)).isTrue();
+      assertThat(catalog.listTables("mydb")).contains("my_table");
+
+      // Verify path contains database name
+      CatalogBaseTable retrieved = catalog.getTable(tablePath);
+      String path = retrieved.getOptions().get("path");
+      assertThat(path).contains("mydb");
+      assertThat(path).contains("my_table");
+
+    } finally {
+      catalog.close();
+    }
+  }
+
+  @Test
+  @DisplayName("Test DynamicTableFactory S3 options are declared")
+  void testDynamicTableFactoryS3Options() {
+    LanceDynamicTableFactory factory = new LanceDynamicTableFactory();
+    Set<String> optionalOptionKeys = new HashSet<>();
+    factory.optionalOptions().forEach(opt -> optionalOptionKeys.add(opt.key()));
+
+    assertThat(optionalOptionKeys)
+        .contains("s3-access-key", "s3-secret-key", "s3-region", "s3-endpoint");
   }
 }

--- a/src/test/java/org/apache/flink/connector/lance/table/LanceSqlITCase.java
+++ b/src/test/java/org/apache/flink/connector/lance/table/LanceSqlITCase.java
@@ -214,29 +214,29 @@ class LanceSqlITCase {
     @DisplayName("Test LanceCatalog creation and basic operations")
     void testLanceCatalogBasicOperations() throws Exception {
         LanceCatalog catalog = new LanceCatalog("test_catalog", "default", warehousePath);
-        
+
         try {
             catalog.open();
-            
+
             // Verify default database exists
             assertThat(catalog.databaseExists("default")).isTrue();
-            
+
             // List databases
             List<String> databases = catalog.listDatabases();
             assertThat(databases).contains("default");
-            
+
             // Create new database
             catalog.createDatabase("test_db", null, false);
             assertThat(catalog.databaseExists("test_db")).isTrue();
-            
+
             // List tables (empty)
             List<String> tables = catalog.listTables("test_db");
             assertThat(tables).isEmpty();
-            
+
             // Drop database
             catalog.dropDatabase("test_db", false, true);
             assertThat(catalog.databaseExists("test_db")).isFalse();
-            
+
         } finally {
             catalog.close();
         }
@@ -246,7 +246,7 @@ class LanceSqlITCase {
     @DisplayName("Test LanceCatalog warehouse path")
     void testLanceCatalogWarehouse() throws Exception {
         LanceCatalog catalog = new LanceCatalog("test", "default", warehousePath);
-        
+
         try {
             catalog.open();
             assertThat(catalog.getWarehouse()).isEqualTo(warehousePath);
@@ -288,7 +288,7 @@ class LanceSqlITCase {
         assertThat(LanceCatalogFactory.S3_ENDPOINT.key()).isEqualTo("s3-endpoint");
         assertThat(LanceCatalogFactory.S3_VIRTUAL_HOSTED_STYLE.key()).isEqualTo("s3-virtual-hosted-style");
         assertThat(LanceCatalogFactory.S3_ALLOW_HTTP.key()).isEqualTo("s3-allow-http");
-        
+
         // Default values
         assertThat(LanceCatalogFactory.S3_VIRTUAL_HOSTED_STYLE.defaultValue()).isTrue();
         assertThat(LanceCatalogFactory.S3_ALLOW_HTTP.defaultValue()).isFalse();
@@ -300,19 +300,19 @@ class LanceSqlITCase {
         // S3 path should be identified as remote storage
         LanceCatalog s3Catalog = new LanceCatalog("test", "default", "s3://bucket/path");
         assertThat(s3Catalog.isRemoteStorage()).isTrue();
-        
+
         // S3A path
         LanceCatalog s3aCatalog = new LanceCatalog("test", "default", "s3a://bucket/path");
         assertThat(s3aCatalog.isRemoteStorage()).isTrue();
-        
+
         // GCS path
         LanceCatalog gcsCatalog = new LanceCatalog("test", "default", "gs://bucket/path");
         assertThat(gcsCatalog.isRemoteStorage()).isTrue();
-        
+
         // Azure path
         LanceCatalog azCatalog = new LanceCatalog("test", "default", "az://container/path");
         assertThat(azCatalog.isRemoteStorage()).isTrue();
-        
+
         // Local path should be identified as local storage
         LanceCatalog localCatalog = new LanceCatalog("test", "default", warehousePath);
         assertThat(localCatalog.isRemoteStorage()).isFalse();
@@ -325,14 +325,14 @@ class LanceSqlITCase {
         storageOptions.put("aws_access_key_id", "test-key");
         storageOptions.put("aws_secret_access_key", "test-secret");
         storageOptions.put("aws_region", "us-east-1");
-        
+
         LanceCatalog catalog = new LanceCatalog(
-                "test_catalog", 
-                "default", 
+                "test_catalog",
+                "default",
                 "s3://bucket/warehouse",
                 storageOptions
         );
-        
+
         assertThat(catalog.getStorageOptions()).containsEntry("aws_access_key_id", "test-key");
         assertThat(catalog.getStorageOptions()).containsEntry("aws_secret_access_key", "test-secret");
         assertThat(catalog.getStorageOptions()).containsEntry("aws_region", "us-east-1");

--- a/src/test/java/org/apache/flink/connector/lance/table/LanceSqlITCase.java
+++ b/src/test/java/org/apache/flink/connector/lance/table/LanceSqlITCase.java
@@ -1,11 +1,7 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
@@ -15,19 +11,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.flink.connector.lance.table;
 
 import org.apache.flink.connector.lance.config.LanceOptions;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,305 +36,289 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * Lance SQL integration tests.
- */
+/** Lance SQL integration tests. */
 class LanceSqlITCase {
 
-    @TempDir
-    Path tempDir;
+  @TempDir Path tempDir;
 
-    private String datasetPath;
-    private String warehousePath;
+  private String datasetPath;
+  private String warehousePath;
 
-    @BeforeEach
-    void setUp() {
-        datasetPath = tempDir.resolve("test_sql_dataset").toString();
-        warehousePath = tempDir.resolve("test_warehouse").toString();
+  @BeforeEach
+  void setUp() {
+    datasetPath = tempDir.resolve("test_sql_dataset").toString();
+    warehousePath = tempDir.resolve("test_warehouse").toString();
+  }
+
+  @Test
+  @DisplayName("Test LanceDynamicTableFactory identifier")
+  void testFactoryIdentifier() {
+    LanceDynamicTableFactory factory = new LanceDynamicTableFactory();
+    assertThat(factory.factoryIdentifier()).isEqualTo("lance");
+  }
+
+  @Test
+  @DisplayName("Test LanceDynamicTableFactory required options")
+  void testRequiredOptions() {
+    LanceDynamicTableFactory factory = new LanceDynamicTableFactory();
+    Set<String> requiredOptionKeys = new HashSet<>();
+    factory.requiredOptions().forEach(opt -> requiredOptionKeys.add(opt.key()));
+
+    assertThat(requiredOptionKeys).contains("path");
+  }
+
+  @Test
+  @DisplayName("Test LanceDynamicTableFactory optional options")
+  void testOptionalOptions() {
+    LanceDynamicTableFactory factory = new LanceDynamicTableFactory();
+    Set<String> optionalOptionKeys = new HashSet<>();
+    factory.optionalOptions().forEach(opt -> optionalOptionKeys.add(opt.key()));
+
+    assertThat(optionalOptionKeys)
+        .contains(
+            "read.batch-size",
+            "read.columns",
+            "read.filter",
+            "write.batch-size",
+            "write.mode",
+            "write.max-rows-per-file",
+            "index.type",
+            "index.column",
+            "vector.column",
+            "vector.metric");
+  }
+
+  @Test
+  @DisplayName("Test LanceDynamicTableSource creation")
+  void testDynamicTableSourceCreation() {
+    LanceOptions options = LanceOptions.builder().path(datasetPath).readBatchSize(512).build();
+
+    List<RowType.RowField> fields = new ArrayList<>();
+    fields.add(new RowType.RowField("id", new BigIntType()));
+    fields.add(new RowType.RowField("content", new VarCharType()));
+    fields.add(new RowType.RowField("embedding", new ArrayType(new FloatType())));
+    RowType rowType = new RowType(fields);
+
+    DataType dataType =
+        DataTypes.ROW(
+            DataTypes.FIELD("id", DataTypes.BIGINT()),
+            DataTypes.FIELD("content", DataTypes.STRING()),
+            DataTypes.FIELD("embedding", DataTypes.ARRAY(DataTypes.FLOAT())));
+
+    LanceDynamicTableSource source = new LanceDynamicTableSource(options, dataType);
+
+    assertThat(source.getOptions()).isEqualTo(options);
+    assertThat(source.getPhysicalDataType()).isEqualTo(dataType);
+    assertThat(source.asSummaryString()).isEqualTo("Lance Table Source");
+  }
+
+  @Test
+  @DisplayName("Test LanceDynamicTableSink creation")
+  void testDynamicTableSinkCreation() {
+    LanceOptions options =
+        LanceOptions.builder()
+            .path(datasetPath)
+            .writeBatchSize(256)
+            .writeMode(LanceOptions.WriteMode.APPEND)
+            .build();
+
+    DataType dataType =
+        DataTypes.ROW(
+            DataTypes.FIELD("id", DataTypes.BIGINT()),
+            DataTypes.FIELD("content", DataTypes.STRING()),
+            DataTypes.FIELD("embedding", DataTypes.ARRAY(DataTypes.FLOAT())));
+
+    LanceDynamicTableSink sink = new LanceDynamicTableSink(options, dataType);
+
+    assertThat(sink.getOptions()).isEqualTo(options);
+    assertThat(sink.getPhysicalDataType()).isEqualTo(dataType);
+    assertThat(sink.asSummaryString()).isEqualTo("Lance Table Sink");
+  }
+
+  @Test
+  @DisplayName("Test LanceDynamicTableSource copy")
+  void testDynamicTableSourceCopy() {
+    LanceOptions options = LanceOptions.builder().path(datasetPath).build();
+
+    DataType dataType = DataTypes.ROW(DataTypes.FIELD("id", DataTypes.BIGINT()));
+
+    LanceDynamicTableSource source = new LanceDynamicTableSource(options, dataType);
+    LanceDynamicTableSource copiedSource = (LanceDynamicTableSource) source.copy();
+
+    assertThat(copiedSource).isNotSameAs(source);
+    assertThat(copiedSource.getOptions()).isEqualTo(source.getOptions());
+  }
+
+  @Test
+  @DisplayName("Test LanceDynamicTableSink copy")
+  void testDynamicTableSinkCopy() {
+    LanceOptions options = LanceOptions.builder().path(datasetPath).build();
+
+    DataType dataType = DataTypes.ROW(DataTypes.FIELD("id", DataTypes.BIGINT()));
+
+    LanceDynamicTableSink sink = new LanceDynamicTableSink(options, dataType);
+    LanceDynamicTableSink copiedSink = (LanceDynamicTableSink) sink.copy();
+
+    assertThat(copiedSink).isNotSameAs(sink);
+    assertThat(copiedSink.getOptions()).isEqualTo(sink.getOptions());
+  }
+
+  @Test
+  @DisplayName("Test LanceCatalogFactory identifier")
+  void testCatalogFactoryIdentifier() {
+    LanceCatalogFactory factory = new LanceCatalogFactory();
+    assertThat(factory.factoryIdentifier()).isEqualTo("lance");
+  }
+
+  @Test
+  @DisplayName("Test LanceCatalogFactory required options")
+  void testCatalogRequiredOptions() {
+    LanceCatalogFactory factory = new LanceCatalogFactory();
+    Set<String> requiredOptionKeys = new HashSet<>();
+    factory.requiredOptions().forEach(opt -> requiredOptionKeys.add(opt.key()));
+
+    assertThat(requiredOptionKeys).contains("warehouse");
+  }
+
+  @Test
+  @DisplayName("Test LanceCatalogFactory optional options")
+  void testCatalogOptionalOptions() {
+    LanceCatalogFactory factory = new LanceCatalogFactory();
+    Set<String> optionalOptionKeys = new HashSet<>();
+    factory.optionalOptions().forEach(opt -> optionalOptionKeys.add(opt.key()));
+
+    assertThat(optionalOptionKeys).contains("default-database");
+  }
+
+  @Test
+  @DisplayName("Test LanceCatalog creation and basic operations")
+  void testLanceCatalogBasicOperations() throws Exception {
+    LanceCatalog catalog = new LanceCatalog("test_catalog", "default", warehousePath);
+
+    try {
+      catalog.open();
+
+      // Verify default database exists
+      assertThat(catalog.databaseExists("default")).isTrue();
+
+      // List databases
+      List<String> databases = catalog.listDatabases();
+      assertThat(databases).contains("default");
+
+      // Create new database
+      catalog.createDatabase("test_db", null, false);
+      assertThat(catalog.databaseExists("test_db")).isTrue();
+
+      // List tables (empty)
+      List<String> tables = catalog.listTables("test_db");
+      assertThat(tables).isEmpty();
+
+      // Drop database
+      catalog.dropDatabase("test_db", false, true);
+      assertThat(catalog.databaseExists("test_db")).isFalse();
+
+    } finally {
+      catalog.close();
     }
+  }
 
-    @Test
-    @DisplayName("Test LanceDynamicTableFactory identifier")
-    void testFactoryIdentifier() {
-        LanceDynamicTableFactory factory = new LanceDynamicTableFactory();
-        assertThat(factory.factoryIdentifier()).isEqualTo("lance");
+  @Test
+  @DisplayName("Test LanceCatalog warehouse path")
+  void testLanceCatalogWarehouse() throws Exception {
+    LanceCatalog catalog = new LanceCatalog("test", "default", warehousePath);
+
+    try {
+      catalog.open();
+      assertThat(catalog.getWarehouse()).isEqualTo(warehousePath);
+    } finally {
+      catalog.close();
     }
+  }
 
-    @Test
-    @DisplayName("Test LanceDynamicTableFactory required options")
-    void testRequiredOptions() {
-        LanceDynamicTableFactory factory = new LanceDynamicTableFactory();
-        Set<String> requiredOptionKeys = new HashSet<>();
-        factory.requiredOptions().forEach(opt -> requiredOptionKeys.add(opt.key()));
+  @Test
+  @DisplayName("Test configuration options definition")
+  void testConfigOptions() {
+    assertThat(LanceDynamicTableFactory.PATH.key()).isEqualTo("path");
+    assertThat(LanceDynamicTableFactory.READ_BATCH_SIZE.key()).isEqualTo("read.batch-size");
+    assertThat(LanceDynamicTableFactory.READ_BATCH_SIZE.defaultValue()).isEqualTo(1024);
+    assertThat(LanceDynamicTableFactory.WRITE_BATCH_SIZE.key()).isEqualTo("write.batch-size");
+    assertThat(LanceDynamicTableFactory.WRITE_MODE.key()).isEqualTo("write.mode");
+    assertThat(LanceDynamicTableFactory.WRITE_MODE.defaultValue()).isEqualTo("append");
+    assertThat(LanceDynamicTableFactory.INDEX_TYPE.key()).isEqualTo("index.type");
+    assertThat(LanceDynamicTableFactory.INDEX_TYPE.defaultValue()).isEqualTo("IVF_PQ");
+    assertThat(LanceDynamicTableFactory.VECTOR_METRIC.key()).isEqualTo("vector.metric");
+    assertThat(LanceDynamicTableFactory.VECTOR_METRIC.defaultValue()).isEqualTo("L2");
+  }
 
-        assertThat(requiredOptionKeys).contains("path");
-    }
+  @Test
+  @DisplayName("Test Catalog configuration options definition")
+  void testCatalogConfigOptions() {
+    assertThat(LanceCatalogFactory.WAREHOUSE.key()).isEqualTo("warehouse");
+    assertThat(LanceCatalogFactory.DEFAULT_DATABASE.key()).isEqualTo("default-database");
+    assertThat(LanceCatalogFactory.DEFAULT_DATABASE.defaultValue()).isEqualTo("default");
+  }
 
-    @Test
-    @DisplayName("Test LanceDynamicTableFactory optional options")
-    void testOptionalOptions() {
-        LanceDynamicTableFactory factory = new LanceDynamicTableFactory();
-        Set<String> optionalOptionKeys = new HashSet<>();
-        factory.optionalOptions().forEach(opt -> optionalOptionKeys.add(opt.key()));
+  @Test
+  @DisplayName("Test S3 Catalog configuration options definition")
+  void testS3CatalogConfigOptions() {
+    // S3 configuration options
+    assertThat(LanceCatalogFactory.S3_ACCESS_KEY.key()).isEqualTo("s3-access-key");
+    assertThat(LanceCatalogFactory.S3_SECRET_KEY.key()).isEqualTo("s3-secret-key");
+    assertThat(LanceCatalogFactory.S3_REGION.key()).isEqualTo("s3-region");
+    assertThat(LanceCatalogFactory.S3_ENDPOINT.key()).isEqualTo("s3-endpoint");
+    assertThat(LanceCatalogFactory.S3_VIRTUAL_HOSTED_STYLE.key())
+        .isEqualTo("s3-virtual-hosted-style");
+    assertThat(LanceCatalogFactory.S3_ALLOW_HTTP.key()).isEqualTo("s3-allow-http");
 
-        assertThat(optionalOptionKeys).contains(
-                "read.batch-size",
-                "read.columns",
-                "read.filter",
-                "write.batch-size",
-                "write.mode",
-                "write.max-rows-per-file",
-                "index.type",
-                "index.column",
-                "vector.column",
-                "vector.metric"
-        );
-    }
+    // Default values
+    assertThat(LanceCatalogFactory.S3_VIRTUAL_HOSTED_STYLE.defaultValue()).isTrue();
+    assertThat(LanceCatalogFactory.S3_ALLOW_HTTP.defaultValue()).isFalse();
+  }
 
-    @Test
-    @DisplayName("Test LanceDynamicTableSource creation")
-    void testDynamicTableSourceCreation() {
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .readBatchSize(512)
-                .build();
+  @Test
+  @DisplayName("Test LanceCatalog S3 remote storage detection")
+  void testLanceCatalogRemoteStorageDetection() {
+    // S3 path should be identified as remote storage
+    LanceCatalog s3Catalog = new LanceCatalog("test", "default", "s3://bucket/path");
+    assertThat(s3Catalog.isRemoteStorage()).isTrue();
 
-        List<RowType.RowField> fields = new ArrayList<>();
-        fields.add(new RowType.RowField("id", new BigIntType()));
-        fields.add(new RowType.RowField("content", new VarCharType()));
-        fields.add(new RowType.RowField("embedding", new ArrayType(new FloatType())));
-        RowType rowType = new RowType(fields);
+    // S3A path
+    LanceCatalog s3aCatalog = new LanceCatalog("test", "default", "s3a://bucket/path");
+    assertThat(s3aCatalog.isRemoteStorage()).isTrue();
 
-        DataType dataType = DataTypes.ROW(
-                DataTypes.FIELD("id", DataTypes.BIGINT()),
-                DataTypes.FIELD("content", DataTypes.STRING()),
-                DataTypes.FIELD("embedding", DataTypes.ARRAY(DataTypes.FLOAT()))
-        );
+    // GCS path
+    LanceCatalog gcsCatalog = new LanceCatalog("test", "default", "gs://bucket/path");
+    assertThat(gcsCatalog.isRemoteStorage()).isTrue();
 
-        LanceDynamicTableSource source = new LanceDynamicTableSource(options, dataType);
+    // Azure path
+    LanceCatalog azCatalog = new LanceCatalog("test", "default", "az://container/path");
+    assertThat(azCatalog.isRemoteStorage()).isTrue();
 
-        assertThat(source.getOptions()).isEqualTo(options);
-        assertThat(source.getPhysicalDataType()).isEqualTo(dataType);
-        assertThat(source.asSummaryString()).isEqualTo("Lance Table Source");
-    }
+    // Local path should be identified as local storage
+    LanceCatalog localCatalog = new LanceCatalog("test", "default", warehousePath);
+    assertThat(localCatalog.isRemoteStorage()).isFalse();
+  }
 
-    @Test
-    @DisplayName("Test LanceDynamicTableSink creation")
-    void testDynamicTableSinkCreation() {
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .writeBatchSize(256)
-                .writeMode(LanceOptions.WriteMode.APPEND)
-                .build();
+  @Test
+  @DisplayName("Test LanceCatalog construction with storage options")
+  void testLanceCatalogWithStorageOptions() {
+    Map<String, String> storageOptions = new HashMap<>();
+    storageOptions.put("aws_access_key_id", "test-key");
+    storageOptions.put("aws_secret_access_key", "test-secret");
+    storageOptions.put("aws_region", "us-east-1");
 
-        DataType dataType = DataTypes.ROW(
-                DataTypes.FIELD("id", DataTypes.BIGINT()),
-                DataTypes.FIELD("content", DataTypes.STRING()),
-                DataTypes.FIELD("embedding", DataTypes.ARRAY(DataTypes.FLOAT()))
-        );
+    LanceCatalog catalog =
+        new LanceCatalog("test_catalog", "default", "s3://bucket/warehouse", storageOptions);
 
-        LanceDynamicTableSink sink = new LanceDynamicTableSink(options, dataType);
+    assertThat(catalog.getStorageOptions()).containsEntry("aws_access_key_id", "test-key");
+    assertThat(catalog.getStorageOptions()).containsEntry("aws_secret_access_key", "test-secret");
+    assertThat(catalog.getStorageOptions()).containsEntry("aws_region", "us-east-1");
+  }
 
-        assertThat(sink.getOptions()).isEqualTo(options);
-        assertThat(sink.getPhysicalDataType()).isEqualTo(dataType);
-        assertThat(sink.asSummaryString()).isEqualTo("Lance Table Sink");
-    }
-
-    @Test
-    @DisplayName("Test LanceDynamicTableSource copy")
-    void testDynamicTableSourceCopy() {
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .build();
-
-        DataType dataType = DataTypes.ROW(
-                DataTypes.FIELD("id", DataTypes.BIGINT())
-        );
-
-        LanceDynamicTableSource source = new LanceDynamicTableSource(options, dataType);
-        LanceDynamicTableSource copiedSource = (LanceDynamicTableSource) source.copy();
-
-        assertThat(copiedSource).isNotSameAs(source);
-        assertThat(copiedSource.getOptions()).isEqualTo(source.getOptions());
-    }
-
-    @Test
-    @DisplayName("Test LanceDynamicTableSink copy")
-    void testDynamicTableSinkCopy() {
-        LanceOptions options = LanceOptions.builder()
-                .path(datasetPath)
-                .build();
-
-        DataType dataType = DataTypes.ROW(
-                DataTypes.FIELD("id", DataTypes.BIGINT())
-        );
-
-        LanceDynamicTableSink sink = new LanceDynamicTableSink(options, dataType);
-        LanceDynamicTableSink copiedSink = (LanceDynamicTableSink) sink.copy();
-
-        assertThat(copiedSink).isNotSameAs(sink);
-        assertThat(copiedSink.getOptions()).isEqualTo(sink.getOptions());
-    }
-
-    @Test
-    @DisplayName("Test LanceCatalogFactory identifier")
-    void testCatalogFactoryIdentifier() {
-        LanceCatalogFactory factory = new LanceCatalogFactory();
-        assertThat(factory.factoryIdentifier()).isEqualTo("lance");
-    }
-
-    @Test
-    @DisplayName("Test LanceCatalogFactory required options")
-    void testCatalogRequiredOptions() {
-        LanceCatalogFactory factory = new LanceCatalogFactory();
-        Set<String> requiredOptionKeys = new HashSet<>();
-        factory.requiredOptions().forEach(opt -> requiredOptionKeys.add(opt.key()));
-
-        assertThat(requiredOptionKeys).contains("warehouse");
-    }
-
-    @Test
-    @DisplayName("Test LanceCatalogFactory optional options")
-    void testCatalogOptionalOptions() {
-        LanceCatalogFactory factory = new LanceCatalogFactory();
-        Set<String> optionalOptionKeys = new HashSet<>();
-        factory.optionalOptions().forEach(opt -> optionalOptionKeys.add(opt.key()));
-
-        assertThat(optionalOptionKeys).contains("default-database");
-    }
-
-    @Test
-    @DisplayName("Test LanceCatalog creation and basic operations")
-    void testLanceCatalogBasicOperations() throws Exception {
-        LanceCatalog catalog = new LanceCatalog("test_catalog", "default", warehousePath);
-
-        try {
-            catalog.open();
-
-            // Verify default database exists
-            assertThat(catalog.databaseExists("default")).isTrue();
-
-            // List databases
-            List<String> databases = catalog.listDatabases();
-            assertThat(databases).contains("default");
-
-            // Create new database
-            catalog.createDatabase("test_db", null, false);
-            assertThat(catalog.databaseExists("test_db")).isTrue();
-
-            // List tables (empty)
-            List<String> tables = catalog.listTables("test_db");
-            assertThat(tables).isEmpty();
-
-            // Drop database
-            catalog.dropDatabase("test_db", false, true);
-            assertThat(catalog.databaseExists("test_db")).isFalse();
-
-        } finally {
-            catalog.close();
-        }
-    }
-
-    @Test
-    @DisplayName("Test LanceCatalog warehouse path")
-    void testLanceCatalogWarehouse() throws Exception {
-        LanceCatalog catalog = new LanceCatalog("test", "default", warehousePath);
-
-        try {
-            catalog.open();
-            assertThat(catalog.getWarehouse()).isEqualTo(warehousePath);
-        } finally {
-            catalog.close();
-        }
-    }
-
-    @Test
-    @DisplayName("Test configuration options definition")
-    void testConfigOptions() {
-        assertThat(LanceDynamicTableFactory.PATH.key()).isEqualTo("path");
-        assertThat(LanceDynamicTableFactory.READ_BATCH_SIZE.key()).isEqualTo("read.batch-size");
-        assertThat(LanceDynamicTableFactory.READ_BATCH_SIZE.defaultValue()).isEqualTo(1024);
-        assertThat(LanceDynamicTableFactory.WRITE_BATCH_SIZE.key()).isEqualTo("write.batch-size");
-        assertThat(LanceDynamicTableFactory.WRITE_MODE.key()).isEqualTo("write.mode");
-        assertThat(LanceDynamicTableFactory.WRITE_MODE.defaultValue()).isEqualTo("append");
-        assertThat(LanceDynamicTableFactory.INDEX_TYPE.key()).isEqualTo("index.type");
-        assertThat(LanceDynamicTableFactory.INDEX_TYPE.defaultValue()).isEqualTo("IVF_PQ");
-        assertThat(LanceDynamicTableFactory.VECTOR_METRIC.key()).isEqualTo("vector.metric");
-        assertThat(LanceDynamicTableFactory.VECTOR_METRIC.defaultValue()).isEqualTo("L2");
-    }
-
-    @Test
-    @DisplayName("Test Catalog configuration options definition")
-    void testCatalogConfigOptions() {
-        assertThat(LanceCatalogFactory.WAREHOUSE.key()).isEqualTo("warehouse");
-        assertThat(LanceCatalogFactory.DEFAULT_DATABASE.key()).isEqualTo("default-database");
-        assertThat(LanceCatalogFactory.DEFAULT_DATABASE.defaultValue()).isEqualTo("default");
-    }
-
-    @Test
-    @DisplayName("Test S3 Catalog configuration options definition")
-    void testS3CatalogConfigOptions() {
-        // S3 configuration options
-        assertThat(LanceCatalogFactory.S3_ACCESS_KEY.key()).isEqualTo("s3-access-key");
-        assertThat(LanceCatalogFactory.S3_SECRET_KEY.key()).isEqualTo("s3-secret-key");
-        assertThat(LanceCatalogFactory.S3_REGION.key()).isEqualTo("s3-region");
-        assertThat(LanceCatalogFactory.S3_ENDPOINT.key()).isEqualTo("s3-endpoint");
-        assertThat(LanceCatalogFactory.S3_VIRTUAL_HOSTED_STYLE.key()).isEqualTo("s3-virtual-hosted-style");
-        assertThat(LanceCatalogFactory.S3_ALLOW_HTTP.key()).isEqualTo("s3-allow-http");
-
-        // Default values
-        assertThat(LanceCatalogFactory.S3_VIRTUAL_HOSTED_STYLE.defaultValue()).isTrue();
-        assertThat(LanceCatalogFactory.S3_ALLOW_HTTP.defaultValue()).isFalse();
-    }
-
-    @Test
-    @DisplayName("Test LanceCatalog S3 remote storage detection")
-    void testLanceCatalogRemoteStorageDetection() {
-        // S3 path should be identified as remote storage
-        LanceCatalog s3Catalog = new LanceCatalog("test", "default", "s3://bucket/path");
-        assertThat(s3Catalog.isRemoteStorage()).isTrue();
-
-        // S3A path
-        LanceCatalog s3aCatalog = new LanceCatalog("test", "default", "s3a://bucket/path");
-        assertThat(s3aCatalog.isRemoteStorage()).isTrue();
-
-        // GCS path
-        LanceCatalog gcsCatalog = new LanceCatalog("test", "default", "gs://bucket/path");
-        assertThat(gcsCatalog.isRemoteStorage()).isTrue();
-
-        // Azure path
-        LanceCatalog azCatalog = new LanceCatalog("test", "default", "az://container/path");
-        assertThat(azCatalog.isRemoteStorage()).isTrue();
-
-        // Local path should be identified as local storage
-        LanceCatalog localCatalog = new LanceCatalog("test", "default", warehousePath);
-        assertThat(localCatalog.isRemoteStorage()).isFalse();
-    }
-
-    @Test
-    @DisplayName("Test LanceCatalog construction with storage options")
-    void testLanceCatalogWithStorageOptions() {
-        Map<String, String> storageOptions = new HashMap<>();
-        storageOptions.put("aws_access_key_id", "test-key");
-        storageOptions.put("aws_secret_access_key", "test-secret");
-        storageOptions.put("aws_region", "us-east-1");
-
-        LanceCatalog catalog = new LanceCatalog(
-                "test_catalog",
-                "default",
-                "s3://bucket/warehouse",
-                storageOptions
-        );
-
-        assertThat(catalog.getStorageOptions()).containsEntry("aws_access_key_id", "test-key");
-        assertThat(catalog.getStorageOptions()).containsEntry("aws_secret_access_key", "test-secret");
-        assertThat(catalog.getStorageOptions()).containsEntry("aws_region", "us-east-1");
-    }
-
-    @Test
-    @DisplayName("Test vector search UDF configuration")
-    void testVectorSearchFunctionConfiguration() {
-        LanceVectorSearchFunction function = new LanceVectorSearchFunction();
-        assertThat(function).isNotNull();
-    }
+  @Test
+  @DisplayName("Test vector search UDF configuration")
+  void testVectorSearchFunctionConfiguration() {
+    LanceVectorSearchFunction function = new LanceVectorSearchFunction();
+    assertThat(function).isNotNull();
+  }
 }


### PR DESCRIPTION
- Based on the trino-lance plugin, the source and sink APIs of Flink-lance have been refactored.

- code architecture diagram
<img width="1391" height="674" alt="Clipboard_Screenshot_1770775901" src="https://github.com/user-attachments/assets/6718d1ba-fbe9-4107-aa45-60d280513782" />

- Implementation details

  - Migrate Source from RichParallelSourceFunction to Source V2 API (FLIP-27)
    - Add LanceSource, LanceSourceReader, LanceSplitEnumerator
    - Add LanceSourceSplit, LanceEnumeratorState with serializers
    - Support checkpoint/recovery, parallel split assignment
    - Update LanceDynamicTableSource to use SourceProvider
  
  - Migrate Sink from RichSinkFunction to Sink V2 API (FLIP-143)
    - Add LanceSink, LanceSinkWriter
    - Support APPEND and OVERWRITE write modes
    - Support checkpoint flush and auto batch flush
    - Update LanceDynamicTableSink to use SinkV2Provider
    - Fix Append mode missing read_version parameter bug
  
  - Add comprehensive unit tests
    - LanceSourceV2Test: 23 tests covering Split, Serializer, State, Source
    - LanceSinkV2Test: 13 tests covering Writer, write modes, checkpoint