### PR TITLE
chore: set version to 0.1.0 for first release

### DIFF
--- a/lance-flink-1.18/pom.xml
+++ b/lance-flink-1.18/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>lance-flink-root</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/lance-flink-1.19/pom.xml
+++ b/lance-flink-1.19/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>lance-flink-root</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/lance-flink-1.20/pom.xml
+++ b/lance-flink-1.20/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.apache.flink</groupId>
         <artifactId>lance-flink-root</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
+        <version>0.1.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.apache.flink</groupId>
     <artifactId>lance-flink-root</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>0.1.0</version>
     <packaging>pom</packaging>
 
     <name>Lance Flink Connector</name>
@@ -19,7 +19,7 @@
         <maven.compiler.target>11</maven.compiler.target>
 
         <!-- Lance Flink Connector 版本 -->
-        <lance-flink.version>1.0.0-SNAPSHOT</lance-flink.version>
+        <lance-flink.version>0.1.0</lance-flink.version>
 
         <!-- Lance 依赖版本 -->
         <lance.version>7.0.0</lance.version>


### PR DESCRIPTION
Set version from `1.0.0-SNAPSHOT` to `0.1.0` for the first official release of lance-flink.