### PR TITLE
chore(deps): bump 7 low-risk build-tooling dependencies

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -47,7 +47,7 @@ jobs:
     name: Verify PR title / description conforms to semantic-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
       # These rules are disabled because Github will always ensure there
@@ -70,7 +70,7 @@ jobs:
 
             ${{ github.event.pull_request.body }}
       - if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const message = `**ACTION NEEDED**

--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+                <version>3.15.0</version>
                 <configuration>
                     <source>${maven.compiler.source}</source>
                     <target>${maven.compiler.target}</target>
@@ -242,7 +242,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -289,7 +289,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.5.0</version>
                 <configuration>
                     <archive>
                         <manifest>
@@ -304,7 +304,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -329,7 +329,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.10</version>
+                <version>0.8.14</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
## Summary

Bumps 7 low-risk dependencies in a single PR, consolidating the equivalent Dependabot suggestions (#27, #28, #30, #33, #35, #36, #37). All upgrades are either patch/minor bumps of build-time tooling or GitHub Actions versions — no production runtime code or APIs are affected.

## Changes

### GitHub Actions (`.github/workflows/pr-title.yml`)

| Action | From | To | Related |
|---|---|---|---|
| `actions/github-script` | `v7` | `v9` | #27 |
| `actions/setup-node` | `v4` | `v6` | #28 |

### Maven build plugins (`pom.xml`)

| Plugin | From | To | Related |
|---|---|---|---|
| `maven-compiler-plugin` | `3.11.0` | `3.15.0` | #30 |
| `maven-jar-plugin` | `3.3.0` | `3.5.0` | #33 |
| `maven-source-plugin` | `3.3.0` | `3.4.0` | #35 |
| `maven-shade-plugin` | `3.5.0` | `3.6.2` | #36 |
| `jacoco-maven-plugin` | `0.8.10` | `0.8.14` | #37 |

## Why one combined PR?

Each of the 7 individual Dependabot PRs touches a single line of build-tool config. Reviewing/merging them one by one creates unnecessary noise. They are independent, all build-time only, and have no inter-dependency, so combining is safe and saves reviewer cycles.

## Risk

**Very low.** None of these dependencies appear in the production classpath:
- All Maven plugins only run during `mvn` build/test phases.
- GitHub Actions only run in CI.

No source code changes were required.

## Verification

```
$ mvn -DskipTests compile
...
[INFO] --- compiler:3.15.0:compile (default-compile) @ flink-connector-lance ---
[INFO] argLine set to -javaagent:.../org.jacoco.agent-0.8.14-runtime.jar=...
[INFO] BUILD SUCCESS
```

Confirms `maven-compiler-plugin 3.15.0` and `jacoco-maven-plugin 0.8.14` are picked up correctly.

## Out of scope (intentionally NOT included)

The following Dependabot PRs are **not** part of this batch and will be handled separately due to higher risk:

- #29 JUnit 5.9.3 → 6.0.3 (requires Java 17+)
- #31 Arrow 14.0.0 → 19.0.0 (5 major versions, conflicts with #20)
- #32 Mockito 5.3.1 → 5.23.0 (medium risk)
- #34 log4j 2.20.0 → 2.26.0 (medium risk)
- #38 Flink 1.16.1 → 2.2.0 (cross-major, breaks current Source/Sink API usage)

## Closes

Closes #27, #28, #30, #33, #35, #36, #37
