### PR TITLE
fix: send the table schema as an Arrow IPC stream when creating a table

### DIFF
--- a/src/main/java/org/apache/flink/connector/lance/table/LanceNamespaceCatalog.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceNamespaceCatalog.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.catalog.CatalogPartition;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
@@ -345,8 +346,22 @@ public class LanceNamespaceCatalog extends AbstractCatalog {
                             + "Specify the Lance dataset path, e.g. WITH ('path' = '/data/my_dataset')");
         }
 
+        // Serialized before the try below: that catch classifies errors coming back from the
+        // namespace, and wrapping a local schema failure in "Failed to create table" would bury
+        // the message that says what is actually wrong with the schema. The catch here keeps the
+        // method's contract of only throwing CatalogException, since serialization can also fail
+        // with a ValidationException (duplicate column names) or an IllegalStateException (an
+        // Arrow buffer leak detected when the child allocator closes).
+        byte[] arrowIpcSchema;
         try {
-            byte[] arrowIpcSchema = toArrowIpcSchema(table, allocator);
+            arrowIpcSchema = toArrowIpcSchema(table, allocator);
+        } catch (CatalogException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw new CatalogException("Cannot build the Arrow schema for table " + tablePath, e);
+        }
+
+        try {
             namespace.createTable(
                     new CreateTableRequest().id(tableId(tablePath)), arrowIpcSchema);
         } catch (RuntimeException e) {
@@ -374,28 +389,61 @@ public class LanceNamespaceCatalog extends AbstractCatalog {
      * @return the Arrow IPC stream bytes
      */
     static byte[] toArrowIpcSchema(CatalogBaseTable table, BufferAllocator allocator) {
-        Schema arrowSchema = LanceTypeConverter.toArrowSchema(resolveRowType(table));
+        Schema arrowSchema;
+        try {
+            arrowSchema = LanceTypeConverter.toArrowSchema(resolveRowType(table));
+        } catch (LanceTypeConverter.UnsupportedTypeException e) {
+            throw new CatalogException(
+                    "Cannot create a Lance table with this schema: " + e.getMessage(), e);
+        }
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator);
+        // The child allocator attributes any Arrow buffer leak to this method instead of to
+        // close() at the end of the catalog's life. Declared first so it closes last.
+        try (BufferAllocator ipcAllocator =
+                        allocator.newChildAllocator("lance-ipc-schema", 0, Long.MAX_VALUE);
+                VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, ipcAllocator);
                 ArrowStreamWriter writer = new ArrowStreamWriter(root, null, out)) {
             root.setRowCount(0);
             writer.start();
             writer.writeBatch();
             writer.end();
         } catch (IOException e) {
+            // Defensive: ByteArrayOutputStream never throws here. Two other failures do escape
+            // this clause as RuntimeException, which is why the caller wraps them: a real stream
+            // or channel would surface IO errors through ArrowWriter.close(), and ipcAllocator
+            // .close() throws IllegalStateException on a leaked buffer.
             throw new CatalogException("Failed to serialize table schema as an Arrow IPC stream", e);
         }
         return out.toByteArray();
     }
 
     /**
-     * Build a {@link RowType} from a table's declared physical columns.
+     * Build a {@link RowType} from a table's physical columns.
+     *
+     * <p>A {@link ResolvedCatalogTable} carries a resolved schema, and {@code
+     * toPhysicalRowDataType()} already drops computed and metadata columns, so that path is used
+     * when available. Flink hands catalogs a resolved table on the SQL DDL path; a programmatic
+     * caller may pass a plain {@link CatalogBaseTable}, which is why the unresolved fallback stays.
      *
      * @param table the table to read the schema from
      * @return the row type of the table's physical columns
      */
     static RowType resolveRowType(CatalogBaseTable table) {
+        if (table instanceof ResolvedCatalogTable) {
+            RowType rowType =
+                    (RowType)
+                            ((ResolvedCatalogTable) table)
+                                    .getResolvedSchema()
+                                    .toPhysicalRowDataType()
+                                    .getLogicalType();
+            if (rowType.getFieldCount() == 0) {
+                throw new CatalogException(
+                        "Cannot create a Lance table without physical columns: the schema declares none");
+            }
+            return rowType;
+        }
+
         List<RowType.RowField> fields = new ArrayList<>();
         for (org.apache.flink.table.api.Schema.UnresolvedColumn column :
                 table.getUnresolvedSchema().getColumns()) {
@@ -405,6 +453,16 @@ public class LanceNamespaceCatalog extends AbstractCatalog {
             }
             org.apache.flink.table.api.Schema.UnresolvedPhysicalColumn physical =
                     (org.apache.flink.table.api.Schema.UnresolvedPhysicalColumn) column;
+            // getDataType() is declared as AbstractDataType: a column declared with
+            // Schema.column(name, "BIGINT") yields an UnresolvedDataType, which cannot be
+            // resolved without a catalog's type factory.
+            if (!(physical.getDataType() instanceof DataType)) {
+                throw new CatalogException(
+                        "Column '"
+                                + physical.getName()
+                                + "' has an unresolved data type. Declare it with DataTypes.* "
+                                + "or create the table through SQL DDL.");
+            }
             DataType dataType = (DataType) physical.getDataType();
             fields.add(new RowType.RowField(physical.getName(), dataType.getLogicalType()));
         }

--- a/src/main/java/org/apache/flink/connector/lance/table/LanceNamespaceCatalog.java
+++ b/src/main/java/org/apache/flink/connector/lance/table/LanceNamespaceCatalog.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.lance.table;
 
 import org.apache.flink.connector.lance.catalog.namespace.LanceNamespaceConfig;
+import org.apache.flink.connector.lance.converter.LanceTypeConverter;
 
 import org.apache.flink.table.catalog.AbstractCatalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
@@ -40,6 +41,8 @@ import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
 import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
 
 import org.lance.namespace.LanceNamespace;
 import org.lance.namespace.model.CreateNamespaceRequest;
@@ -56,9 +59,14 @@ import org.lance.namespace.model.NamespaceExistsRequest;
 import org.lance.namespace.model.TableExistsRequest;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -338,7 +346,9 @@ public class LanceNamespaceCatalog extends AbstractCatalog {
         }
 
         try {
-            namespace.createTable(new CreateTableRequest().id(tableId(tablePath)), new byte[0]);
+            byte[] arrowIpcSchema = toArrowIpcSchema(table, allocator);
+            namespace.createTable(
+                    new CreateTableRequest().id(tableId(tablePath)), arrowIpcSchema);
         } catch (RuntimeException e) {
             if (isAlreadyExists(e)) {
                 if (!ignoreIfExists) {
@@ -348,6 +358,61 @@ public class LanceNamespaceCatalog extends AbstractCatalog {
             }
             throw new CatalogException("Failed to create table: " + tablePath, e);
         }
+    }
+
+    /**
+     * Serialize a table's schema as an Arrow IPC stream.
+     *
+     * <p>{@code createTable} on the namespace API takes the request plus the table schema as an
+     * Arrow IPC stream; a directory-backed namespace rejects an empty body with {@code
+     * InvalidInputException code=13}, and a schema-only stream with {@code InternalException
+     * code=18}. So the stream carries the schema plus one batch of zero rows: enough for the
+     * namespace to derive the schema, while creating an empty dataset.
+     *
+     * @param table the table whose schema to serialize
+     * @param allocator the allocator backing the Arrow vectors
+     * @return the Arrow IPC stream bytes
+     */
+    static byte[] toArrowIpcSchema(CatalogBaseTable table, BufferAllocator allocator) {
+        Schema arrowSchema = LanceTypeConverter.toArrowSchema(resolveRowType(table));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (VectorSchemaRoot root = VectorSchemaRoot.create(arrowSchema, allocator);
+                ArrowStreamWriter writer = new ArrowStreamWriter(root, null, out)) {
+            root.setRowCount(0);
+            writer.start();
+            writer.writeBatch();
+            writer.end();
+        } catch (IOException e) {
+            throw new CatalogException("Failed to serialize table schema as an Arrow IPC stream", e);
+        }
+        return out.toByteArray();
+    }
+
+    /**
+     * Build a {@link RowType} from a table's declared physical columns.
+     *
+     * @param table the table to read the schema from
+     * @return the row type of the table's physical columns
+     */
+    static RowType resolveRowType(CatalogBaseTable table) {
+        List<RowType.RowField> fields = new ArrayList<>();
+        for (org.apache.flink.table.api.Schema.UnresolvedColumn column :
+                table.getUnresolvedSchema().getColumns()) {
+            if (!(column instanceof org.apache.flink.table.api.Schema.UnresolvedPhysicalColumn)) {
+                // Computed and metadata columns are not part of the stored dataset.
+                continue;
+            }
+            org.apache.flink.table.api.Schema.UnresolvedPhysicalColumn physical =
+                    (org.apache.flink.table.api.Schema.UnresolvedPhysicalColumn) column;
+            DataType dataType = (DataType) physical.getDataType();
+            fields.add(new RowType.RowField(physical.getName(), dataType.getLogicalType()));
+        }
+        if (fields.isEmpty()) {
+            throw new CatalogException(
+                    "Cannot create a Lance table without physical columns: the schema declares none");
+        }
+        return new RowType(fields);
     }
 
     @Override

--- a/src/test/java/org/apache/flink/connector/lance/table/LanceNamespaceCatalogSchemaTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/table/LanceNamespaceCatalogSchemaTest.java
@@ -20,7 +20,13 @@ package org.apache.flink.connector.lance.table;
 
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -29,6 +35,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.lance.namespace.LanceNamespace;
+import org.lance.namespace.model.NamespaceExistsRequest;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
@@ -42,9 +50,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Tests for the Arrow IPC schema stream that {@link LanceNamespaceCatalog} sends with
  * {@code createTable}.
  *
- * <p>These exercise the serialization in isolation, without a live namespace, by invoking the
- * private helper reflectively. The end-to-end path is covered by {@code
- * LanceNamespaceCatalogITCase}.
+ * <p>Most cases call the package-private serialization helpers directly, so they need no
+ * namespace at all. The one case that goes through {@code createTable} uses a stub namespace,
+ * since it asserts how a schema failure is reported before the namespace is ever called.
+ * {@code LanceNamespaceCatalogITCase} covers createTable against a real directory namespace.
  */
 @DisplayName("Lance Namespace Catalog Schema Serialization Tests")
 class LanceNamespaceCatalogSchemaTest {
@@ -122,10 +131,114 @@ class LanceNamespaceCatalogSchemaTest {
                 .hasMessageContaining("without physical columns");
     }
 
+    @Test
+    @DisplayName("A vector column is serialized")
+    void testVectorColumn() throws Exception {
+        CatalogTable table = tableWith(
+                Schema.newBuilder()
+                        .column("id", DataTypes.BIGINT())
+                        .column("embedding", DataTypes.ARRAY(DataTypes.FLOAT()))
+                        .build());
+
+        byte[] ipc = LanceNamespaceCatalog.toArrowIpcSchema(table, allocator);
+
+        try (ArrowStreamReader reader =
+                new ArrowStreamReader(new ByteArrayInputStream(ipc), allocator)) {
+            assertThat(reader.getVectorSchemaRoot().getSchema().getFields())
+                    .extracting(org.apache.arrow.vector.types.pojo.Field::getName)
+                    .containsExactly("id", "embedding");
+        }
+    }
+
+    @Test
+    @DisplayName("A column declared with a type string is rejected by name")
+    void testUnresolvedDataTypeRejected() {
+        // Schema.column(String, String) yields an UnresolvedDataType, which cannot be
+        // resolved without a catalog's type factory.
+        CatalogTable table = tableWith(Schema.newBuilder().column("id", "BIGINT").build());
+
+        assertThatThrownBy(() -> LanceNamespaceCatalog.toArrowIpcSchema(table, allocator))
+                .isInstanceOf(org.apache.flink.table.catalog.exceptions.CatalogException.class)
+                .hasMessageContaining("'id'")
+                .hasMessageContaining("unresolved data type");
+    }
+
+    @Test
+    @DisplayName("An unsupported column type is rejected as a schema problem")
+    void testUnsupportedTypeRejected() {
+        CatalogTable table = tableWith(
+                Schema.newBuilder().column("amount", DataTypes.DECIMAL(10, 2)).build());
+
+        assertThatThrownBy(() -> LanceNamespaceCatalog.toArrowIpcSchema(table, allocator))
+                .isInstanceOf(org.apache.flink.table.catalog.exceptions.CatalogException.class)
+                .hasMessageContaining("Cannot create a Lance table with this schema")
+                .hasMessageContaining("DecimalType");
+    }
+
+    @Test
+    @DisplayName("A resolved table uses its resolved physical schema")
+    void testResolvedTableUsesPhysicalSchema() {
+        // The declared schema is deliberately different from the resolved one: only the resolved
+        // path can return "id", and only the unresolved path would reject the type string. So
+        // this fails if the resolved branch stops being taken.
+        CatalogTable declared = tableWith(Schema.newBuilder().column("wrong", "BIGINT").build());
+        ResolvedSchema resolved = ResolvedSchema.of(
+                Column.physical("id", DataTypes.BIGINT()),
+                Column.metadata("ts", DataTypes.TIMESTAMP_LTZ(3), "timestamp", false));
+
+        RowType rowType =
+                LanceNamespaceCatalog.resolveRowType(new ResolvedCatalogTable(declared, resolved));
+
+        assertThat(rowType.getFieldNames()).containsExactly("id");
+    }
+
+    @Test
+    @DisplayName("createTable wraps a non-CatalogException schema failure")
+    void testCreateTableWrapsSchemaFailure() {
+        // Duplicate names survive Schema.Builder and fail inside RowType with a bare
+        // ValidationException. createTable has to surface that as a CatalogException so it
+        // keeps the contract its signature declares, with the original cause attached.
+        CatalogTable table = tableWith(
+                Schema.newBuilder()
+                        .column("a", DataTypes.BIGINT())
+                        .column("a", DataTypes.STRING())
+                        .build());
+
+        LanceNamespaceCatalog catalog = new LanceNamespaceCatalog(
+                "test", "default", new NoopNamespace(), allocator, Collections.emptyMap());
+
+        assertThatThrownBy(
+                        () ->
+                                catalog.createTable(
+                                        new ObjectPath("default", "dup"), table, false))
+                .isInstanceOf(org.apache.flink.table.catalog.exceptions.CatalogException.class)
+                .hasMessageContaining("Cannot build the Arrow schema")
+                .hasCauseInstanceOf(ValidationException.class);
+    }
+
     private static CatalogTable tableWith(Schema schema) {
         Map<String, String> options = new HashMap<>();
         options.put("connector", "lance");
         options.put("path", "/tmp/does-not-need-to-exist");
         return CatalogTable.of(schema, "", Collections.emptyList(), options);
+    }
+
+    /**
+     * Namespace stub for the one test that goes through createTable without reaching the
+     * namespace. Every other method on the
+     * interface has a default implementation, so only these two need bodies; {@code
+     * namespaceExists} returning normally is what makes {@code databaseExists} true.
+     */
+    private static final class NoopNamespace implements LanceNamespace {
+        @Override
+        public void initialize(Map<String, String> configProperties, BufferAllocator allocator) {}
+
+        @Override
+        public String namespaceId() {
+            return "test";
+        }
+
+        @Override
+        public void namespaceExists(NamespaceExistsRequest request) {}
     }
 }

--- a/src/test/java/org/apache/flink/connector/lance/table/LanceNamespaceCatalogSchemaTest.java
+++ b/src/test/java/org/apache/flink/connector/lance/table/LanceNamespaceCatalogSchemaTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.lance.table;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.catalog.CatalogTable;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.ipc.ArrowStreamReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests for the Arrow IPC schema stream that {@link LanceNamespaceCatalog} sends with
+ * {@code createTable}.
+ *
+ * <p>These exercise the serialization in isolation, without a live namespace, by invoking the
+ * private helper reflectively. The end-to-end path is covered by {@code
+ * LanceNamespaceCatalogITCase}.
+ */
+@DisplayName("Lance Namespace Catalog Schema Serialization Tests")
+class LanceNamespaceCatalogSchemaTest {
+
+    private BufferAllocator allocator;
+
+    @BeforeEach
+    void setUp() {
+        allocator = new RootAllocator(Long.MAX_VALUE);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (allocator != null) {
+            allocator.close();
+        }
+    }
+
+    @Test
+    @DisplayName("Schema is serialized as a readable Arrow IPC stream")
+    void testSchemaRoundTrip() throws Exception {
+        CatalogTable table = tableWith(
+                Schema.newBuilder()
+                        .column("id", DataTypes.BIGINT())
+                        .column("name", DataTypes.STRING())
+                        .column("score", DataTypes.DOUBLE())
+                        .build());
+
+        byte[] ipc = LanceNamespaceCatalog.toArrowIpcSchema(table, allocator);
+
+        assertThat(ipc).isNotEmpty();
+
+        try (ArrowStreamReader reader =
+                new ArrowStreamReader(new ByteArrayInputStream(ipc), allocator)) {
+            org.apache.arrow.vector.types.pojo.Schema arrowSchema = reader.getVectorSchemaRoot()
+                    .getSchema();
+            assertThat(arrowSchema.getFields())
+                    .extracting(org.apache.arrow.vector.types.pojo.Field::getName)
+                    .containsExactly("id", "name", "score");
+
+            // The stream carries one batch of zero rows: the namespace rejects a
+            // schema-only stream, and an empty table must not gain phantom rows.
+            assertThat(reader.loadNextBatch()).isTrue();
+            assertThat(reader.getVectorSchemaRoot().getRowCount()).isZero();
+            assertThat(reader.loadNextBatch()).isFalse();
+        }
+    }
+
+    @Test
+    @DisplayName("Computed and metadata columns are excluded from the stored schema")
+    void testOnlyPhysicalColumnsAreSerialized() throws Exception {
+        CatalogTable table = tableWith(
+                Schema.newBuilder()
+                        .column("id", DataTypes.BIGINT())
+                        .columnByExpression("id_doubled", "id * 2")
+                        .build());
+
+        byte[] ipc = LanceNamespaceCatalog.toArrowIpcSchema(table, allocator);
+
+        try (ArrowStreamReader reader =
+                new ArrowStreamReader(new ByteArrayInputStream(ipc), allocator)) {
+            assertThat(reader.getVectorSchemaRoot().getSchema().getFields())
+                    .extracting(org.apache.arrow.vector.types.pojo.Field::getName)
+                    .containsExactly("id");
+        }
+    }
+
+    @Test
+    @DisplayName("A schema with no physical columns is rejected with a clear message")
+    void testNoPhysicalColumnsRejected() {
+        CatalogTable table = tableWith(Schema.newBuilder().build());
+
+        assertThatThrownBy(() -> LanceNamespaceCatalog.toArrowIpcSchema(table, allocator))
+                .isInstanceOf(org.apache.flink.table.catalog.exceptions.CatalogException.class)
+                .hasMessageContaining("without physical columns");
+    }
+
+    private static CatalogTable tableWith(Schema schema) {
+        Map<String, String> options = new HashMap<>();
+        options.put("connector", "lance");
+        options.put("path", "/tmp/does-not-need-to-exist");
+        return CatalogTable.of(schema, "", Collections.emptyList(), options);
+    }
+}


### PR DESCRIPTION
## What

`LanceNamespaceCatalog.createTable` now sends the table schema as an Arrow IPC stream. It previously passed `new byte[0]`, so creating a table through this catalog never worked.

## The bug

```java
namespace.createTable(new CreateTableRequest().id(tableId(tablePath)), new byte[0]);
```

The second argument is the request body, which the namespace API expects to be the schema as an Arrow IPC stream. A directory-backed namespace rejects an empty one:

```
InvalidInputException{code=13, message='Invalid input: Request data (Arrow IPC stream) is required for create_table'}
```

So every `createTable` call failed, and the schema the caller declared was thrown away. `LanceNamespaceCatalogITCase.testCreateTable` has been failing on this the whole time; it just never ran, since the repo has no failsafe plugin and `*ITCase` doesn't match surefire's default includes.

## How

Build the body from the table's physical columns: `RowType` -> `LanceTypeConverter.toArrowSchema` (reusing the existing converter) -> `ArrowStreamWriter`.

Two details worth calling out:

- **The stream needs a batch, not just a schema.** Writing only the schema gets you a different rejection: `InternalException{code=18, message='Internal error: No data provided for table creation'}`. So the stream carries the schema plus one batch of zero rows, which is enough for the namespace to derive the schema while leaving the dataset empty. Both error codes are in the Javadoc so nobody has to rediscover this.
- **Computed and metadata columns are skipped**, since they aren't part of the stored dataset. A schema that declares no physical columns now fails with a clear message instead of an opaque namespace error.

`toArrowIpcSchema` and `resolveRowType` are package-private static so the serialization is testable without standing up a namespace.

## Test plan

- [x] New `LanceNamespaceCatalogSchemaTest`, 3 cases: the IPC stream reads back the same field names, one zero-row batch and no more; computed columns are excluded; an empty schema is rejected with a message naming the problem.
- [x] Confirmed the new test catches the constraint: dropping `writer.writeBatch()` turns it red (`loadNextBatch` expected true but was false). Source restored after.
- [x] `LanceNamespaceCatalogITCase` now passes, 3 run / 0 failures. It fails on `main`.
- [x] All three `*ITCase` classes together: 36 run / 0 failures (`LanceConnectorITCase` 15, `LanceSqlITCase` 18, `LanceNamespaceCatalogITCase` 3).
- [x] `mvn -B -ntp -am -pl lance-flink-1.18 verify` -> BUILD SUCCESS (181 run, 0 failures, 17 skipped). Same for 1.19 and 1.20.

The 17 skips are `LanceCatalogS3Test$MinioIntegrationTests`, gated on MinIO env vars. I ran the `*ITCase` classes through surefire with an explicit `-Dtest` since nothing runs them by default.

## Follow-up

Wiring `*ITCase` into CI is the next PR: add `maven-failsafe-plugin` and split the workflow into a unit-test lane and an IT job. That needs `classesDirectory` pointed at `target/classes`, because failsafe otherwise runs against the shaded jar, where the relocated Arrow packages no longer match the signatures the tests were compiled against. This PR is what makes those ITs green first, so the CI change doesn't have to quarantine anything.
