### PR TITLE
test: assert IN predicate falls back to Flink instead of disabling the case

### DIFF
--- a/src/test/java/org/apache/flink/connector/lance/table/LanceReadOptimizationsTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/table/LanceReadOptimizationsTest.java
@@ -30,7 +30,6 @@ import org.apache.flink.table.functions.BuiltInFunctionDefinition;
 import org.apache.flink.table.types.DataType;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -50,7 +49,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * <p>Test contents:
  * <ul>
  *   <li>Limit push-down</li>
- *   <li>Predicate push-down (basic comparison, IN, BETWEEN)</li>
+ *   <li>Predicate push-down (basic comparisons, logical operators, IS NULL, LIKE;
+ *       IN is not pushed down and BETWEEN is not implemented)</li>
  *   <li>Column pruning</li>
  * </ul>
  */
@@ -246,12 +246,7 @@ public class LanceReadOptimizationsTest {
         }
 
         @Test
-        @Disabled(
-                "IN predicate push-down is not yet implemented in the source; "
-                    + "convertToLanceFilter() returns null for BuiltInFunctionDefinitions.IN "
-                    + "(see LanceDynamicTableSource: \"IN (not supported yet)\"). "
-                    + "Re-enable once IN push-down lands.")
-        @DisplayName("Test IN predicate push-down")
+        @DisplayName("Test IN predicate is not pushed down (handled by Flink)")
         void testInPredicatePushDown() {
             LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
 
@@ -261,7 +256,7 @@ public class LanceReadOptimizationsTest {
             ValueLiteralExpression value1 = new ValueLiteralExpression("active");
             ValueLiteralExpression value2 = new ValueLiteralExpression("pending");
             ValueLiteralExpression value3 = new ValueLiteralExpression("completed");
-            
+
             CallExpression inExpr = CallExpression.permanent(
                     BuiltInFunctionDefinitions.IN,
                     Arrays.asList(fieldRef, value1, value2, value3),
@@ -270,7 +265,13 @@ public class LanceReadOptimizationsTest {
 
             SupportsFilterPushDown.Result result = source.applyFilters(Collections.singletonList(inExpr));
 
-            assertEquals(1, result.getAcceptedFilters().size(), "IN predicate should be accepted");
+            // IN push-down is not implemented yet: convertCallExpression() has no branch
+            // for BuiltInFunctionDefinitions.IN (see LanceDynamicTableSource, comment
+            // "IN (not supported yet)") and returns null, so applyFilters() leaves the
+            // predicate to Flink instead of pushing it down. Assert that fallback so the
+            // path stays covered; flip these expectations once IN push-down lands.
+            assertEquals(0, result.getAcceptedFilters().size(), "IN should not be pushed down yet");
+            assertEquals(1, result.getRemainingFilters().size(), "IN should be left for Flink to evaluate");
         }
 
         @Test


### PR DESCRIPTION
## What

Re-enables `LanceReadOptimizationsTest.testInPredicatePushDown`, which #55 disabled, by asserting what the connector actually does with an `IN` predicate today.

## Why

#55 needed a green pipeline, and this test was the one red case: it asserted that `IN` gets pushed down, but the source never implemented that. `convertCallExpression()` has no branch for `BuiltInFunctionDefinitions.IN`, so it returns `null` and `applyFilters()` routes the predicate into `remainingFilters`. The quickest way to get CI green was `@Disabled`, with re-working the test called out as a follow-up. This is that follow-up.

Disabling had a cost: `testInPredicatePushDown` was the only test touching `BuiltInFunctionDefinitions.IN`, so the `IN` path ended up with no coverage at all. Nothing would catch it if a later refactor made `IN` throw, or accepted it for push-down when the filter translation still can't express it.

## How

Assert the fallback rather than the unimplemented feature:

```java
assertEquals(0, result.getAcceptedFilters().size(), "IN should not be pushed down yet");
assertEquals(1, result.getRemainingFilters().size(), "IN should be left for Flink to evaluate");
```

CI stays green and the path stays under test. When `IN` push-down does land, these assertions turn red, which is the reminder to flip them back to `acceptedFilters == 1`. The reasoning is in a comment on the test so the next reader doesn't have to re-derive it.

Also corrected the class Javadoc, which listed `IN` and `BETWEEN` as covered. `BETWEEN` has no test and no implementation either (the source just has a `// BETWEEN (not supported yet)` comment).

## Test plan

- [x] `mvn -pl lance-flink-1.18 test -Dtest=LanceReadOptimizationsTest` -> 24 run, 0 failures, 0 skipped (was 24 run / 1 skipped)
- [x] `mvn -B -ntp -am -pl lance-flink-1.18 verify` -> BUILD SUCCESS (178 run, 0 failures, 17 skipped)
- [x] `mvn -B -ntp -am -pl lance-flink-1.19 verify` -> BUILD SUCCESS
- [x] `mvn -B -ntp -am -pl lance-flink-1.20 verify` -> BUILD SUCCESS

The remaining 17 skips are `LanceCatalogS3Test$MinioIntegrationTests`, gated on MinIO env vars.

## Still open from the #55 discussion

Wiring `*ITCase` into CI needs work before the pipeline part is worth doing, since the ITs don't pass today:

1. Fix the shade relocation. With `maven-failsafe-plugin` added locally, the ITs run post-`package` against the shaded jar and hit `NoSuchMethodError` on `LanceTypeConverter.toArrowSchema(RowType)` and `LanceNamespace.connect(String, Map, BufferAllocator)`, which looks like relocated and non-relocated Arrow signatures mixed on one classpath.
2. Fix `LanceNamespaceCatalog.createTable`, which doesn't send the Arrow IPC schema stream, so `DirectoryNamespace` rejects it with `InvalidInputException code=13`.
3. Then add failsafe and split the workflow into a fast unit-test lane and a separate IT job.
