### PR TITLE
test: assert SQL IN push-down through the OR chain the planner produces

### DIFF
--- a/src/test/java/org/apache/flink/connector/lance/table/LanceReadOptimizationsTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/table/LanceReadOptimizationsTest.java
@@ -30,7 +30,6 @@ import org.apache.flink.table.functions.BuiltInFunctionDefinition;
 import org.apache.flink.table.types.DataType;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -50,7 +49,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * <p>Test contents:
  * <ul>
  *   <li>Limit push-down</li>
- *   <li>Predicate push-down (basic comparison, IN, BETWEEN)</li>
+ *   <li>Predicate push-down (comparisons, AND/OR, IS NULL, LIKE; SQL IN arrives as an
+ *       OR chain, and BETWEEN is not implemented)</li>
  *   <li>Column pruning</li>
  * </ul>
  */
@@ -246,31 +246,37 @@ public class LanceReadOptimizationsTest {
         }
 
         @Test
-        @Disabled(
-                "IN predicate push-down is not yet implemented in the source; "
-                    + "convertToLanceFilter() returns null for BuiltInFunctionDefinitions.IN "
-                    + "(see LanceDynamicTableSource: \"IN (not supported yet)\"). "
-                    + "Re-enable once IN push-down lands.")
-        @DisplayName("Test IN predicate push-down")
+        @DisplayName("Test SQL IN is pushed down as an OR chain")
         void testInPredicatePushDown() {
             LanceDynamicTableSource source = new LanceDynamicTableSource(baseOptions, physicalDataType);
 
-            // Create status IN ('active', 'pending', 'completed') expression
-            FieldReferenceExpression fieldRef = new FieldReferenceExpression(
-                    "status", DataTypes.STRING(), 0, 2);
-            ValueLiteralExpression value1 = new ValueLiteralExpression("active");
-            ValueLiteralExpression value2 = new ValueLiteralExpression("pending");
-            ValueLiteralExpression value3 = new ValueLiteralExpression("completed");
-            
-            CallExpression inExpr = CallExpression.permanent(
-                    BuiltInFunctionDefinitions.IN,
-                    Arrays.asList(fieldRef, value1, value2, value3),
+            // The planner never hands BuiltInFunctionDefinitions.IN to applyFilters:
+            // Calcite expands IN over a literal list into OR(=, =, ...) while converting
+            // SQL to RelNode, and RexNodeExtractor expands any SEARCH/Sarg back into OR
+            // before extracting the conjunctive terms. So an EXPLAIN of
+            //   SELECT id FROM t WHERE status IN ('active', 'pending', 'completed')
+            // shows filter=[OR(OR(=(status,'active'), =(status,'pending')),
+            // =(status,'completed'))] pushed into the scan. Build that shape here rather
+            // than a bare IN call, so this exercises the expression the source really sees.
+            ResolvedExpression active = createEqualsExpression("status", "active");
+            ResolvedExpression pending = createEqualsExpression("status", "pending");
+            ResolvedExpression completed = createEqualsExpression("status", "completed");
+
+            CallExpression orExpr = CallExpression.permanent(
+                    BuiltInFunctionDefinitions.OR,
+                    Arrays.asList(
+                            CallExpression.permanent(
+                                    BuiltInFunctionDefinitions.OR,
+                                    Arrays.asList(active, pending),
+                                    DataTypes.BOOLEAN()),
+                            completed),
                     DataTypes.BOOLEAN()
             );
 
-            SupportsFilterPushDown.Result result = source.applyFilters(Collections.singletonList(inExpr));
+            SupportsFilterPushDown.Result result = source.applyFilters(Collections.singletonList(orExpr));
 
-            assertEquals(1, result.getAcceptedFilters().size(), "IN predicate should be accepted");
+            assertEquals(1, result.getAcceptedFilters().size(), "OR chain from IN should be accepted");
+            assertEquals(0, result.getRemainingFilters().size(), "Nothing should be left for Flink");
         }
 
         @Test


### PR DESCRIPTION
## What

Re-enables `LanceReadOptimizationsTest.testInPredicatePushDown`, disabled by #55, by asserting the expression shape the planner actually hands to the source: an OR chain, not a bare `IN` call.

## Why the source has no IN branch

The old test built a `CallExpression` on `BuiltInFunctionDefinitions.IN` and asserted it was accepted. `convertCallExpression()` has no IN branch, so it always failed, and #55 disabled it to get the new pipeline green.

Measuring with `EXPLAIN` shows the source doesn't need one. Calcite expands `IN` over a literal list into `OR(=, =, ...)` while converting SQL to RelNode, and `RexNodeExtractor` expands any `SEARCH`/`Sarg` back into OR before extracting the conjunctive terms. A real query:

```sql
SELECT id FROM t WHERE status IN ('active', 'pending', 'completed')
```

pushes this into the scan, with no leftover Calc node above it:

```
filter=[OR(OR(=(status,'active'), =(status,'pending')), =(status,'completed'))]
```

So SQL `IN` is already pushed down by the existing OR and EQUALS handling. I saw the same shape for numeric columns (`id IN (1,2,3)`), a 60-value list (no SEARCH/Sarg), the Table API's `$("status").in(...)`, and on both Flink 1.18 and 1.20. `NOT IN` becomes `and(<>, <>)`.

## How

The test now builds that OR chain and asserts `acceptedFilters` is 1 and `remainingFilters` is 0, with the reasoning in a comment so the next reader doesn't have to re-derive it. The method name stays `testInPredicatePushDown` since SQL `IN` is what it covers; the `@DisplayName` says how.

This also gives the OR push-down path its first coverage. Nothing exercised `BuiltInFunctionDefinitions.OR` before.

Class Javadoc updated: it listed IN and BETWEEN as covered, but BETWEEN has no test and no implementation.

## Test plan

- [x] `mvn -pl lance-flink-1.18 test -Dtest=LanceReadOptimizationsTest` -> 24 run, 0 failures, 0 skipped (was 24 run / 1 skipped)
- [x] Stubbed the source's OR branch to `return null` and confirmed the test turns red (`OR chain from IN should be accepted ==> expected: <1> but was: <0>`), so it does catch regressions on this path. Source restored afterwards.
- [x] `mvn -B -ntp -am -pl lance-flink-1.18 verify` -> BUILD SUCCESS (178 run, 0 failures, 17 skipped)
- [x] Same for `lance-flink-1.19` and `lance-flink-1.20`

The 17 skips are `LanceCatalogS3Test$MinioIntegrationTests`, gated on MinIO env vars.

## Related

This came out of reviewing #21, which adds an explicit `BuiltInFunctionDefinitions.IN` branch. The measurements above suggest that branch isn't reached on the push-down path; I left the details as review comments there. This PR is independent of how #21 is resolved: it makes the existing behaviour tested either way.
