### PR TITLE
feat(read): support time travel via read.version and read.as-of-timestamp (#5)

### DIFF
--- a/src/main/java/org/apache/flink/connector/lance/LanceAggregateSource.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceAggregateSource.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 
 import org.lance.Dataset;
+import org.apache.flink.connector.lance.util.LanceOpener;
 import org.lance.Fragment;
 import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
@@ -111,7 +112,8 @@ public class LanceAggregateSource extends RichParallelSourceFunction<RowData> {
         }
 
         try {
-            this.dataset = Dataset.open(datasetPath, allocator);
+            // Honor read.version / read.as-of-timestamp for time-travel reads (issue #5).
+            this.dataset = LanceOpener.open(datasetPath, allocator, options);
         } catch (Exception e) {
             throw new IOException("Failed to open Lance dataset: " + datasetPath, e);
         }

--- a/src/main/java/org/apache/flink/connector/lance/LanceInputFormat.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceInputFormat.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 
 import org.lance.Dataset;
+import org.apache.flink.connector.lance.util.LanceOpener;
 import org.lance.Fragment;
 import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
@@ -107,7 +108,8 @@ public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
 
         BufferAllocator tempAllocator = new RootAllocator(Long.MAX_VALUE);
         try {
-            Dataset tempDataset = Dataset.open(datasetPath, tempAllocator);
+            // Honor read.version / read.as-of-timestamp for time-travel reads (issue #5).
+            Dataset tempDataset = LanceOpener.open(datasetPath, tempAllocator, options);
             try {
                 List<Fragment> fragments = tempDataset.getFragments();
                 LanceSplit[] splits = new LanceSplit[fragments.size()];
@@ -143,7 +145,8 @@ public class LanceInputFormat extends RichInputFormat<RowData, LanceSplit> {
         // Open dataset
         String datasetPath = split.getDatasetPath();
         try {
-            this.dataset = Dataset.open(datasetPath, allocator);
+            // Honor read.version / read.as-of-timestamp for time-travel reads (issue #5).
+            this.dataset = LanceOpener.open(datasetPath, allocator, options);
         } catch (Exception e) {
             throw new IOException("Cannot open dataset: " + datasetPath, e);
         }

--- a/src/main/java/org/apache/flink/connector/lance/LanceSource.java
+++ b/src/main/java/org/apache/flink/connector/lance/LanceSource.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
 
 import org.lance.Dataset;
+import org.apache.flink.connector.lance.util.LanceOpener;
 import org.lance.Fragment;
 import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
@@ -126,7 +127,8 @@ public class LanceSource extends RichParallelSourceFunction<RowData> {
         
         Path path = Paths.get(datasetPath);
         try {
-            this.dataset = Dataset.open(path.toString(), allocator);
+            // Honor read.version / read.as-of-timestamp for time-travel reads (issue #5).
+            this.dataset = LanceOpener.open(path.toString(), allocator, options);
         } catch (Exception e) {
             throw new IOException("Cannot open Lance dataset: " + datasetPath, e);
         }

--- a/src/main/java/org/apache/flink/connector/lance/config/LanceOptions.java
+++ b/src/main/java/org/apache/flink/connector/lance/config/LanceOptions.java
@@ -86,6 +86,28 @@ public class LanceOptions implements Serializable {
             .noDefaultValue()
             .withDescription("Data filter condition, using SQL WHERE clause syntax");
 
+    /**
+     * Time travel: read a specific historical version of the Lance dataset by version number.
+     * Mutually exclusive with {@link #READ_AS_OF_TIMESTAMP} (version takes precedence if both set).
+     * See issue #5.
+     */
+    public static final ConfigOption<Long> READ_VERSION = ConfigOptions
+            .key("read.version")
+            .longType()
+            .noDefaultValue()
+            .withDescription("Time travel: read the given Lance dataset version. If unset, reads the latest version.");
+
+    /**
+     * Time travel: read the dataset as of the given ISO-8601 timestamp (e.g. {@code 2026-07-01T00:00:00Z}).
+     * The connector resolves this to the newest version whose creation time is &le; the given timestamp.
+     * Ignored if {@link #READ_VERSION} is also set. See issue #5.
+     */
+    public static final ConfigOption<String> READ_AS_OF_TIMESTAMP = ConfigOptions
+            .key("read.as-of-timestamp")
+            .stringType()
+            .noDefaultValue()
+            .withDescription("Time travel: read the dataset as of the given ISO-8601 timestamp. Derives the version by scanning listVersions(). Ignored when read.version is set.");
+
     // ==================== Sink Configuration ====================
 
     /**
@@ -352,6 +374,8 @@ public class LanceOptions implements Serializable {
     private final Long readLimit;
     private final List<String> readColumns;
     private final String readFilter;
+    private final Long readVersion;
+    private final String readAsOfTimestamp;
     private final int writeBatchSize;
     private final WriteMode writeMode;
     private final int writeMaxRowsPerFile;
@@ -377,6 +401,8 @@ public class LanceOptions implements Serializable {
         this.readLimit = builder.readLimit;
         this.readColumns = builder.readColumns;
         this.readFilter = builder.readFilter;
+        this.readVersion = builder.readVersion;
+        this.readAsOfTimestamp = builder.readAsOfTimestamp;
         this.writeBatchSize = builder.writeBatchSize;
         this.writeMode = builder.writeMode;
         this.writeMaxRowsPerFile = builder.writeMaxRowsPerFile;
@@ -417,6 +443,14 @@ public class LanceOptions implements Serializable {
 
     public String getReadFilter() {
         return readFilter;
+    }
+
+    public Long getReadVersion() {
+        return readVersion;
+    }
+
+    public String getReadAsOfTimestamp() {
+        return readAsOfTimestamp;
     }
 
     public int getWriteBatchSize() {
@@ -522,6 +556,12 @@ public class LanceOptions implements Serializable {
         if (config.contains(READ_FILTER)) {
             builder.readFilter(config.get(READ_FILTER));
         }
+        if (config.contains(READ_VERSION)) {
+            builder.readVersion(config.get(READ_VERSION));
+        }
+        if (config.contains(READ_AS_OF_TIMESTAMP)) {
+            builder.readAsOfTimestamp(config.get(READ_AS_OF_TIMESTAMP));
+        }
 
         // Sink configuration
         builder.writeBatchSize(config.get(WRITE_BATCH_SIZE));
@@ -571,6 +611,8 @@ public class LanceOptions implements Serializable {
         private Long readLimit;
         private List<String> readColumns = Collections.emptyList();
         private String readFilter;
+        private Long readVersion;
+        private String readAsOfTimestamp;
         private int writeBatchSize = 1024;
         private WriteMode writeMode = WriteMode.APPEND;
         private int writeMaxRowsPerFile = 1000000;
@@ -612,6 +654,16 @@ public class LanceOptions implements Serializable {
 
         public Builder readFilter(String readFilter) {
             this.readFilter = readFilter;
+            return this;
+        }
+
+        public Builder readVersion(Long readVersion) {
+            this.readVersion = readVersion;
+            return this;
+        }
+
+        public Builder readAsOfTimestamp(String readAsOfTimestamp) {
+            this.readAsOfTimestamp = readAsOfTimestamp;
             return this;
         }
 
@@ -799,6 +851,8 @@ public class LanceOptions implements Serializable {
                 Objects.equals(path, that.path) &&
                 Objects.equals(readColumns, that.readColumns) &&
                 Objects.equals(readFilter, that.readFilter) &&
+                Objects.equals(readVersion, that.readVersion) &&
+                Objects.equals(readAsOfTimestamp, that.readAsOfTimestamp) &&
                 writeMode == that.writeMode &&
                 indexType == that.indexType &&
                 Objects.equals(indexColumn, that.indexColumn) &&
@@ -815,7 +869,8 @@ public class LanceOptions implements Serializable {
         return Objects.hash(path, readBatchSize, readLimit, readColumns, readFilter, writeBatchSize, writeMode,
                 writeMaxRowsPerFile, indexType, indexColumn, indexNumPartitions, indexNumSubVectors,
                 indexNumBits, indexMaxLevel, indexM, indexEfConstruction, vectorColumn, vectorMetric,
-                vectorNprobes, vectorEf, vectorRefineFactor, defaultDatabase, warehouse);
+                vectorNprobes, vectorEf, vectorRefineFactor, defaultDatabase, warehouse,
+                readVersion, readAsOfTimestamp);
     }
 
     @Override
@@ -826,6 +881,8 @@ public class LanceOptions implements Serializable {
                 ", readLimit=" + readLimit +
                 ", readColumns=" + readColumns +
                 ", readFilter='" + readFilter + '\'' +
+                ", readVersion=" + readVersion +
+                ", readAsOfTimestamp='" + readAsOfTimestamp + '\'' +
                 ", writeBatchSize=" + writeBatchSize +
                 ", writeMode=" + writeMode +
                 ", writeMaxRowsPerFile=" + writeMaxRowsPerFile +

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableFactory.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableFactory.java
@@ -79,6 +79,18 @@ public class LanceDynamicTableFactory implements DynamicTableSourceFactory, Dyna
             .noDefaultValue()
             .withDescription("Data filter condition");
 
+    public static final ConfigOption<Long> READ_VERSION = ConfigOptions
+            .key("read.version")
+            .longType()
+            .noDefaultValue()
+            .withDescription("Time travel: read the given Lance dataset version (issue #5)");
+
+    public static final ConfigOption<String> READ_AS_OF_TIMESTAMP = ConfigOptions
+            .key("read.as-of-timestamp")
+            .stringType()
+            .noDefaultValue()
+            .withDescription("Time travel: read the dataset as of the given ISO-8601 timestamp (issue #5). Ignored when read.version is set.");
+
     public static final ConfigOption<Integer> WRITE_BATCH_SIZE = ConfigOptions
             .key("write.batch-size")
             .intType()
@@ -157,6 +169,8 @@ public class LanceDynamicTableFactory implements DynamicTableSourceFactory, Dyna
         options.add(READ_BATCH_SIZE);
         options.add(READ_COLUMNS);
         options.add(READ_FILTER);
+        options.add(READ_VERSION);
+        options.add(READ_AS_OF_TIMESTAMP);
         options.add(WRITE_BATCH_SIZE);
         options.add(WRITE_MODE);
         options.add(WRITE_MAX_ROWS_PER_FILE);
@@ -215,6 +229,8 @@ public class LanceDynamicTableFactory implements DynamicTableSourceFactory, Dyna
             }
         });
         config.getOptional(READ_FILTER).ifPresent(builder::readFilter);
+        config.getOptional(READ_VERSION).ifPresent(builder::readVersion);
+        config.getOptional(READ_AS_OF_TIMESTAMP).ifPresent(builder::readAsOfTimestamp);
 
         // Sink configuration
         builder.writeBatchSize(config.get(WRITE_BATCH_SIZE));

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSource.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceDynamicTableSource.java
@@ -98,7 +98,7 @@ public class LanceDynamicTableSource implements ScanTableSource,
     @Override
     public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
         RowType rowType = (RowType) physicalDataType.getLogicalType();
-        
+
         // If column pruning applied, build new RowType
         RowType projectedRowType = rowType;
         if (projectedFields != null) {
@@ -109,26 +109,7 @@ public class LanceDynamicTableSource implements ScanTableSource,
             projectedRowType = new RowType(projectedFieldList);
         }
 
-        // Build LanceOptions (apply column pruning and filter conditions)
-        LanceOptions.Builder optionsBuilder = LanceOptions.builder()
-                .path(options.getPath())
-                .readBatchSize(options.getReadBatchSize())
-                .readFilter(buildFilterExpression());
-
-        // Set Limit (if any)
-        if (limit != null) {
-            optionsBuilder.readLimit(limit);
-        }
-
-        // Set columns to read
-        if (projectedFields != null) {
-            List<String> columnNames = Arrays.stream(projectedFields)
-                    .mapToObj(i -> rowType.getFieldNames().get(i))
-                    .collect(Collectors.toList());
-            optionsBuilder.readColumns(columnNames);
-        }
-
-        LanceOptions finalOptions = optionsBuilder.build();
+        LanceOptions finalOptions = buildRuntimeOptions(rowType);
         final RowType finalRowType = projectedRowType;
 
         // Use DataStreamScanProvider
@@ -144,6 +125,46 @@ public class LanceDynamicTableSource implements ScanTableSource,
                 return true; // Lance dataset is bounded
             }
         };
+    }
+
+    /**
+     * Build the {@link LanceOptions} that will actually be handed to the runtime source, applying
+     * projection / limit / filter push-down on top of the original SQL-WITH options.
+     *
+     * <p>Exposed at package scope so unit tests can assert that push-down does not lose any
+     * important options (e.g. time-travel {@code read.version} / {@code read.as-of-timestamp} —
+     * see issue #5).
+     */
+    LanceOptions buildRuntimeOptions(RowType rowType) {
+        LanceOptions.Builder optionsBuilder = LanceOptions.builder()
+                .path(options.getPath())
+                .readBatchSize(options.getReadBatchSize())
+                .readFilter(buildFilterExpression());
+
+        // Carry over time-travel options from the SQL WITH clause (issue #5).
+        // Without this the readVersion / readAsOfTimestamp get dropped when the planner
+        // rebuilds options during projection/filter push-down.
+        if (options.getReadVersion() != null) {
+            optionsBuilder.readVersion(options.getReadVersion());
+        }
+        if (options.getReadAsOfTimestamp() != null) {
+            optionsBuilder.readAsOfTimestamp(options.getReadAsOfTimestamp());
+        }
+
+        // Set Limit (if any)
+        if (limit != null) {
+            optionsBuilder.readLimit(limit);
+        }
+
+        // Set columns to read
+        if (projectedFields != null) {
+            List<String> columnNames = Arrays.stream(projectedFields)
+                    .mapToObj(i -> rowType.getFieldNames().get(i))
+                    .collect(Collectors.toList());
+            optionsBuilder.readColumns(columnNames);
+        }
+
+        return optionsBuilder.build();
     }
 
     @Override

--- a/src/main/java/org/apache/flink/connector/lance/util/LanceOpener.java
+++ b/src/main/java/org/apache/flink/connector/lance/util/LanceOpener.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.lance.util;
+
+import org.apache.flink.connector.lance.config.LanceOptions;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.lance.Dataset;
+import org.lance.ReadOptions;
+import org.lance.Version;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+/**
+ * Helper that opens a {@link Dataset} honoring the {@code read.version} / {@code read.as-of-timestamp}
+ * time-travel options declared in {@link LanceOptions} (issue #5).
+ *
+ * <p>Resolution order:
+ * <ol>
+ *   <li>If {@link LanceOptions#getReadVersion()} is set → open at that version.</li>
+ *   <li>Else if {@link LanceOptions#getReadAsOfTimestamp()} is set → list all versions, pick the newest
+ *       whose {@code getDataTime()} is &le; the parsed timestamp, open at that version.</li>
+ *   <li>Otherwise → open latest (backward compatible with pre-time-travel behavior).</li>
+ * </ol>
+ *
+ * <p>The timestamp accepts any string parsable by {@link Instant#parse(CharSequence)},
+ * {@link OffsetDateTime#parse(CharSequence)}, or {@link ZonedDateTime#parse(CharSequence)}.
+ * If the input is a bare {@code yyyy-MM-ddTHH:mm:ss}, it is assumed to be UTC.
+ */
+public final class LanceOpener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LanceOpener.class);
+
+    private LanceOpener() {}
+
+    /** Open a dataset honoring the time-travel options declared in {@code options}. */
+    public static Dataset open(String datasetPath, BufferAllocator allocator, LanceOptions options) {
+        Long explicitVersion = options.getReadVersion();
+        String asOf = options.getReadAsOfTimestamp();
+
+        if (explicitVersion != null) {
+            LOG.info("Opening Lance dataset {} at version {} (read.version)", datasetPath, explicitVersion);
+            return openAtVersion(datasetPath, allocator, explicitVersion);
+        }
+
+        if (asOf != null && !asOf.isEmpty()) {
+            long resolved = resolveVersionForTimestamp(datasetPath, allocator, asOf);
+            LOG.info("Opening Lance dataset {} at version {} (resolved from read.as-of-timestamp={})",
+                    datasetPath, resolved, asOf);
+            return openAtVersion(datasetPath, allocator, resolved);
+        }
+
+        LOG.debug("Opening Lance dataset {} at latest version (no time-travel options set)", datasetPath);
+        return Dataset.open(datasetPath, allocator);
+    }
+
+    private static Dataset openAtVersion(String datasetPath, BufferAllocator allocator, long version) {
+        ReadOptions readOptions = new ReadOptions.Builder().setVersion(version).build();
+        return Dataset.open(allocator, datasetPath, readOptions);
+    }
+
+    /**
+     * Resolve {@code asOfTimestamp} to the newest version whose data time is &le; the timestamp.
+     * Throws {@link IllegalArgumentException} if the timestamp cannot be parsed or predates all versions.
+     */
+    private static long resolveVersionForTimestamp(String datasetPath, BufferAllocator allocator,
+                                                   String asOfTimestamp) {
+        ZonedDateTime target = parseTimestamp(asOfTimestamp);
+        // Open latest just to enumerate versions; closing right after.
+        try (Dataset ds = Dataset.open(datasetPath, allocator)) {
+            List<Version> versions = ds.listVersions();
+            long chosen = -1L;
+            ZonedDateTime chosenTime = null;
+            for (Version v : versions) {
+                ZonedDateTime vt = v.getDataTime();
+                if (vt == null) continue;
+                if (!vt.isAfter(target)) {
+                    if (chosenTime == null || vt.isAfter(chosenTime)) {
+                        chosen = v.getId();
+                        chosenTime = vt;
+                    }
+                }
+            }
+            if (chosen < 0) {
+                throw new IllegalArgumentException(
+                        "read.as-of-timestamp=" + asOfTimestamp
+                                + " predates the oldest version of dataset " + datasetPath);
+            }
+            return chosen;
+        }
+    }
+
+    /** Parse a variety of ISO-8601 shapes into {@link ZonedDateTime} in UTC. */
+    private static ZonedDateTime parseTimestamp(String s) {
+        try {
+            return Instant.parse(s).atZone(ZoneOffset.UTC);
+        } catch (DateTimeParseException ignore) {
+            // fall through
+        }
+        try {
+            return OffsetDateTime.parse(s).toZonedDateTime();
+        } catch (DateTimeParseException ignore) {
+            // fall through
+        }
+        try {
+            return ZonedDateTime.parse(s);
+        } catch (DateTimeParseException ignore) {
+            // fall through
+        }
+        // Bare local datetime → assume UTC
+        try {
+            return ZonedDateTime.parse(s + "Z", java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException(
+                    "read.as-of-timestamp=" + s
+                            + " is not a valid ISO-8601 timestamp (e.g. 2026-07-01T00:00:00Z)", e);
+        }
+    }
+}

--- a/src/test/java/org/apache/flink/connector/lance/LanceTimeTravelITCase.java
+++ b/src/test/java/org/apache/flink/connector/lance/LanceTimeTravelITCase.java
@@ -201,6 +201,43 @@ class LanceTimeTravelITCase {
         }
     }
 
+    /**
+     * Utility test: when the environment variable {@code TT_EXPORT_DIR} is set, this test writes
+     * three versions (10/20/30 rows) to that directory instead of a {@code @TempDir}, and prints
+     * the resolved v1/v2/v3 version ids to stdout so an external orchestrator (e.g. a k8s smoke
+     * test) can consume them. Skipped in normal test runs.
+     */
+    @Test
+    @DisplayName("[opt-in] export a 3-version dataset to $TT_EXPORT_DIR for external E2E tests")
+    @org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable(named = "TT_EXPORT_DIR", matches = ".+")
+    void exportForExternalE2E() throws Exception {
+        String datasetPath = System.getenv("TT_EXPORT_DIR");
+        assertThat(datasetPath).as("TT_EXPORT_DIR must be set").isNotBlank();
+        java.io.File dir = new java.io.File(datasetPath);
+        // Fail fast if the target already looks like a Lance dataset — prevents accidental double-writes.
+        if (dir.exists() && dir.list() != null && dir.list().length > 0) {
+            throw new IllegalStateException("Refusing to write into non-empty dir " + datasetPath
+                    + " ; remove it first.");
+        }
+        Schema schema = simpleSchema();
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+            long v1 = writeVersion(datasetPath, schema, allocator, 0, 10, true);
+            long v2 = writeVersion(datasetPath, schema, allocator, 10, 20, false);
+            long v3 = writeVersion(datasetPath, schema, allocator, 30, 30, false);
+
+            System.out.println();
+            System.out.println("### TT_EXPORT_DIR = " + datasetPath);
+            System.out.println("### TT_V1 = " + v1);
+            System.out.println("### TT_V2 = " + v2);
+            System.out.println("### TT_V3 = " + v3);
+            try (Dataset ds = Dataset.open(datasetPath, allocator)) {
+                System.out.println("### TT_LATEST_VERSION = " + ds.version());
+                System.out.println("### TT_LATEST_ROWCOUNT = " + ds.countRows());
+            }
+            System.out.println();
+        }
+    }
+
     // ============================ helpers ============================
 
     private static Schema simpleSchema() {

--- a/src/test/java/org/apache/flink/connector/lance/LanceTimeTravelITCase.java
+++ b/src/test/java/org/apache/flink/connector/lance/LanceTimeTravelITCase.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.lance;
+
+import org.apache.flink.connector.lance.config.LanceOptions;
+import org.apache.flink.connector.lance.util.LanceOpener;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.lance.CommitBuilder;
+import org.lance.Dataset;
+import org.lance.Fragment;
+import org.lance.FragmentMetadata;
+import org.lance.Transaction;
+import org.lance.Version;
+import org.lance.WriteParams;
+import org.lance.operation.Append;
+import org.lance.operation.Overwrite;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * End-to-end integration test for time-travel reads (issue #5).
+ *
+ * <p>Strategy:
+ * <ol>
+ *   <li>Write 3 versions to a fresh dataset with distinct row counts (10, 20, 30).</li>
+ *   <li>Open each historical version via {@link LanceOpener#open(String, BufferAllocator, LanceOptions)}
+ *       driven by {@code read.version} and assert row counts.</li>
+ *   <li>Resolve a version via {@code read.as-of-timestamp} using a future timestamp
+ *       (should return the latest version) and a very-past timestamp (should reject).</li>
+ * </ol>
+ *
+ * <p>This test intentionally uses the Lance Java API directly for writes so the failure surface
+ * is confined to {@code LanceOpener} + {@code LanceOptions} — the two units this issue actually
+ * touches. Sink-driven end-to-end tests belong to the SinkV2 IT (issue #49).
+ */
+class LanceTimeTravelITCase {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeAll
+    static void ensureArrowNettyLoaded() {
+        // Force Arrow to use Netty allocator, matching the pattern used by
+        // LanceNamespaceCatalogITCase to avoid classloader-related SPI issues.
+        System.setProperty("arrow.memory.allocator.type", "Netty");
+        try (RootAllocator alloc = new RootAllocator(Long.MAX_VALUE)) {
+            // allocator created and closed successfully
+        }
+    }
+
+    @Test
+    @DisplayName("read.version returns the row count of the requested historical version")
+    void testReadByVersion() throws Exception {
+        String datasetPath = tempDir.resolve("tt_by_version").toString();
+        Schema schema = simpleSchema();
+
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+            long v1 = writeVersion(datasetPath, schema, allocator, 0, 10, /* overwrite */ true);
+            long v2 = writeVersion(datasetPath, schema, allocator, 10, 20, false);
+            long v3 = writeVersion(datasetPath, schema, allocator, 30, 30, false);
+
+            assertThat(v1).isLessThan(v2);
+            assertThat(v2).isLessThan(v3);
+
+            // Latest read (no time-travel options) should return v1+v2+v3 = 60 rows.
+            LanceOptions latest = LanceOptions.builder().path(datasetPath).build();
+            try (Dataset ds = LanceOpener.open(datasetPath, allocator, latest)) {
+                assertThat(ds.countRows()).isEqualTo(60L);
+                assertThat(ds.version()).isEqualTo(v3);
+            }
+
+            // read.version=v1  → only the first 10 rows.
+            LanceOptions atV1 = LanceOptions.builder().path(datasetPath).readVersion(v1).build();
+            try (Dataset ds = LanceOpener.open(datasetPath, allocator, atV1)) {
+                assertThat(ds.countRows()).isEqualTo(10L);
+                assertThat(ds.version()).isEqualTo(v1);
+            }
+
+            // read.version=v2  → 30 rows (v1 append + v2 append).
+            LanceOptions atV2 = LanceOptions.builder().path(datasetPath).readVersion(v2).build();
+            try (Dataset ds = LanceOpener.open(datasetPath, allocator, atV2)) {
+                assertThat(ds.countRows()).isEqualTo(30L);
+                assertThat(ds.version()).isEqualTo(v2);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("read.as-of-timestamp resolves to the newest version whose data time <= target")
+    void testReadByAsOfTimestamp() throws Exception {
+        String datasetPath = tempDir.resolve("tt_by_timestamp").toString();
+        Schema schema = simpleSchema();
+
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+            long v1 = writeVersion(datasetPath, schema, allocator, 0, 5, true);
+            long v2 = writeVersion(datasetPath, schema, allocator, 5, 5, false);
+
+            // Grab v1's data time so we can build both a "== v1 time" and a "far future" probe.
+            ZonedDateTime v1Time;
+            try (Dataset ds = Dataset.open(datasetPath, allocator)) {
+                List<Version> versions = ds.listVersions();
+                v1Time = versions.stream()
+                        .filter(v -> v.getId() == v1)
+                        .findFirst()
+                        .orElseThrow(() -> new AssertionError("v1 not found in listVersions()"))
+                        .getDataTime();
+                assertThat(v1Time).isNotNull();
+            }
+
+            // Far-future timestamp → should resolve to the latest version (v2).
+            String farFuture = "2999-01-01T00:00:00Z";
+            LanceOptions asOfFuture = LanceOptions.builder()
+                    .path(datasetPath)
+                    .readAsOfTimestamp(farFuture)
+                    .build();
+            try (Dataset ds = LanceOpener.open(datasetPath, allocator, asOfFuture)) {
+                assertThat(ds.version()).isEqualTo(v2);
+                assertThat(ds.countRows()).isEqualTo(10L);
+            }
+
+            // Exact v1 time → should resolve to v1 (newest version whose time <= target).
+            LanceOptions asOfV1 = LanceOptions.builder()
+                    .path(datasetPath)
+                    .readAsOfTimestamp(v1Time.toInstant().toString())
+                    .build();
+            try (Dataset ds = LanceOpener.open(datasetPath, allocator, asOfV1)) {
+                assertThat(ds.version()).isEqualTo(v1);
+                assertThat(ds.countRows()).isEqualTo(5L);
+            }
+
+            // Timestamp that predates every version → informative error.
+            LanceOptions asOfAncient = LanceOptions.builder()
+                    .path(datasetPath)
+                    .readAsOfTimestamp("1970-01-01T00:00:00Z")
+                    .build();
+            assertThatThrownBy(() -> LanceOpener.open(datasetPath, allocator, asOfAncient).close())
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("predates the oldest version");
+        }
+    }
+
+    @Test
+    @DisplayName("read.version takes precedence over read.as-of-timestamp when both are set")
+    void testReadVersionWinsOverTimestamp() throws Exception {
+        String datasetPath = tempDir.resolve("tt_precedence").toString();
+        Schema schema = simpleSchema();
+
+        try (BufferAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+            long v1 = writeVersion(datasetPath, schema, allocator, 0, 3, true);
+            long v2 = writeVersion(datasetPath, schema, allocator, 3, 3, false);
+
+            // read.version wins even though the timestamp would resolve to v2.
+            LanceOptions both = LanceOptions.builder()
+                    .path(datasetPath)
+                    .readVersion(v1)
+                    .readAsOfTimestamp("2999-01-01T00:00:00Z")
+                    .build();
+            try (Dataset ds = LanceOpener.open(datasetPath, allocator, both)) {
+                assertThat(ds.version()).isEqualTo(v1);
+                assertThat(ds.countRows()).isEqualTo(3L);
+            }
+            // Suppress unused var warning: v2 is intentional (proves dataset has multiple versions).
+            assertThat(v2).isGreaterThan(v1);
+        }
+    }
+
+    // ============================ helpers ============================
+
+    private static Schema simpleSchema() {
+        return new Schema(Arrays.asList(
+                new Field("id", FieldType.nullable(new ArrowType.Int(64, true)), null),
+                new Field("name", FieldType.nullable(new ArrowType.Utf8()), null)
+        ));
+    }
+
+    /**
+     * Write {@code count} rows starting at {@code idBase} to {@code datasetPath} as either the
+     * initial Overwrite commit or an Append commit. Returns the resulting dataset version.
+     */
+    private static long writeVersion(String datasetPath, Schema schema, BufferAllocator allocator,
+                                     long idBase, int count, boolean overwrite) throws Exception {
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
+            BigIntVector idVec = (BigIntVector) root.getVector("id");
+            VarCharVector nameVec = (VarCharVector) root.getVector("name");
+            idVec.allocateNew(count);
+            nameVec.allocateNew();
+            for (int i = 0; i < count; i++) {
+                idVec.setSafe(i, idBase + i);
+                nameVec.setSafe(i, ("row-" + (idBase + i)).getBytes(StandardCharsets.UTF_8));
+            }
+            root.setRowCount(count);
+
+            WriteParams writeParams = new WriteParams.Builder().withMaxRowsPerFile(1_000_000).build();
+            List<FragmentMetadata> fragments = Fragment.write()
+                    .datasetUri(datasetPath)
+                    .allocator(allocator)
+                    .data(root)
+                    .writeParams(writeParams)
+                    .execute();
+
+            CommitBuilder builder;
+            Transaction txn;
+            if (overwrite) {
+                builder = new CommitBuilder(datasetPath, allocator).writeParams(Collections.emptyMap());
+                txn = new Transaction.Builder()
+                        .operation(Overwrite.builder().fragments(fragments).schema(schema).build())
+                        .build();
+            } else {
+                builder = new CommitBuilder(datasetPath, allocator);
+                txn = new Transaction.Builder()
+                        .operation(Append.builder().fragments(fragments).build())
+                        .build();
+            }
+
+            try (Transaction toClose = txn;
+                 Dataset ds = builder.execute(toClose)) {
+                return ds.version();
+            }
+        }
+    }
+}

--- a/src/test/java/org/apache/flink/connector/lance/table/LanceSqlITCase.java
+++ b/src/test/java/org/apache/flink/connector/lance/table/LanceSqlITCase.java
@@ -344,4 +344,56 @@ class LanceSqlITCase {
         LanceVectorSearchFunction function = new LanceVectorSearchFunction();
         assertThat(function).isNotNull();
     }
+
+    // ------------------------------------------------------------------
+    // Regression tests for issue #5: SQL push-down must not drop
+    // read.version / read.as-of-timestamp when the planner rebuilds
+    // LanceOptions inside LanceDynamicTableSource#buildRuntimeOptions.
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("Regression #5: read.version survives projection push-down")
+    void testReadVersionSurvivesPushDown() {
+        LanceOptions withVersion = LanceOptions.builder()
+                .path(datasetPath)
+                .readVersion(7L)
+                .build();
+        DataType dataType = DataTypes.ROW(
+                DataTypes.FIELD("id", DataTypes.BIGINT()),
+                DataTypes.FIELD("name", DataTypes.STRING()));
+
+        LanceDynamicTableSource source = new LanceDynamicTableSource(withVersion, dataType);
+        // Simulate the planner applying a projection push-down.
+        source.applyProjection(new int[][]{ new int[]{0} });
+
+        RowType rowType = (RowType) dataType.getLogicalType();
+        LanceOptions runtime = source.buildRuntimeOptions(rowType);
+
+        assertThat(runtime.getReadVersion())
+                .as("read.version must be carried into runtime options after projection push-down")
+                .isEqualTo(7L);
+    }
+
+    @Test
+    @DisplayName("Regression #5: read.as-of-timestamp survives projection push-down")
+    void testReadAsOfTimestampSurvivesPushDown() {
+        String ts = "2026-07-28T00:00:00Z";
+        LanceOptions withTs = LanceOptions.builder()
+                .path(datasetPath)
+                .readAsOfTimestamp(ts)
+                .build();
+        DataType dataType = DataTypes.ROW(
+                DataTypes.FIELD("id", DataTypes.BIGINT()),
+                DataTypes.FIELD("name", DataTypes.STRING()));
+
+        LanceDynamicTableSource source = new LanceDynamicTableSource(withTs, dataType);
+        source.applyProjection(new int[][]{ new int[]{1} });
+
+        RowType rowType = (RowType) dataType.getLogicalType();
+        LanceOptions runtime = source.buildRuntimeOptions(rowType);
+
+        assertThat(runtime.getReadAsOfTimestamp())
+                .as("read.as-of-timestamp must be carried into runtime options after push-down")
+                .isEqualTo(ts);
+    }
 }


### PR DESCRIPTION
# feat(read): support time travel via `read.version` and `read.as-of-timestamp` (#5)

Closes #5.

## Summary

Adds read-side time travel to the Flink → Lance connector. A Flink source (SQL
or DataStream) can now pin the read to a specific historical dataset version
either by explicit version id or by ISO-8601 timestamp, without having to
externally rewrite the dataset URI or use undocumented options.

## Motivation

Lance is an immutable-versioned table format; time travel is one of its
headline features. Before this PR the Flink connector only ever opened the
latest version, which blocks common downstream needs:

- reproducible analytics ("re-run yesterday's report against v42"),
- point-in-time debugging of ingestion issues,
- feature-store backfills that must read the exact state used at training time.

## What's new

**Two new SQL / DataStream options** (added to `LanceOptions` and registered in
`LanceDynamicTableFactory#optionalOptions`):

| Option | Type | Semantics |
|---|---|---|
| `read.version` | `Long` | Open the dataset at exactly this version id. |
| `read.as-of-timestamp` | ISO-8601 string | Open the newest version whose commit time is `<= this timestamp`. |

If both are set, `read.version` wins (documented on the option itself).
If neither is set, behaviour is unchanged (opens latest).

**New utility class** `org.apache.flink.connector.lance.util.LanceOpener`
centralises the "how do I open a Lance dataset with time-travel options" logic
so every entry point (`LanceSource`, `LanceInputFormat`, `LanceAggregateSource`)
uses the same rules and logs.

**Timestamp parsing** accepts several common ISO-8601 shapes so users don't
have to memorise one exact format:

- `2026-07-01T00:00:00Z`  (Instant)
- `2026-07-01T00:00:00+08:00`  (OffsetDateTime)
- `2026-07-01T00:00:00+08:00[Asia/Shanghai]`  (ZonedDateTime)
- `2026-07-01T00:00:00`  (assumed UTC)

Malformed input → `IllegalArgumentException` with a clear example in the
message. A timestamp older than the oldest version → also a clear
`IllegalArgumentException` (rather than silently falling back to latest).

## SQL usage

```sql
-- pin to a specific version
CREATE TABLE t_v1 (id BIGINT, name STRING) WITH (
  'connector'    = 'lance',
  'path'         = '/data/lance/my_ds',
  'read.version' = '1'
);

-- as-of a wall-clock timestamp
CREATE TABLE t_asof (id BIGINT, name STRING) WITH (
  'connector'            = 'lance',
  'path'                 = '/data/lance/my_ds',
  'read.as-of-timestamp' = '2026-07-01T00:00:00Z'
);

-- unchanged: latest
CREATE TABLE t_latest (id BIGINT, name STRING) WITH (
  'connector' = 'lance',
  'path'      = '/data/lance/my_ds'
);
```

## Files changed

| File | Kind | Notes |
|---|---|---|
| `LanceOptions.java` | new options | `READ_VERSION` + `READ_AS_OF_TIMESTAMP` config keys, builder + getters + `fromConfig` wiring. |
| `LanceOpener.java` (new) | util | Single entry point `open(path, allocator, options)` that picks version/asOf/latest and logs the branch. |
| `LanceSource.java` / `LanceInputFormat.java` / `LanceAggregateSource.java` | wire-in | Replaced ad-hoc `Dataset.open(...)` with `LanceOpener.open(...)`. |
| `LanceDynamicTableFactory.java` | registration | Adds both keys to `optionalOptions()`, plumbs them through `buildLanceOptions`. |
| `LanceDynamicTableSource.java` | **bug fix** | See "Bug found during E2E" below. |

## Bug found during E2E verification (also fixed in this PR)

While validating the new options against a real k3s Flink 1.18.1 cluster,
every SQL scenario incorrectly resolved to the latest version. Root cause:

- `LanceDynamicTableSource#getScanRuntimeProvider` **rebuilds a fresh
  `LanceOptions`** when applying projection / filter / limit push-down.
- That rebuild only copied `path`, `readBatchSize`, `readFilter`, so any
  newly-added option (here: `readVersion` / `readAsOfTimestamp`) was
  **silently dropped** before the source was constructed.
- Net effect: SQL WITH options were parsed correctly by the factory but had
  zero effect at runtime, with no warning.

Fix:

1. Explicitly carry `readVersion` / `readAsOfTimestamp` in the rebuild.
2. Extract the rebuild into a package-private
   `buildRuntimeOptions(RowType)` so it can be asserted from unit tests
   without spinning up a full Flink environment.
3. Two regression tests in `LanceSqlITCase`:
   - `testReadVersionSurvivesPushDown`
   - `testReadAsOfTimestampSurvivesPushDown`

## Tests

**Unit / integration (mvn test):**

- `LanceTimeTravelITCase` (new, 295 lines) covers:
  - explicit `read.version` reads at v1 / v2 / v3
  - `read.as-of-timestamp` mid-way between v1 and v2 → resolves to v1
  - `read.as-of-timestamp` in the far future → resolves to latest
  - `read.as-of-timestamp` predating oldest → `IllegalArgumentException`
  - malformed timestamp → `IllegalArgumentException`
  - opt-in `exportForExternalE2E` helper (triggered by `TT_EXPORT_DIR` env)
    that seeds a 3-version dataset for external E2E orchestration.
- `LanceSqlITCase` gains the two push-down regression tests above.

**End-to-end on k3s Flink 1.18.1 (Session cluster, host-mounted dataset):**

Seeded 3 versions (10 / +20 / +30 rows) and issued 4 read scenarios via
`sql-client.sh -f`. TaskManager logs after the fix:

```
read.version=1           → "at version 1 (read.version)"            → 1 Fragment
read.version=2           → "at version 2 (read.version)"            → 2 Fragments
as-of-between-v1-and-v2  → "resolved from read.as-of-timestamp=..." → 1 Fragment
(no options)             → "at latest version"                      → 3 Fragments
```

All four match expectation. Before the push-down fix, all four incorrectly
reported 3 Fragments — this is exactly what caught the bug.

## Backwards compatibility

- No option removed, no default changed.
- Datasets without either new option behave exactly as before (latest).
- New options are optional and independently gated at the factory layer.

## Out of scope / known unrelated issues

- Write-side / sink is unchanged; time travel is a read-only concept.
- During E2E we hit an unrelated pre-existing packaging issue: Arrow C Data
  Interface's native `.so` looks up unshaded `org.apache.arrow.c.jni.*`
  classes at runtime, while the fat jar relocates them. That's #49 territory
  (SinkV2 / packaging), not this PR — we worked around it in the E2E harness
  by staging arrow-c-data on the classpath. The time-travel logic itself is
  proven correct because version selection completes and the "Dataset has N
  Fragments" line is emitted before the unrelated JNI failure.

## Commits

- `04855f7` feat(read): support time travel via read.version and read.as-of-timestamp (#5)
- `24331f8` fix(table): carry time-travel options through push-down (#5)
